### PR TITLE
feat(site): add apache answer chart documentation page

### DIFF
--- a/src/components/ChartGrid.astro
+++ b/src/components/ChartGrid.astro
@@ -77,6 +77,13 @@ const charts = [
     color: 'bg-blue-100 text-blue-700',
     letter: 'Wp',
   },
+  {
+    name: 'Answer',
+    slug: 'answer',
+    description: 'Apache Answer Q&A platform with SQLite, PostgreSQL, MySQL, and S3 backup.',
+    color: 'bg-cyan-100 text-cyan-700',
+    letter: 'An',
+  },
 ];
 ---
 
@@ -87,7 +94,7 @@ const charts = [
         Available Charts
       </h2>
       <p class="mt-4 text-lg text-muted leading-relaxed">
-        Eleven production-ready charts covering databases, messaging, identity, CMS, game servers, networking, and general workloads.
+        Twelve production-ready charts covering databases, messaging, identity, CMS, Q&amp;A, game servers, networking, and general workloads.
       </p>
     </div>
 

--- a/src/layouts/DocsLayout.astro
+++ b/src/layouts/DocsLayout.astro
@@ -29,6 +29,7 @@ const chartNav = [
   { label: 'Minecraft', href: '/docs/charts/minecraft' },
   { label: 'Pi-hole', href: '/docs/charts/pihole' },
   { label: 'WordPress', href: '/docs/charts/wordpress' },
+  { label: 'Answer', href: '/docs/charts/answer' },
 ];
 
 const allPages = [

--- a/src/pages/docs/charts/answer.mdx
+++ b/src/pages/docs/charts/answer.mdx
@@ -1,0 +1,109 @@
+---
+layout: ../../../layouts/DocsLayout.astro
+title: Apache Answer Chart
+description: HelmForge Apache Answer chart — Q&A platform with SQLite, PostgreSQL, or MySQL, auto-install, and S3 backup.
+---
+
+# Apache Answer
+
+Deploy Apache Answer on Kubernetes using the official [apache/answer](https://hub.docker.com/r/apache/answer) Docker image. Supports SQLite (default), PostgreSQL, MySQL, automatic setup, and scheduled backups.
+
+## Key Features
+
+- **SQLite by Default** — zero database configuration needed
+- **PostgreSQL Subchart** — bundled via HelmForge dependency
+- **MySQL Subchart** — bundled via HelmForge dependency
+- **External Database** — connect to existing PostgreSQL or MySQL
+- **Auto-Install** — unattended setup via environment variables
+- **Scheduled Backups** — database-aware CronJob with S3 upload
+- **Ingress Support** — TLS with cert-manager
+
+## Installation
+
+**HTTPS repository:**
+
+```bash
+helm repo add helmforge https://repo.helmforge.dev
+helm repo update
+helm install answer helmforge/answer
+```
+
+**OCI registry:**
+
+```bash
+helm install answer oci://ghcr.io/helmforgedev/helm/answer
+```
+
+## Basic Example (SQLite)
+
+```yaml
+# values.yaml
+answer:
+  siteName: "My Q&A"
+
+admin:
+  name: admin
+  password: "change-me"
+
+persistence:
+  enabled: true
+  size: 5Gi
+```
+
+## PostgreSQL Example
+
+```yaml
+postgresql:
+  enabled: true
+  auth:
+    database: answer
+    username: answer
+    password: "strong-password"
+
+ingress:
+  enabled: true
+  ingressClassName: traefik
+  hosts:
+    - host: qa.example.com
+      paths:
+        - path: /
+          pathType: Prefix
+  tls:
+    - secretName: answer-tls
+      hosts:
+        - qa.example.com
+```
+
+## External Database Example
+
+```yaml
+database:
+  external:
+    vendor: postgres
+    host: db.example.com
+    name: answer
+    username: answer
+    existingSecret: answer-db-credentials
+```
+
+## Key Values
+
+| Key | Default | Description |
+|-----|---------|-------------|
+| `answer.siteName` | `Apache Answer` | Site name |
+| `answer.siteUrl` | `""` | Full external URL (auto-detected from ingress) |
+| `answer.language` | `en-US` | Default UI language |
+| `answer.autoInstall` | `true` | Enable unattended setup |
+| `admin.name` | `admin` | Admin username |
+| `admin.password` | `""` | Admin password (auto-generated) |
+| `database.mode` | `auto` | Database mode (auto, sqlite, external, postgresql, mysql) |
+| `postgresql.enabled` | `false` | Deploy PostgreSQL subchart |
+| `mysql.enabled` | `false` | Deploy MySQL subchart |
+| `persistence.enabled` | `true` | Enable persistent storage |
+| `persistence.size` | `5Gi` | PVC size |
+| `ingress.enabled` | `false` | Enable ingress |
+| `backup.enabled` | `false` | Enable S3 backups |
+
+## More Information
+
+See the [source code and full values reference](https://github.com/helmforgedev/charts/tree/main/charts/answer) on GitHub.


### PR DESCRIPTION
## Summary

- Add Apache Answer chart documentation page at `/docs/charts/answer`
- Add Answer to sidebar navigation in DocsLayout
- Add Answer card to ChartGrid component (cyan, "An")
- Update chart count to twelve

## Test plan

- [x] `npm run build` succeeds (17 pages)
- [x] Answer page renders at `/docs/charts/answer/index.html`
- [ ] CI pipeline