### PR TITLE
docs(site): clarify strapi ingress guidance

### DIFF
--- a/src/pages/docs/charts/strapi.mdx
+++ b/src/pages/docs/charts/strapi.mdx
@@ -8,6 +8,8 @@ description: HelmForge Strapi chart — headless CMS with SQLite, PostgreSQL, or
 
 Deploy Strapi on Kubernetes as a headless CMS for APIs, websites, and custom admin experiences. The chart is designed for a prebuilt Strapi project image and supports SQLite, PostgreSQL, MySQL, persistent uploads, and scheduled backups.
 
+Set `ingress.ingressClassName` to the controller available in your cluster, such as `traefik`, `nginx`, or another supported ingress class.
+
 ## Key Features
 
 - **Prebuilt project image** — intended for your own Strapi application image


### PR DESCRIPTION
## Summary
- clarify that the Strapi docs page should use the ingress class supported by the cluster
- mention examples such as 	raefik, 
ginx, or another supported ingress controller

## Validation
- npm run build