### PR TITLE
feat(site): add adguard home chart documentation

### DIFF
--- a/src/components/ChartGrid.astro
+++ b/src/components/ChartGrid.astro
@@ -133,6 +133,13 @@ const charts = [
     color: 'bg-blue-100 text-blue-600',
     letter: 'Au',
   },
+  {
+    name: 'AdGuard Home',
+    slug: 'adguard-home',
+    description: 'Network-wide DNS ad/tracker blocker with multi-instance sync and S3 backup.',
+    color: 'bg-green-100 text-green-600',
+    letter: 'Ag',
+  },
 ];
 ---
 
@@ -143,7 +150,7 @@ const charts = [
         Available Charts
       </h2>
       <p class="mt-4 text-lg text-muted leading-relaxed">
-        Nineteen production-ready charts covering databases, messaging, identity, CMS, Q&amp;A, automation, media, remote access, tunnels, dynamic DNS, monitoring, game servers, networking, and general workloads.
+        Twenty production-ready charts covering databases, messaging, identity, CMS, Q&amp;A, automation, media, remote access, tunnels, dynamic DNS, monitoring, game servers, networking, and general workloads.
       </p>
     </div>
 

--- a/src/layouts/DocsLayout.astro
+++ b/src/layouts/DocsLayout.astro
@@ -37,6 +37,7 @@ const chartNav = [
   { label: 'DDNS Updater', href: '/docs/charts/ddns-updater' },
   { label: 'Uptime Kuma', href: '/docs/charts/uptime-kuma' },
   { label: 'Authelia', href: '/docs/charts/authelia' },
+  { label: 'AdGuard Home', href: '/docs/charts/adguard-home' },
 ];
 
 const allPages = [

--- a/src/pages/docs/charts/adguard-home.mdx
+++ b/src/pages/docs/charts/adguard-home.mdx
@@ -1,0 +1,126 @@
+---
+layout: ../../../layouts/DocsLayout.astro
+title: AdGuard Home Chart
+description: HelmForge AdGuard Home chart — DNS ad/tracker blocker with sync, S3 backup, and two deployment modes.
+---
+
+# AdGuard Home
+
+Deploy [AdGuard Home](https://adguard.com/adguard-home/overview.html) on Kubernetes using the official [adguard/adguardhome](https://hub.docker.com/r/adguard/adguardhome) Docker image. Network-wide DNS-level ad and tracker blocking for all devices.
+
+## Key Features
+
+- **Network-wide ad blocking** — DNS-level filtering for all devices
+- **Two deployment modes** — wizard (port 3000) or pre-configured (port 80)
+- **DNS over HTTPS / TLS** — encrypted upstream DNS resolvers
+- **AdGuardHome Sync** — multi-instance synchronization via adguardhome-sync
+- **S3 backup** — automated CronJob-based backup to any S3-compatible storage
+- **Separate DNS service** — dedicated LoadBalancer for DNS traffic
+- **Ingress support** — TLS with cert-manager for the web UI
+- **Config seeding** — initial configuration preserved across upgrades
+
+## Installation
+
+**HTTPS repository:**
+
+```bash
+helm repo add helmforge https://repo.helmforge.dev
+helm repo update
+helm install adguard-home helmforge/adguard-home
+```
+
+**OCI registry:**
+
+```bash
+helm install adguard-home oci://ghcr.io/helmforgedev/helm/adguard-home
+```
+
+## Wizard Mode (Default)
+
+By default, AdGuard Home starts in wizard mode on port 3000. Complete the setup via the web UI:
+
+```bash
+helm install adguard-home oci://ghcr.io/helmforgedev/helm/adguard-home \
+  --set service.dns.type=LoadBalancer \
+  --set service.dns.loadBalancerIP=192.168.1.53
+
+kubectl port-forward svc/adguard-home-adguard-home-web 3000:80
+# Visit http://localhost:3000
+```
+
+## Pre-Configured Mode
+
+Skip the wizard by providing `config.adGuardHome`:
+
+```yaml
+config:
+  adGuardHome:
+    http:
+      address: 0.0.0.0:80
+    users:
+      - name: admin
+        # bcrypt hash — generate with: htpasswd -bnBC 10 "" 'PASSWORD' | cut -d: -f2
+        password: "$2y$10$..."
+    dns:
+      bind_hosts:
+        - 0.0.0.0
+      port: 53
+      upstream_dns:
+        - https://dns.cloudflare.com/dns-query
+        - https://dns.google/dns-query
+      bootstrap_dns:
+        - 1.1.1.1
+      protection_enabled: true
+      filtering_enabled: true
+    filters:
+      - enabled: true
+        url: https://adguardteam.github.io/HostlistsRegistry/assets/filter_1.txt
+        name: AdGuard DNS filter
+        id: 1
+    schema_version: 29
+
+service:
+  dns:
+    type: LoadBalancer
+    loadBalancerIP: "192.168.1.53"
+```
+
+## Multi-Instance Sync
+
+Synchronize configuration from an origin to replicas using adguardhome-sync:
+
+```yaml
+sync:
+  enabled: true
+  origin:
+    url: "http://adguard-primary:80"
+    username: admin
+    password: changeme
+  replicas:
+    - url: "http://adguard-replica:80"
+      username: admin
+      password: changeme
+```
+
+## Key Values
+
+| Key | Default | Description |
+|-----|---------|-------------|
+| `config.adGuardHome` | `{}` | Pre-seed config (empty = wizard mode) |
+| `config.existingSecret` | `""` | Existing Secret with AdGuardHome.yaml |
+| `persistence.conf.enabled` | `true` | Enable conf volume |
+| `persistence.conf.size` | `256Mi` | Conf PVC size |
+| `persistence.work.enabled` | `true` | Enable work volume |
+| `persistence.work.size` | `2Gi` | Work PVC size |
+| `service.web.type` | `ClusterIP` | Web UI service type |
+| `service.dns.type` | `LoadBalancer` | DNS service type |
+| `service.dns.loadBalancerIP` | `""` | Fixed DNS IP |
+| `ingress.enabled` | `false` | Enable ingress |
+| `sync.enabled` | `false` | Enable adguardhome-sync |
+| `sync.cron` | `*/10 * * * *` | Sync schedule |
+| `backup.enabled` | `false` | Enable S3 backup CronJob |
+| `backup.schedule` | `0 2 * * *` | Backup schedule |
+
+## More Information
+
+See the [source code and full values reference](https://github.com/helmforgedev/charts/tree/main/charts/adguard-home) on GitHub.

--- a/src/pages/docs/charts/index.mdx
+++ b/src/pages/docs/charts/index.mdx
@@ -6,7 +6,7 @@ description: Browse all HelmForge Helm charts — databases, messaging, identity
 
 # Charts Overview
 
-HelmForge provides eight production-ready Helm charts. Each chart supports multiple architectures, security hardening, and observability out of the box.
+HelmForge provides twenty production-ready Helm charts. Each chart supports multiple architectures, security hardening, and observability out of the box.
 
 ## General Purpose
 
@@ -35,6 +35,33 @@ HelmForge provides eight production-ready Helm charts. Each chart supports multi
 |-------|-------------|
 | [Keycloak](/docs/charts/keycloak) | Keycloak identity and access management |
 | [Vaultwarden](/docs/charts/vaultwarden) | Self-hosted Bitwarden-compatible password manager |
+| [Authelia](/docs/charts/authelia) | SSO, MFA, and OpenID Connect authentication server |
+
+## Networking & DNS
+
+| Chart | Description |
+|-------|-------------|
+| [Pi-hole](/docs/charts/pihole) | DNS sinkhole with custom records and Unbound recursive DNS |
+| [AdGuard Home](/docs/charts/adguard-home) | DNS ad/tracker blocker with sync and S3 backup |
+| [Cloudflared](/docs/charts/cloudflared) | Cloudflare Tunnel for secure outbound-only connections |
+| [DDNS Updater](/docs/charts/ddns-updater) | Dynamic DNS updater for 50+ providers |
+
+## CMS & Applications
+
+| Chart | Description |
+|-------|-------------|
+| [WordPress](/docs/charts/wordpress) | WordPress CMS with MySQL, S3 backup, and metrics |
+| [Answer](/docs/charts/answer) | Apache Answer Q&A platform with S3 backup |
+| [n8n](/docs/charts/n8n) | Workflow automation with queue mode and S3 backup |
+| [Komga](/docs/charts/komga) | Media server for comics and manga with OPDS |
+| [Guacamole](/docs/charts/guacamole) | Remote desktop gateway with RDP, VNC, SSH |
+
+## Monitoring & Gaming
+
+| Chart | Description |
+|-------|-------------|
+| [Uptime Kuma](/docs/charts/uptime-kuma) | Self-hosted monitoring with status pages |
+| [Minecraft](/docs/charts/minecraft) | Java Edition server with cross-play, modding, and backup |
 
 ## Common Features
 


### PR DESCRIPTION
## Summary

- Add AdGuard Home chart documentation page
- Register in sidebar navigation, chart grid, and charts index
- Update charts index page with all missing charts (was listing 8, now 20)
- Update chart count from "nineteen" to "twenty" in ChartGrid

## Test plan

- [x] `npm run build` passes (25 pages)
- [ ] CI passes