### PR TITLE
docs(site): add kafka chart docs

### DIFF
--- a/src/components/ChartGrid.astro
+++ b/src/components/ChartGrid.astro
@@ -154,6 +154,13 @@ const charts = [
     color: 'bg-cyan-100 text-cyan-700',
     letter: 'Ve',
   },
+  {
+    name: 'Kafka',
+    slug: 'kafka',
+    description: 'KRaft single-broker and production-oriented cluster modes with persistent storage and optional metrics.',
+    color: 'bg-orange-100 text-orange-700',
+    letter: 'Ka',
+  },
 ];
 ---
 
@@ -164,7 +171,7 @@ const charts = [
         Available Charts
       </h2>
       <p class="mt-4 text-lg text-muted leading-relaxed">
-        Twenty-two production-ready charts covering databases, messaging, identity, CMS, headless CMS, Q&amp;A, automation, media, remote access, tunnels, dynamic DNS, monitoring, game servers, Kubernetes backup, and general workloads.
+        Twenty-three production-ready charts covering databases, messaging, identity, CMS, headless CMS, Q&amp;A, automation, media, remote access, tunnels, dynamic DNS, monitoring, game servers, Kubernetes backup, streaming, and general workloads.
       </p>
     </div>
 

--- a/src/layouts/DocsLayout.astro
+++ b/src/layouts/DocsLayout.astro
@@ -40,6 +40,7 @@ const chartNav = [
   { label: 'Authelia', href: '/docs/charts/authelia' },
   { label: 'AdGuard Home', href: '/docs/charts/adguard-home' },
   { label: 'Velero', href: '/docs/charts/velero' },
+  { label: 'Kafka', href: '/docs/charts/kafka' },
 ];
 
 const allPages = [

--- a/src/pages/docs/charts/index.mdx
+++ b/src/pages/docs/charts/index.mdx
@@ -6,7 +6,7 @@ description: Browse all HelmForge Helm charts — databases, messaging, identity
 
 # Charts Overview
 
-HelmForge provides twenty-two production-ready Helm charts. Each chart supports multiple architectures, security hardening, and observability out of the box.
+HelmForge provides twenty-three production-ready Helm charts. Each chart supports multiple architectures, security hardening, and observability out of the box.
 
 ## General Purpose
 
@@ -28,6 +28,7 @@ HelmForge provides twenty-two production-ready Helm charts. Each chart supports 
 |-------|-------------|
 | [Redis](/docs/charts/redis) | Redis with standalone and Sentinel high-availability |
 | [RabbitMQ](/docs/charts/rabbitmq) | RabbitMQ with management UI and clustering |
+| [Kafka](/docs/charts/kafka) | KRaft single-broker and production-oriented cluster modes with persistent storage |
 
 ## Identity & Security
 

--- a/src/pages/docs/charts/kafka.mdx
+++ b/src/pages/docs/charts/kafka.mdx
@@ -1,0 +1,90 @@
+---
+layout: ../../../layouts/DocsLayout.astro
+title: Kafka Chart
+description: HelmForge Kafka chart for Apache Kafka KRaft single-broker and production-oriented cluster deployments.
+---
+
+# Kafka
+
+Deploy Apache Kafka on Kubernetes using the official `apache/kafka:4.2.0` image with a KRaft-only design. The chart intentionally supports a simple `single-broker` path for development and a production-oriented `cluster` path with dedicated controllers and brokers.
+
+## Key Features
+
+- **Latest stable Kafka** — pinned to the latest stable upstream Kafka release
+- **KRaft only** — no ZooKeeper mode in this chart
+- **Two clear topologies** — `single-broker` for simple environments and `cluster` for production-oriented deployments
+- **Persistent storage** — supported for single-broker, controllers, and brokers
+- **Stable broker DNS** — advertised listeners use StatefulSet pod DNS names inside the cluster
+- **Optional metrics** — JMX exporter javaagent with optional ServiceMonitor
+
+## Installation
+
+**HTTPS repository:**
+
+```bash
+helm repo add helmforge https://repo.helmforge.dev
+helm repo update
+helm install kafka helmforge/kafka -f values.yaml
+```
+
+**OCI registry:**
+
+```bash
+helm install kafka oci://ghcr.io/helmforgedev/helm/kafka -f values.yaml
+```
+
+## Single-Broker Example
+
+```yaml
+architecture: single-broker
+
+singleBroker:
+  persistence:
+    size: 8Gi
+```
+
+## Cluster Example
+
+```yaml
+architecture: cluster
+
+cluster:
+  minInSyncReplicas: 2
+  controllers:
+    replicaCount: 3
+    persistence:
+      size: 8Gi
+  brokers:
+    replicaCount: 3
+    persistence:
+      size: 50Gi
+
+pdb:
+  enabled: true
+```
+
+## Key Values
+
+| Key | Default | Description |
+|-----|---------|-------------|
+| `architecture` | `single-broker` | `single-broker` or `cluster` |
+| `image.repository` | `apache/kafka` | Kafka image repository |
+| `image.tag` | `4.2.0` | Kafka image tag |
+| `kraft.existingSecret` | `""` | Existing secret with KRaft cluster ID and controller directory IDs |
+| `listeners.client.port` | `9092` | Kafka client port |
+| `listeners.controller.port` | `9093` | KRaft controller port |
+| `cluster.controllers.replicaCount` | `3` | Dedicated controller replicas |
+| `cluster.brokers.replicaCount` | `3` | Dedicated broker replicas |
+| `cluster.minInSyncReplicas` | `2` | Recommended minimum ISR for cluster mode |
+| `metrics.enabled` | `false` | Enable JMX exporter metrics |
+
+## Validation Guidance
+
+- use `single-broker` for development and CI, not as the production baseline
+- use `cluster` for production-oriented workloads with dedicated controllers and brokers
+- validate topic creation, producer, and consumer flows before promotion
+- plan external listeners, TLS, and auth as explicit follow-up work if your environment needs them
+
+## More Information
+
+See the [source code and full values reference](https://github.com/helmforgedev/charts/tree/main/charts/kafka) on GitHub.

--- a/src/pages/docs/index.mdx
+++ b/src/pages/docs/index.mdx
@@ -45,3 +45,4 @@ Charts are available through two channels:
 | [Vaultwarden](/docs/charts/vaultwarden) | Self-hosted Bitwarden-compatible password manager |
 | [Strapi](/docs/charts/strapi) | Headless CMS with SQLite, PostgreSQL, MySQL, uploads persistence, and S3 backup |
 | [Velero](/docs/charts/velero) | Kubernetes backup, restore, migration, schedules, and S3-compatible object storage |
+| [Kafka](/docs/charts/kafka) | KRaft single-broker and production-oriented cluster modes with persistent storage and optional metrics |


### PR DESCRIPTION
## Summary
- add the Kafka chart documentation page
- add Kafka to the chart grid, docs navigation, and overview pages
- update the published chart count

## Validation
- npm run build
