### PR TITLE
feat(site): add maturity badges to chart grid cards

### DIFF
--- a/src/components/ChartGrid.astro
+++ b/src/components/ChartGrid.astro
@@ -6,6 +6,7 @@ const charts = [
     description: 'Multi-purpose chart for Deployments, StatefulSets, DaemonSets, Jobs, and CronJobs.',
     color: 'bg-slate-100 text-slate-600',
     letter: 'G',
+    maturity: 'stable',
   },
   {
     name: 'MySQL',
@@ -13,6 +14,7 @@ const charts = [
     description: 'MySQL with standalone and source-replica replication architectures.',
     color: 'bg-sky-100 text-sky-700',
     letter: 'My',
+    maturity: 'stable',
   },
   {
     name: 'PostgreSQL',
@@ -20,6 +22,7 @@ const charts = [
     description: 'PostgreSQL with standalone and streaming replication support.',
     color: 'bg-indigo-100 text-indigo-700',
     letter: 'Pg',
+    maturity: 'stable',
   },
   {
     name: 'Redis',
@@ -27,6 +30,7 @@ const charts = [
     description: 'Redis with standalone and Sentinel high-availability modes.',
     color: 'bg-red-100 text-red-600',
     letter: 'Rd',
+    maturity: 'beta',
   },
   {
     name: 'MongoDB',
@@ -34,6 +38,7 @@ const charts = [
     description: 'MongoDB with standalone and replica set configurations.',
     color: 'bg-green-100 text-green-700',
     letter: 'Mg',
+    maturity: 'stable',
   },
   {
     name: 'RabbitMQ',
@@ -41,6 +46,7 @@ const charts = [
     description: 'RabbitMQ with management UI and clustering support.',
     color: 'bg-orange-100 text-orange-600',
     letter: 'Rb',
+    maturity: 'beta',
   },
   {
     name: 'Keycloak',
@@ -48,6 +54,7 @@ const charts = [
     description: 'Keycloak identity and access management for SSO and federation.',
     color: 'bg-teal-100 text-teal-700',
     letter: 'Kc',
+    maturity: 'stable',
   },
   {
     name: 'Vaultwarden',
@@ -55,6 +62,7 @@ const charts = [
     description: 'Self-hosted Bitwarden-compatible password manager.',
     color: 'bg-violet-100 text-violet-700',
     letter: 'Vw',
+    maturity: 'stable',
   },
   {
     name: 'Minecraft',
@@ -62,6 +70,7 @@ const charts = [
     description: 'Minecraft Java Edition server with cross-play, modding, backup, and monitoring.',
     color: 'bg-emerald-100 text-emerald-700',
     letter: 'Mc',
+    maturity: 'beta',
   },
   {
     name: 'Pi-hole',
@@ -69,6 +78,7 @@ const charts = [
     description: 'Network-wide ad blocking DNS sinkhole with Unbound recursive DNS.',
     color: 'bg-rose-100 text-rose-700',
     letter: 'Ph',
+    maturity: 'alpha',
   },
   {
     name: 'WordPress',
@@ -76,6 +86,7 @@ const charts = [
     description: 'WordPress CMS with MySQL, S3 backup, and Apache metrics.',
     color: 'bg-blue-100 text-blue-700',
     letter: 'Wp',
+    maturity: 'alpha',
   },
   {
     name: 'Strapi',
@@ -83,6 +94,7 @@ const charts = [
     description: 'Headless CMS with SQLite, PostgreSQL, MySQL, uploads persistence, and S3 backup.',
     color: 'bg-indigo-100 text-indigo-700',
     letter: 'St',
+    maturity: 'beta',
   },
   {
     name: 'Answer',
@@ -90,6 +102,7 @@ const charts = [
     description: 'Apache Answer Q&A platform with SQLite, PostgreSQL, MySQL, and S3 backup.',
     color: 'bg-cyan-100 text-cyan-700',
     letter: 'An',
+    maturity: 'beta',
   },
   {
     name: 'n8n',
@@ -97,6 +110,7 @@ const charts = [
     description: 'Workflow automation with SQLite, PostgreSQL, MySQL, Redis queue mode, and S3 backup.',
     color: 'bg-amber-100 text-amber-700',
     letter: 'N8',
+    maturity: 'alpha',
   },
   {
     name: 'Komga',
@@ -104,6 +118,7 @@ const charts = [
     description: 'Media server for comics and manga with OPDS, web reader, and S3 backup.',
     color: 'bg-lime-100 text-lime-700',
     letter: 'Kg',
+    maturity: 'beta',
   },
   {
     name: 'Guacamole',
@@ -111,6 +126,7 @@ const charts = [
     description: 'Remote desktop gateway with RDP, VNC, SSH, OIDC/SAML SSO, and S3 backup.',
     color: 'bg-yellow-100 text-yellow-700',
     letter: 'Gc',
+    maturity: 'beta',
   },
   {
     name: 'Cloudflared',
@@ -118,6 +134,7 @@ const charts = [
     description: 'Cloudflare Tunnel for secure, outbound-only connections with HA and Prometheus metrics.',
     color: 'bg-orange-100 text-orange-700',
     letter: 'Cf',
+    maturity: 'beta',
   },
   {
     name: 'DDNS Updater',
@@ -125,6 +142,7 @@ const charts = [
     description: 'Dynamic DNS updater supporting 50+ providers with web UI and persistent history.',
     color: 'bg-purple-100 text-purple-700',
     letter: 'Dd',
+    maturity: 'beta',
   },
   {
     name: 'Uptime Kuma',
@@ -132,6 +150,7 @@ const charts = [
     description: 'Self-hosted monitoring with HTTP/TCP/DNS checks, status pages, and 90+ notifications.',
     color: 'bg-emerald-100 text-emerald-700',
     letter: 'Uk',
+    maturity: 'alpha',
   },
   {
     name: 'Authelia',
@@ -139,6 +158,7 @@ const charts = [
     description: 'SSO, MFA, and OpenID Connect authentication server with forward auth for reverse proxies.',
     color: 'bg-blue-100 text-blue-600',
     letter: 'Au',
+    maturity: 'beta',
   },
   {
     name: 'AdGuard Home',
@@ -146,6 +166,7 @@ const charts = [
     description: 'Network-wide DNS ad/tracker blocker with multi-instance sync and S3 backup.',
     color: 'bg-green-100 text-green-600',
     letter: 'Ag',
+    maturity: 'beta',
   },
   {
     name: 'Velero',
@@ -153,6 +174,7 @@ const charts = [
     description: 'Kubernetes backup, restore, migration, schedules, and S3-compatible object storage.',
     color: 'bg-cyan-100 text-cyan-700',
     letter: 'Ve',
+    maturity: 'alpha',
   },
   {
     name: 'Kafka',
@@ -160,8 +182,15 @@ const charts = [
     description: 'KRaft single-broker and production-oriented cluster modes with persistent storage and optional metrics.',
     color: 'bg-orange-100 text-orange-700',
     letter: 'Ka',
+    maturity: 'alpha',
   },
 ];
+
+const maturityStyles = {
+  stable: 'bg-green-100 text-green-700 border-green-200',
+  beta: 'bg-amber-100 text-amber-700 border-amber-200',
+  alpha: 'bg-red-100 text-red-600 border-red-200',
+} as const;
 ---
 
 <section class="py-20 sm:py-28 bg-surface">
@@ -181,8 +210,13 @@ const charts = [
           href={`/docs/charts/${chart.slug}`}
           class="group block p-5 rounded-xl bg-white border border-slate-200 hover:border-primary/30 hover:shadow-lg hover:shadow-primary/5 transition-all duration-300"
         >
-          <div class={`w-10 h-10 rounded-lg flex items-center justify-center text-sm font-bold mb-3 ${chart.color}`}>
-            {chart.letter}
+          <div class="flex items-center justify-between mb-3">
+            <div class={`w-10 h-10 rounded-lg flex items-center justify-center text-sm font-bold ${chart.color}`}>
+              {chart.letter}
+            </div>
+            <span class={`text-[10px] font-semibold uppercase tracking-wider px-2 py-0.5 rounded-full border ${maturityStyles[chart.maturity]}`}>
+              {chart.maturity}
+            </span>
           </div>
           <h3 class="text-base font-semibold text-dark group-hover:text-primary transition-colors mb-1.5">
             {chart.name}


### PR DESCRIPTION
## Summary

- Add maturity badge (stable/beta/alpha) to each chart card in ChartGrid
- Color-coded: green for stable, amber for beta, red for alpha
- Badge positioned top-right of each card, next to the letter icon

### Classification

- **6 stable**: generic, mysql, postgresql, mongodb, keycloak, vaultwarden
- **11 beta**: redis, rabbitmq, minecraft, strapi, answer, komga, guacamole, cloudflared, ddns-updater, authelia, adguard-home
- **6 alpha**: pihole, wordpress, n8n, uptime-kuma, velero, kafka

Matches the `helmforge.dev/maturity` annotations in helmforgedev/charts#104.

## Test plan

- [ ] Verify `npm run build` passes (28 pages)
- [ ] Verify badges render correctly on the landing page
- [ ] Verify badge colors are visually distinct and readable