### PR TITLE
docs(site): add velero chart docs

### DIFF
--- a/src/components/ChartGrid.astro
+++ b/src/components/ChartGrid.astro
@@ -147,6 +147,13 @@ const charts = [
     color: 'bg-green-100 text-green-600',
     letter: 'Ag',
   },
+  {
+    name: 'Velero',
+    slug: 'velero',
+    description: 'Kubernetes backup, restore, migration, schedules, and S3-compatible object storage.',
+    color: 'bg-cyan-100 text-cyan-700',
+    letter: 'Ve',
+  },
 ];
 ---
 
@@ -157,7 +164,7 @@ const charts = [
         Available Charts
       </h2>
       <p class="mt-4 text-lg text-muted leading-relaxed">
-        Twenty-one production-ready charts covering databases, messaging, identity, CMS, headless CMS, Q&amp;A, automation, media, remote access, tunnels, dynamic DNS, monitoring, game servers, networking, and general workloads.
+        Twenty-two production-ready charts covering databases, messaging, identity, CMS, headless CMS, Q&amp;A, automation, media, remote access, tunnels, dynamic DNS, monitoring, game servers, Kubernetes backup, and general workloads.
       </p>
     </div>
 

--- a/src/layouts/DocsLayout.astro
+++ b/src/layouts/DocsLayout.astro
@@ -39,6 +39,7 @@ const chartNav = [
   { label: 'Uptime Kuma', href: '/docs/charts/uptime-kuma' },
   { label: 'Authelia', href: '/docs/charts/authelia' },
   { label: 'AdGuard Home', href: '/docs/charts/adguard-home' },
+  { label: 'Velero', href: '/docs/charts/velero' },
 ];
 
 const allPages = [

--- a/src/pages/docs/charts/index.mdx
+++ b/src/pages/docs/charts/index.mdx
@@ -6,7 +6,7 @@ description: Browse all HelmForge Helm charts — databases, messaging, identity
 
 # Charts Overview
 
-HelmForge provides twenty-one production-ready Helm charts. Each chart supports multiple architectures, security hardening, and observability out of the box.
+HelmForge provides twenty-two production-ready Helm charts. Each chart supports multiple architectures, security hardening, and observability out of the box.
 
 ## General Purpose
 
@@ -63,6 +63,12 @@ HelmForge provides twenty-one production-ready Helm charts. Each chart supports 
 |-------|-------------|
 | [Uptime Kuma](/docs/charts/uptime-kuma) | Self-hosted monitoring with status pages |
 | [Minecraft](/docs/charts/minecraft) | Java Edition server with cross-play, modding, and backup |
+
+## Backup & Recovery
+
+| Chart | Description |
+|-------|-------------|
+| [Velero](/docs/charts/velero) | Kubernetes backup, restore, migration, schedules, and S3-compatible object storage |
 
 ## Common Features
 

--- a/src/pages/docs/charts/velero.mdx
+++ b/src/pages/docs/charts/velero.mdx
@@ -1,0 +1,92 @@
+---
+layout: ../../../layouts/DocsLayout.astro
+title: Velero Chart
+description: HelmForge Velero chart for Kubernetes backup, restore, migration, schedules, and S3-compatible object storage.
+---
+
+# Velero
+
+Deploy [Velero](https://velero.io/) on Kubernetes using the official `docker.io/velero/velero` image for backup, restore, migration, and optional filesystem backup workflows.
+
+## Key Features
+
+- **Latest stable Velero** — chart pinned to the latest stable upstream release
+- **Official CRDs included** — Velero CRDs shipped through the chart `crds/` directory
+- **S3-compatible storage** — validated with the AWS plugin against MinIO and similar providers
+- **Recurring schedules** — optional `Schedule` resources rendered from chart values
+- **Filesystem backup** — optional node-agent DaemonSet for pod volume backups
+- **Metrics support** — metrics Service and optional ServiceMonitor
+
+## Installation
+
+**HTTPS repository:**
+
+```bash
+helm repo add helmforge https://repo.helmforge.dev
+helm repo update
+helm install velero helmforge/velero -n velero --create-namespace -f values.yaml
+```
+
+**OCI registry:**
+
+```bash
+helm install velero oci://ghcr.io/helmforgedev/helm/velero -n velero --create-namespace -f values.yaml
+```
+
+## S3-Compatible Example
+
+```yaml
+credentials:
+  secretContents: |
+    [default]
+    aws_access_key_id=minioadmin
+    aws_secret_access_key=minioadmin123
+
+configuration:
+  backupStorageLocations:
+    - name: default
+      provider: aws
+      bucket: velero
+      default: true
+      config:
+        region: minio
+        s3Url: http://minio.minio.svc.cluster.local:9000
+        s3ForcePathStyle: true
+        insecureSkipTLSVerify: true
+```
+
+## Scheduled Backup Example
+
+```yaml
+schedules:
+  - name: daily
+    schedule: "0 3 * * *"
+    template:
+      ttl: 168h
+      includedNamespaces:
+        - apps
+      snapshotVolumes: false
+      defaultVolumesToFsBackup: true
+```
+
+## Key Values
+
+| Key | Default | Description |
+|-----|---------|-------------|
+| `image.repository` | `docker.io/velero/velero` | Velero server image |
+| `plugins.aws.tag` | `v1.14.0` | Default AWS/S3 plugin image tag |
+| `configuration.backupStorageLocations` | one default entry | Backup storage definitions |
+| `configuration.volumeSnapshotLocations` | `[]` | Snapshot storage definitions |
+| `schedules` | `[]` | Schedule resources created by the chart |
+| `nodeAgent.enabled` | `false` | Deploy the filesystem backup DaemonSet |
+| `metrics.serviceMonitor.enabled` | `false` | Create a Prometheus Operator ServiceMonitor |
+
+## Validation Guidance
+
+- always confirm the active `kubectl` context before any local validation install, upgrade, or uninstall
+- for S3-compatible storage, validate that the `BackupStorageLocation` reaches `Available`
+- create at least one real test backup before enabling recurring schedules in shared environments
+
+## More Information
+
+See the [source code and full values reference](https://github.com/helmforgedev/charts/tree/main/charts/velero) on GitHub.

--- a/src/pages/docs/index.mdx
+++ b/src/pages/docs/index.mdx
@@ -44,3 +44,4 @@ Charts are available through two channels:
 | [Keycloak](/docs/charts/keycloak) | Keycloak identity and access management |
 | [Vaultwarden](/docs/charts/vaultwarden) | Self-hosted Bitwarden-compatible password manager |
 | [Strapi](/docs/charts/strapi) | Headless CMS with SQLite, PostgreSQL, MySQL, uploads persistence, and S3 backup |
+| [Velero](/docs/charts/velero) | Kubernetes backup, restore, migration, schedules, and S3-compatible object storage |


### PR DESCRIPTION
## Summary
- add the Velero chart documentation page
- include Velero in docs navigation and chart overview pages
- update the chart grid and catalog totals to reflect the new chart

## Validation
- npm run build
