### PR TITLE
docs(site): add strapi chart docs

### DIFF
--- a/src/components/ChartGrid.astro
+++ b/src/components/ChartGrid.astro
@@ -78,6 +78,13 @@ const charts = [
     letter: 'Wp',
   },
   {
+    name: 'Strapi',
+    slug: 'strapi',
+    description: 'Headless CMS with SQLite, PostgreSQL, MySQL, uploads persistence, and S3 backup.',
+    color: 'bg-indigo-100 text-indigo-700',
+    letter: 'St',
+  },
+  {
     name: 'Answer',
     slug: 'answer',
     description: 'Apache Answer Q&A platform with SQLite, PostgreSQL, MySQL, and S3 backup.',
@@ -150,7 +157,7 @@ const charts = [
         Available Charts
       </h2>
       <p class="mt-4 text-lg text-muted leading-relaxed">
-        Twenty production-ready charts covering databases, messaging, identity, CMS, Q&amp;A, automation, media, remote access, tunnels, dynamic DNS, monitoring, game servers, networking, and general workloads.
+        Twenty-one production-ready charts covering databases, messaging, identity, CMS, headless CMS, Q&amp;A, automation, media, remote access, tunnels, dynamic DNS, monitoring, game servers, networking, and general workloads.
       </p>
     </div>
 

--- a/src/layouts/DocsLayout.astro
+++ b/src/layouts/DocsLayout.astro
@@ -29,6 +29,7 @@ const chartNav = [
   { label: 'Minecraft', href: '/docs/charts/minecraft' },
   { label: 'Pi-hole', href: '/docs/charts/pihole' },
   { label: 'WordPress', href: '/docs/charts/wordpress' },
+  { label: 'Strapi', href: '/docs/charts/strapi' },
   { label: 'Answer', href: '/docs/charts/answer' },
   { label: 'n8n', href: '/docs/charts/n8n' },
   { label: 'Komga', href: '/docs/charts/komga' },

--- a/src/pages/docs/charts/index.mdx
+++ b/src/pages/docs/charts/index.mdx
@@ -6,7 +6,7 @@ description: Browse all HelmForge Helm charts — databases, messaging, identity
 
 # Charts Overview
 
-HelmForge provides twenty production-ready Helm charts. Each chart supports multiple architectures, security hardening, and observability out of the box.
+HelmForge provides twenty-one production-ready Helm charts. Each chart supports multiple architectures, security hardening, and observability out of the box.
 
 ## General Purpose
 
@@ -51,6 +51,7 @@ HelmForge provides twenty production-ready Helm charts. Each chart supports mult
 | Chart | Description |
 |-------|-------------|
 | [WordPress](/docs/charts/wordpress) | WordPress CMS with MySQL, S3 backup, and metrics |
+| [Strapi](/docs/charts/strapi) | Headless CMS with SQLite, PostgreSQL, MySQL, uploads persistence, and S3 backup |
 | [Answer](/docs/charts/answer) | Apache Answer Q&A platform with S3 backup |
 | [n8n](/docs/charts/n8n) | Workflow automation with queue mode and S3 backup |
 | [Komga](/docs/charts/komga) | Media server for comics and manga with OPDS |

--- a/src/pages/docs/charts/strapi.mdx
+++ b/src/pages/docs/charts/strapi.mdx
@@ -1,0 +1,108 @@
+---
+layout: ../../../layouts/DocsLayout.astro
+title: Strapi Chart
+description: HelmForge Strapi chart — headless CMS with SQLite, PostgreSQL, or MySQL, uploads persistence, and S3 backup.
+---
+
+# Strapi
+
+Deploy Strapi on Kubernetes as a headless CMS for APIs, websites, and custom admin experiences. The chart is designed for a prebuilt Strapi project image and supports SQLite, PostgreSQL, MySQL, persistent uploads, and scheduled backups.
+
+## Key Features
+
+- **Prebuilt project image** — intended for your own Strapi application image
+- **SQLite by default** — simple initial deployment path
+- **PostgreSQL subchart** — bundled via HelmForge dependency
+- **MySQL subchart** — bundled via HelmForge dependency
+- **External database** — connect to existing PostgreSQL or MySQL
+- **Application secrets** — auto-generated app keys and token salts
+- **Uploads persistence** — PVC-backed media storage
+- **Scheduled backups** — SQLite archive or SQL dump workflows to S3
+
+## Installation
+
+**HTTPS repository:**
+
+```bash
+helm repo add helmforge https://repo.helmforge.dev
+helm repo update
+helm install strapi helmforge/strapi
+```
+
+**OCI registry:**
+
+```bash
+helm install strapi oci://ghcr.io/helmforgedev/helm/strapi
+```
+
+## Basic Example
+
+```yaml
+image:
+  repository: ghcr.io/example/my-strapi
+  tag: "1.0.0"
+
+persistence:
+  enabled: true
+  size: 5Gi
+```
+
+## PostgreSQL Example
+
+```yaml
+image:
+  repository: ghcr.io/example/my-strapi
+  tag: "1.0.0"
+
+postgresql:
+  enabled: true
+  auth:
+    database: strapi
+    username: strapi
+    password: "strong-password"
+
+ingress:
+  enabled: true
+  ingressClassName: traefik
+  hosts:
+    - host: cms.example.com
+      paths:
+        - path: /
+          pathType: Prefix
+  tls:
+    - secretName: strapi-tls
+      hosts:
+        - cms.example.com
+```
+
+## External Database Example
+
+```yaml
+database:
+  mode: external
+  external:
+    vendor: postgres
+    host: db.example.com
+    name: strapi
+    username: strapi
+    existingSecret: strapi-db-credentials
+```
+
+## Key Values
+
+| Key | Default | Description |
+|-----|---------|-------------|
+| `image.repository` | `vshadbolt/strapi` | Container image for the Strapi project |
+| `strapi.url` | `""` | Public URL (auto-detected from ingress if empty) |
+| `database.mode` | `auto` | Database mode (auto, sqlite, external, postgresql, mysql) |
+| `database.sqlite.directory` | `/opt/app/.tmp` | SQLite directory |
+| `postgresql.enabled` | `false` | Deploy PostgreSQL subchart |
+| `mysql.enabled` | `false` | Deploy MySQL subchart |
+| `persistence.enabled` | `true` | Enable uploads and SQLite persistence |
+| `ingress.enabled` | `false` | Enable ingress |
+| `backup.enabled` | `false` | Enable S3 backups |
+| `secrets.existingSecret` | `""` | Use an existing secret for Strapi app secrets |
+
+## More Information
+
+See the [source code and full values reference](https://github.com/helmforgedev/charts/tree/main/charts/strapi) on GitHub.

--- a/src/pages/docs/index.mdx
+++ b/src/pages/docs/index.mdx
@@ -43,3 +43,4 @@ Charts are available through two channels:
 | [RabbitMQ](/docs/charts/rabbitmq) | RabbitMQ with management UI and clustering |
 | [Keycloak](/docs/charts/keycloak) | Keycloak identity and access management |
 | [Vaultwarden](/docs/charts/vaultwarden) | Self-hosted Bitwarden-compatible password manager |
+| [Strapi](/docs/charts/strapi) | Headless CMS with SQLite, PostgreSQL, MySQL, uploads persistence, and S3 backup |


### PR DESCRIPTION
## Summary
- add the Strapi chart page to the public docs site
- update chart navigation, overview pages, and landing page grid
- increase the published chart count to reflect the new Strapi entry

## Validation
- npm run build