### PR TITLE
feat(site): add pi-hole chart documentation page

### DIFF
--- a/src/components/ChartGrid.astro
+++ b/src/components/ChartGrid.astro
@@ -63,6 +63,13 @@ const charts = [
     color: 'bg-emerald-100 text-emerald-700',
     letter: 'Mc',
   },
+  {
+    name: 'Pi-hole',
+    slug: 'pihole',
+    description: 'Network-wide ad blocking DNS sinkhole with Unbound recursive DNS.',
+    color: 'bg-rose-100 text-rose-700',
+    letter: 'Ph',
+  },
 ];
 ---
 
@@ -73,7 +80,7 @@ const charts = [
         Available Charts
       </h2>
       <p class="mt-4 text-lg text-muted leading-relaxed">
-        Nine production-ready charts covering databases, messaging, identity, game servers, and general workloads.
+        Ten production-ready charts covering databases, messaging, identity, game servers, networking, and general workloads.
       </p>
     </div>
 

--- a/src/layouts/DocsLayout.astro
+++ b/src/layouts/DocsLayout.astro
@@ -27,6 +27,7 @@ const chartNav = [
   { label: 'Keycloak', href: '/docs/charts/keycloak' },
   { label: 'Vaultwarden', href: '/docs/charts/vaultwarden' },
   { label: 'Minecraft', href: '/docs/charts/minecraft' },
+  { label: 'Pi-hole', href: '/docs/charts/pihole' },
 ];
 
 const allPages = [

--- a/src/pages/docs/charts/pihole.mdx
+++ b/src/pages/docs/charts/pihole.mdx
@@ -1,0 +1,96 @@
+---
+layout: ../../../layouts/DocsLayout.astro
+title: Pi-hole Chart
+description: HelmForge Pi-hole chart — DNS sinkhole with custom records, Unbound recursive DNS, and Prometheus metrics.
+---
+
+# Pi-hole
+
+Deploy Pi-hole DNS sinkhole on Kubernetes using the official [pihole/pihole](https://hub.docker.com/r/pihole/pihole) container image. Provides network-wide ad blocking via DNS filtering with optional Unbound recursive DNS.
+
+## Key Features
+
+- **Network-Wide Ad Blocking** — DNS-level filtering for all devices
+- **Custom DNS Records** — Local A records, CNAME records, and dnsmasq config
+- **Unbound Sidecar** — Optional recursive DNS resolver for privacy
+- **Pi-hole v6+** — Modern configuration via FTLCONF environment variables
+- **Prometheus Metrics** — pihole-exporter sidecar with ServiceMonitor
+- **Ingress Support** — Configurable ingress with TLS for web admin
+- **DNSSEC Validation** — Optional DNS Security Extensions
+
+## Installation
+
+**HTTPS repository:**
+
+```bash
+helm repo add helmforge https://repo.helmforge.dev
+helm repo update
+helm install pihole helmforge/pihole
+```
+
+**OCI registry:**
+
+```bash
+helm install pihole oci://ghcr.io/helmforgedev/helm/pihole
+```
+
+## Basic Example
+
+```yaml
+# values.yaml
+admin:
+  password: "change-me"
+
+pihole:
+  timezone: UTC
+  upstreamDns: "1.1.1.1;1.0.0.1"
+
+dns:
+  customRecords:
+    - "192.168.1.1 router.home"
+    - "192.168.1.10 nas.home"
+
+serviceDns:
+  type: LoadBalancer
+  loadBalancerIP: "192.168.1.53"
+
+persistence:
+  enabled: true
+  size: 1Gi
+```
+
+## Unbound Example
+
+```yaml
+unbound:
+  enabled: true
+
+pihole:
+  dnssec: true
+
+serviceDns:
+  type: LoadBalancer
+  loadBalancerIP: "192.168.1.53"
+```
+
+## Key Values
+
+| Key | Default | Description |
+|-----|---------|-------------|
+| `pihole.timezone` | `UTC` | Timezone for logs |
+| `pihole.upstreamDns` | `8.8.8.8;8.8.4.4` | Upstream DNS servers |
+| `pihole.dnssec` | `false` | Enable DNSSEC validation |
+| `admin.password` | `""` | Admin password (auto-generated if empty) |
+| `dns.customRecords` | `[]` | Local DNS A records |
+| `dns.cnameRecords` | `[]` | Custom CNAME records |
+| `unbound.enabled` | `false` | Enable Unbound recursive DNS |
+| `metrics.enabled` | `false` | Enable Prometheus metrics |
+| `ingress.enabled` | `false` | Enable ingress for web admin |
+| `serviceDns.type` | `LoadBalancer` | DNS service type |
+| `serviceDns.loadBalancerIP` | — | Fixed IP for DNS |
+| `persistence.enabled` | `true` | Enable persistent storage |
+| `persistence.size` | `1Gi` | PVC size |
+
+## More Information
+
+See the [source code and full values reference](https://github.com/helmforgedev/charts/tree/main/charts/pihole) on GitHub.


### PR DESCRIPTION
## Summary

- New Pi-hole chart documentation page at `/docs/charts/pihole`
- Added Pi-hole to sidebar navigation in DocsLayout
- Added Pi-hole card to ChartGrid component, updated count to 10

## Test plan

- [x] `npm run build` succeeds with 15 pages
- [ ] CI pipeline passes (build, sitemap, page count, link check)