### PR TITLE
docs(site): require chart docs to stay in sync

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -83,6 +83,7 @@ When creating a new chart doc:
 - [ ] Include Installation section with HTTPS repository and OCI registry
 - [ ] Include Key Values table
 - [ ] Link to GitHub source
+- [ ] Keep chart maturity and other public metadata aligned with the `helm/` repository when chart pages or cards expose that information
 
 ### Page Removal Checklist
 
@@ -105,6 +106,8 @@ MDX page (frontmatter: layout, title, description)
 | When you change... | Also update... |
 |---------------------|----------------|
 | Add/remove a chart doc | `DocsLayout.astro` (chartNav) + `ChartGrid.astro` |
+| A chart is added in `helm/` | Create `src/pages/docs/charts/<name>.mdx` + update `DocsLayout.astro` + update `ChartGrid.astro` |
+| Public chart metadata changes in `helm/` (for example maturity) | Update the related chart page and any listing/card content that exposes that metadata |
 | Add/remove a docs page | `DocsLayout.astro` (sidebarNav) |
 | Add a new font | `astro.config.mjs` (fonts) + `global.css` (@theme) |
 | Change site domain | `astro.config.mjs` (site) + `robots.txt` (Sitemap URL) |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -122,6 +122,7 @@ Every new page or document MUST follow these steps:
 4. **Sitemap is automatic** — `@astrojs/sitemap` generates it at build time
 5. **Canonical URL is automatic** — `BaseLayout.astro` generates it from `Astro.url`
 6. **Build to verify** — run `npm run build` and confirm the new page appears
+7. **Keep chart docs in sync with `helm/`** — when a chart is added or its public metadata changes in the charts repository, update the corresponding page, sidebar, and landing-page card here in the same workstream
 
 ### Chart Documentation Standard
 


### PR DESCRIPTION
## Summary
- require site updates when a chart is added in the charts repository
- require updating site content when public chart metadata changes, such as maturity
- reinforce that chart pages, sidebar, and landing cards must stay aligned with helm

## Validation
- npm run build
