### PR TITLE
feat(site): add minecraft chart documentation page

### DIFF
--- a/src/components/ChartGrid.astro
+++ b/src/components/ChartGrid.astro
@@ -56,6 +56,13 @@ const charts = [
     color: 'bg-violet-100 text-violet-700',
     letter: 'Vw',
   },
+  {
+    name: 'Minecraft',
+    slug: 'minecraft',
+    description: 'Minecraft Java Edition server with cross-play, modding, backup, and monitoring.',
+    color: 'bg-emerald-100 text-emerald-700',
+    letter: 'Mc',
+  },
 ];
 ---
 
@@ -66,7 +73,7 @@ const charts = [
         Available Charts
       </h2>
       <p class="mt-4 text-lg text-muted leading-relaxed">
-        Eight production-ready charts covering databases, messaging, identity, and general workloads.
+        Nine production-ready charts covering databases, messaging, identity, game servers, and general workloads.
       </p>
     </div>
 

--- a/src/layouts/DocsLayout.astro
+++ b/src/layouts/DocsLayout.astro
@@ -26,6 +26,7 @@ const chartNav = [
   { label: 'RabbitMQ', href: '/docs/charts/rabbitmq' },
   { label: 'Keycloak', href: '/docs/charts/keycloak' },
   { label: 'Vaultwarden', href: '/docs/charts/vaultwarden' },
+  { label: 'Minecraft', href: '/docs/charts/minecraft' },
 ];
 
 const allPages = [

--- a/src/pages/docs/charts/minecraft.mdx
+++ b/src/pages/docs/charts/minecraft.mdx
@@ -1,0 +1,98 @@
+---
+layout: ../../../layouts/DocsLayout.astro
+title: Minecraft Chart
+description: HelmForge Minecraft chart — Java Edition server with Vanilla, Paper, Forge, Fabric, GeyserMC cross-play, and S3 backup.
+---
+
+# Minecraft
+
+Deploy Minecraft Java Edition servers on Kubernetes using the [itzg/minecraft-server](https://docker-minecraft-server.readthedocs.io/) container image. Supports multiple server types, cross-play, modding, monitoring, and scheduled backups.
+
+## Key Features
+
+- **Multiple Server Types** — Vanilla, Paper, Spigot, Forge, Fabric, Quilt
+- **GeyserMC Cross-Play** — Allow Bedrock clients (mobile, console) to join Java servers
+- **Authentication** — Online/offline mode, whitelist, operators
+- **RCON** — Remote console with auto-generated password
+- **Scheduled Backups** — CronJob-based backup to S3-compatible storage
+- **Prometheus Monitoring** — mc-monitor sidecar with ServiceMonitor
+- **Mod/Plugin Support** — Modrinth, CurseForge, Spiget, direct URLs
+- **Optimized JVM** — Aikar's GC flags for production workloads
+
+## Installation
+
+**HTTPS repository:**
+
+```bash
+helm repo add helmforge https://repo.helmforge.dev
+helm repo update
+helm install minecraft helmforge/minecraft --set server.eula=true
+```
+
+**OCI registry:**
+
+```bash
+helm install minecraft oci://ghcr.io/helmforgedev/helm/minecraft --set server.eula=true
+```
+
+## Basic Example
+
+```yaml
+# values.yaml
+server:
+  eula: true
+  type: PAPER
+  motd: "My Minecraft Server"
+  maxPlayers: 20
+
+jvm:
+  memory: 2G
+  useAikarFlags: true
+
+auth:
+  onlineMode: true
+  whitelist: "player1,player2"
+  ops: "player1"
+
+persistence:
+  enabled: true
+  size: 20Gi
+```
+
+## Cross-Play Example
+
+```yaml
+server:
+  eula: true
+  type: PAPER
+
+geyser:
+  enabled: true
+  port: 19132
+
+mods:
+  modrinthProjects: "geyser,floodgate"
+```
+
+## Key Values
+
+| Key | Default | Description |
+|-----|---------|-------------|
+| `server.eula` | `true` | Accept the Minecraft EULA (required) |
+| `server.type` | `VANILLA` | Server type (VANILLA, PAPER, FORGE, FABRIC, etc.) |
+| `server.version` | `LATEST` | Minecraft version |
+| `server.maxPlayers` | `20` | Maximum concurrent players |
+| `jvm.memory` | `1G` | JVM heap allocation |
+| `jvm.useAikarFlags` | `false` | Aikar's optimized GC flags |
+| `auth.onlineMode` | `true` | Mojang online authentication |
+| `auth.whitelist` | `""` | Whitelisted players |
+| `geyser.enabled` | `false` | Enable GeyserMC cross-play |
+| `rcon.enabled` | `true` | Enable RCON remote console |
+| `metrics.enabled` | `false` | Enable Prometheus metrics |
+| `backup.enabled` | `false` | Enable S3 backups |
+| `persistence.enabled` | `true` | Enable persistent storage |
+| `persistence.size` | `10Gi` | PVC size |
+
+## More Information
+
+See the [source code and full values reference](https://github.com/helmforgedev/charts/tree/main/charts/minecraft) on GitHub.


### PR DESCRIPTION
## Summary

- Add Minecraft chart documentation page at `/docs/charts/minecraft`
- Register in `DocsLayout.astro` sidebar navigation (chartNav)
- Register in `ChartGrid.astro` landing page grid
- Update chart count from 8 to 9

## Test plan

- [x] `npm run build` succeeds with zero errors
- [x] 14 pages built including `/docs/charts/minecraft/index.html`
- [x] Sidebar navigation includes Minecraft entry
- [x] Chart grid includes Minecraft card