### PR TITLE
feat(site): add cloudflared and ddns-updater docs

### DIFF
--- a/src/components/ChartGrid.astro
+++ b/src/components/ChartGrid.astro
@@ -105,6 +105,20 @@ const charts = [
     color: 'bg-yellow-100 text-yellow-700',
     letter: 'Gc',
   },
+  {
+    name: 'Cloudflared',
+    slug: 'cloudflared',
+    description: 'Cloudflare Tunnel for secure, outbound-only connections with HA and Prometheus metrics.',
+    color: 'bg-orange-100 text-orange-700',
+    letter: 'Cf',
+  },
+  {
+    name: 'DDNS Updater',
+    slug: 'ddns-updater',
+    description: 'Dynamic DNS updater supporting 50+ providers with web UI and persistent history.',
+    color: 'bg-purple-100 text-purple-700',
+    letter: 'Dd',
+  },
 ];
 ---
 
@@ -115,7 +129,7 @@ const charts = [
         Available Charts
       </h2>
       <p class="mt-4 text-lg text-muted leading-relaxed">
-        Fifteen production-ready charts covering databases, messaging, identity, CMS, Q&amp;A, automation, media, remote access, game servers, networking, and general workloads.
+        Seventeen production-ready charts covering databases, messaging, identity, CMS, Q&amp;A, automation, media, remote access, tunnels, dynamic DNS, game servers, networking, and general workloads.
       </p>
     </div>
 

--- a/src/layouts/DocsLayout.astro
+++ b/src/layouts/DocsLayout.astro
@@ -33,6 +33,8 @@ const chartNav = [
   { label: 'n8n', href: '/docs/charts/n8n' },
   { label: 'Komga', href: '/docs/charts/komga' },
   { label: 'Guacamole', href: '/docs/charts/guacamole' },
+  { label: 'Cloudflared', href: '/docs/charts/cloudflared' },
+  { label: 'DDNS Updater', href: '/docs/charts/ddns-updater' },
 ];
 
 const allPages = [

--- a/src/pages/docs/charts/cloudflared.mdx
+++ b/src/pages/docs/charts/cloudflared.mdx
@@ -1,0 +1,94 @@
+---
+layout: ../../../layouts/DocsLayout.astro
+title: Cloudflare Tunnel Chart
+description: HelmForge Cloudflare Tunnel chart — secure outbound-only connections with HA, PDB, and Prometheus metrics.
+---
+
+# Cloudflare Tunnel (cloudflared)
+
+Deploy Cloudflare Tunnel on Kubernetes using the official [cloudflare/cloudflared](https://hub.docker.com/r/cloudflare/cloudflared) Docker image. Secure, outbound-only connections between your cluster and Cloudflare's network — no open ports, no public IP required.
+
+## Key Features
+
+- **Zero-trust networking** — no inbound firewall rules needed
+- **Remotely-managed** — configure routes in the Cloudflare dashboard
+- **High availability** — 2 replicas with PodDisruptionBudget by default
+- **Prometheus metrics** — `/ready` and `/metrics` on port 2000
+- **ServiceMonitor** — optional Prometheus Operator integration
+- **Existing secrets** — bring your own Secret for the tunnel token
+
+## Installation
+
+**HTTPS repository:**
+
+```bash
+helm repo add helmforge https://repo.helmforge.dev
+helm repo update
+helm install cloudflared helmforge/cloudflared -f values.yaml
+```
+
+**OCI registry:**
+
+```bash
+helm install cloudflared oci://ghcr.io/helmforgedev/helm/cloudflared -f values.yaml
+```
+
+## Basic Example
+
+```yaml
+# values.yaml
+tunnel:
+  token: "eyJhIjoiY2Y..."  # From Cloudflare dashboard
+```
+
+Create a tunnel in the [Cloudflare dashboard](https://one.dash.cloudflare.com) under **Networks → Tunnels**, copy the token, and configure public hostnames to route traffic to your Kubernetes services.
+
+## Production Example
+
+```yaml
+tunnel:
+  existingSecret: cloudflare-tunnel
+
+replicaCount: 2
+
+pdb:
+  enabled: true
+  minAvailable: 1
+
+resources:
+  requests:
+    cpu: 50m
+    memory: 64Mi
+  limits:
+    memory: 128Mi
+
+serviceMonitor:
+  enabled: true
+  labels:
+    release: prometheus
+```
+
+## Key Values
+
+| Key | Default | Description |
+|-----|---------|-------------|
+| `tunnel.token` | `""` | Tunnel token from Cloudflare dashboard |
+| `tunnel.existingSecret` | `""` | Existing secret with tunnel token |
+| `replicaCount` | `2` | Number of replicas |
+| `cloudflared.logLevel` | `info` | Log level |
+| `cloudflared.noAutoupdate` | `true` | Disable auto-update |
+| `cloudflared.metricsPort` | `2000` | Metrics listen port |
+| `pdb.enabled` | `true` | Create PodDisruptionBudget |
+| `pdb.minAvailable` | `1` | Min available during disruption |
+| `metrics.enabled` | `true` | Expose metrics service |
+| `serviceMonitor.enabled` | `false` | Create Prometheus ServiceMonitor |
+
+## Important Notes
+
+- **Do not use HPA** — downscaling terminates active tunnel connections
+- **No ingress template** — cloudflared replaces traditional ingress controllers
+- **Routing is dashboard-managed** — use the Cloudflare dashboard to map hostnames to services
+
+## More Information
+
+See the [source code and full values reference](https://github.com/helmforgedev/charts/tree/main/charts/cloudflared) on GitHub.

--- a/src/pages/docs/charts/ddns-updater.mdx
+++ b/src/pages/docs/charts/ddns-updater.mdx
@@ -1,0 +1,99 @@
+---
+layout: ../../../layouts/DocsLayout.astro
+title: DDNS Updater Chart
+description: HelmForge DDNS Updater chart — dynamic DNS for 50+ providers with web UI and persistent history.
+---
+
+# DDNS Updater
+
+Deploy [ddns-updater](https://github.com/qdm12/ddns-updater) on Kubernetes using the official [qmcgaw/ddns-updater](https://hub.docker.com/r/qmcgaw/ddns-updater) Docker image. Keep DNS A/AAAA records updated across 50+ providers with a responsive web UI.
+
+## Key Features
+
+- **50+ DNS providers** — Cloudflare, Route53, DuckDNS, Namecheap, GoDaddy, Hetzner, and more
+- **Web UI** — responsive dashboard for monitoring update status
+- **Multi-provider** — manage records across different providers in a single deployment
+- **Persistent history** — update history stored in a PVC
+- **Existing secrets** — bring your own Secret for credentials
+- **Ingress support** — expose the web UI with TLS
+
+## Installation
+
+**HTTPS repository:**
+
+```bash
+helm repo add helmforge https://repo.helmforge.dev
+helm repo update
+helm install ddns-updater helmforge/ddns-updater -f values.yaml
+```
+
+**OCI registry:**
+
+```bash
+helm install ddns-updater oci://ghcr.io/helmforgedev/helm/ddns-updater -f values.yaml
+```
+
+## Basic Example (Cloudflare)
+
+```yaml
+# values.yaml
+config:
+  settings:
+    - provider: cloudflare
+      zone_identifier: "your-zone-id"
+      domain: "example.com"
+      host: "@"
+      ttl: 300
+      token: "your-cloudflare-api-token"
+      proxied: false
+      ip_version: "ipv4"
+```
+
+Access the web UI with `kubectl port-forward svc/<release>-ddns-updater 8000:80`.
+
+## Multi-Provider Example
+
+```yaml
+config:
+  settings:
+    - provider: cloudflare
+      zone_identifier: "cf-zone-id"
+      domain: "example.com"
+      host: "@"
+      token: "cf-token"
+      proxied: true
+    - provider: duckdns
+      domain: "myhost.duckdns.org"
+      token: "duck-token"
+    - provider: namecheap
+      domain: "example.org"
+      host: "home"
+      password: "ddns-password"
+```
+
+## External Secret
+
+```yaml
+config:
+  existingSecret: ddns-config
+  existingSecretKey: config.json
+```
+
+## Key Values
+
+| Key | Default | Description |
+|-----|---------|-------------|
+| `config.settings` | `[]` | DNS records to update (provider-specific) |
+| `config.existingSecret` | `""` | Existing secret with config.json |
+| `ddns.period` | `5m` | Check interval |
+| `ddns.httpTimeout` | `10s` | HTTP timeout |
+| `ddns.publicIpFetchers` | `all` | IP detection method |
+| `ddns.logLevel` | `info` | Log level |
+| `ddns.port` | `8000` | Web UI container port |
+| `persistence.enabled` | `true` | Persist update history |
+| `persistence.size` | `256Mi` | PVC size |
+| `ingress.enabled` | `false` | Enable ingress for web UI |
+
+## More Information
+
+See the [source code and full values reference](https://github.com/helmforgedev/charts/tree/main/charts/ddns-updater) on GitHub.


### PR DESCRIPTION
## Summary

- Add documentation page for Cloudflare Tunnel (cloudflared) chart
- Add documentation page for DDNS Updater chart
- Update sidebar navigation with both new entries
- Update chart grid to 17 charts with Cloudflared (Cf, orange) and DDNS Updater (Dd, purple)

## Test plan

- [ ] CI build passes
- [ ] New pages render correctly
- [ ] Merge