### PR TITLE
feat(site): add S3 backup badges to chart grid, update hero, and add dolibarr docs

### DIFF
--- a/src/components/ChartGrid.astro
+++ b/src/components/ChartGrid.astro
@@ -7,6 +7,7 @@ const charts = [
     color: 'bg-slate-100 text-slate-600',
     letter: 'G',
     maturity: 'stable',
+    backup: false,
   },
   {
     name: 'MySQL',
@@ -15,6 +16,7 @@ const charts = [
     color: 'bg-sky-100 text-sky-700',
     letter: 'My',
     maturity: 'stable',
+    backup: true,
   },
   {
     name: 'PostgreSQL',
@@ -23,6 +25,7 @@ const charts = [
     color: 'bg-indigo-100 text-indigo-700',
     letter: 'Pg',
     maturity: 'stable',
+    backup: true,
   },
   {
     name: 'Redis',
@@ -31,6 +34,7 @@ const charts = [
     color: 'bg-red-100 text-red-600',
     letter: 'Rd',
     maturity: 'beta',
+    backup: false,
   },
   {
     name: 'MongoDB',
@@ -39,6 +43,7 @@ const charts = [
     color: 'bg-green-100 text-green-700',
     letter: 'Mg',
     maturity: 'stable',
+    backup: true,
   },
   {
     name: 'RabbitMQ',
@@ -47,6 +52,7 @@ const charts = [
     color: 'bg-orange-100 text-orange-600',
     letter: 'Rb',
     maturity: 'beta',
+    backup: false,
   },
   {
     name: 'Keycloak',
@@ -55,6 +61,7 @@ const charts = [
     color: 'bg-teal-100 text-teal-700',
     letter: 'Kc',
     maturity: 'stable',
+    backup: true,
   },
   {
     name: 'Vaultwarden',
@@ -63,6 +70,7 @@ const charts = [
     color: 'bg-violet-100 text-violet-700',
     letter: 'Vw',
     maturity: 'stable',
+    backup: true,
   },
   {
     name: 'Minecraft',
@@ -71,6 +79,7 @@ const charts = [
     color: 'bg-emerald-100 text-emerald-700',
     letter: 'Mc',
     maturity: 'beta',
+    backup: true,
   },
   {
     name: 'Pi-hole',
@@ -79,6 +88,7 @@ const charts = [
     color: 'bg-rose-100 text-rose-700',
     letter: 'Ph',
     maturity: 'alpha',
+    backup: true,
   },
   {
     name: 'WordPress',
@@ -87,6 +97,7 @@ const charts = [
     color: 'bg-blue-100 text-blue-700',
     letter: 'Wp',
     maturity: 'alpha',
+    backup: true,
   },
   {
     name: 'Strapi',
@@ -95,6 +106,7 @@ const charts = [
     color: 'bg-indigo-100 text-indigo-700',
     letter: 'St',
     maturity: 'beta',
+    backup: true,
   },
   {
     name: 'Answer',
@@ -103,6 +115,7 @@ const charts = [
     color: 'bg-cyan-100 text-cyan-700',
     letter: 'An',
     maturity: 'beta',
+    backup: true,
   },
   {
     name: 'n8n',
@@ -111,6 +124,7 @@ const charts = [
     color: 'bg-amber-100 text-amber-700',
     letter: 'N8',
     maturity: 'alpha',
+    backup: true,
   },
   {
     name: 'Komga',
@@ -119,6 +133,7 @@ const charts = [
     color: 'bg-lime-100 text-lime-700',
     letter: 'Kg',
     maturity: 'beta',
+    backup: true,
   },
   {
     name: 'Guacamole',
@@ -127,6 +142,7 @@ const charts = [
     color: 'bg-yellow-100 text-yellow-700',
     letter: 'Gc',
     maturity: 'beta',
+    backup: true,
   },
   {
     name: 'Cloudflared',
@@ -135,6 +151,7 @@ const charts = [
     color: 'bg-orange-100 text-orange-700',
     letter: 'Cf',
     maturity: 'beta',
+    backup: false,
   },
   {
     name: 'DDNS Updater',
@@ -143,6 +160,7 @@ const charts = [
     color: 'bg-purple-100 text-purple-700',
     letter: 'Dd',
     maturity: 'beta',
+    backup: false,
   },
   {
     name: 'Uptime Kuma',
@@ -151,6 +169,7 @@ const charts = [
     color: 'bg-emerald-100 text-emerald-700',
     letter: 'Uk',
     maturity: 'alpha',
+    backup: true,
   },
   {
     name: 'Authelia',
@@ -159,6 +178,7 @@ const charts = [
     color: 'bg-blue-100 text-blue-600',
     letter: 'Au',
     maturity: 'beta',
+    backup: true,
   },
   {
     name: 'AdGuard Home',
@@ -167,6 +187,7 @@ const charts = [
     color: 'bg-green-100 text-green-600',
     letter: 'Ag',
     maturity: 'beta',
+    backup: true,
   },
   {
     name: 'Velero',
@@ -175,6 +196,7 @@ const charts = [
     color: 'bg-cyan-100 text-cyan-700',
     letter: 'Ve',
     maturity: 'alpha',
+    backup: true,
   },
   {
     name: 'Kafka',
@@ -183,6 +205,16 @@ const charts = [
     color: 'bg-orange-100 text-orange-700',
     letter: 'Ka',
     maturity: 'alpha',
+    backup: false,
+  },
+  {
+    name: 'Dolibarr',
+    slug: 'dolibarr',
+    description: 'Dolibarr ERP/CRM with MySQL subchart, auto-installation, and persistent documents.',
+    color: 'bg-fuchsia-100 text-fuchsia-700',
+    letter: 'Dl',
+    maturity: 'alpha',
+    backup: false,
   },
 ];
 
@@ -200,7 +232,7 @@ const maturityStyles = {
         Available Charts
       </h2>
       <p class="mt-4 text-lg text-muted leading-relaxed">
-        Twenty-three production-ready charts covering databases, messaging, identity, CMS, headless CMS, Q&amp;A, automation, media, remote access, tunnels, dynamic DNS, monitoring, game servers, Kubernetes backup, streaming, and general workloads.
+        Twenty-four production-ready charts covering databases, messaging, identity, ERP, CMS, headless CMS, Q&amp;A, automation, media, remote access, tunnels, dynamic DNS, monitoring, game servers, Kubernetes backup, streaming, and general workloads.
       </p>
     </div>
 
@@ -211,8 +243,18 @@ const maturityStyles = {
           class="group block p-5 rounded-xl bg-white border border-slate-200 hover:border-primary/30 hover:shadow-lg hover:shadow-primary/5 transition-all duration-300"
         >
           <div class="flex items-center justify-between mb-3">
-            <div class={`w-10 h-10 rounded-lg flex items-center justify-center text-sm font-bold ${chart.color}`}>
-              {chart.letter}
+            <div class="flex items-center gap-2">
+              <div class={`w-10 h-10 rounded-lg flex items-center justify-center text-sm font-bold ${chart.color}`}>
+                {chart.letter}
+              </div>
+              {chart.backup && (
+                <span class="inline-flex items-center gap-1 text-[10px] font-semibold uppercase tracking-wider px-1.5 py-0.5 rounded-full border bg-primary/10 text-primary border-primary/20" title="S3 backup included">
+                  <svg class="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M7 16a4 4 0 01-.88-7.903A5 5 0 1115.9 6L16 6a5 5 0 011 9.9M9 19l3 3m0 0l3-3m-3 3V10" />
+                  </svg>
+                  S3
+                </span>
+              )}
             </div>
             <span class={`text-[10px] font-semibold uppercase tracking-wider px-2 py-0.5 rounded-full border ${maturityStyles[chart.maturity]}`}>
               {chart.maturity}

--- a/src/components/Hero.astro
+++ b/src/components/Hero.astro
@@ -21,7 +21,7 @@
       </h1>
 
       <p class="mt-6 text-lg sm:text-xl text-slate-400 leading-relaxed max-w-2xl mx-auto">
-        Open-source charts built with security, observability, and operational excellence in mind. Install in seconds.
+        Open-source charts with built-in S3 backup, security hardening, and production defaults. Install in seconds.
       </p>
 
       <!-- CTAs -->

--- a/src/layouts/DocsLayout.astro
+++ b/src/layouts/DocsLayout.astro
@@ -41,6 +41,7 @@ const chartNav = [
   { label: 'AdGuard Home', href: '/docs/charts/adguard-home' },
   { label: 'Velero', href: '/docs/charts/velero' },
   { label: 'Kafka', href: '/docs/charts/kafka' },
+  { label: 'Dolibarr', href: '/docs/charts/dolibarr' },
 ];
 
 const allPages = [

--- a/src/layouts/DocsLayout.astro
+++ b/src/layouts/DocsLayout.astro
@@ -15,6 +15,7 @@ const currentPath = Astro.url.pathname;
 const sidebarNav = [
   { label: 'Getting Started', href: '/docs/getting-started' },
   { label: 'Charts Overview', href: '/docs/charts' },
+  { label: 'HelmForge vs Generic Charts', href: '/docs/comparison' },
 ];
 
 const chartNav = [

--- a/src/pages/docs/charts/dolibarr.mdx
+++ b/src/pages/docs/charts/dolibarr.mdx
@@ -1,0 +1,87 @@
+---
+layout: ../../../layouts/DocsLayout.astro
+title: Dolibarr
+description: Helm chart for Dolibarr ERP/CRM on Kubernetes with MySQL support.
+---
+
+# Dolibarr
+
+Helm chart for deploying [Dolibarr ERP/CRM](https://www.dolibarr.org/) on Kubernetes using the official [`dolibarr/dolibarr`](https://hub.docker.com/r/dolibarr/dolibarr) Docker image.
+
+## Key Features
+
+- **Official Dolibarr image** based on `dolibarr/dolibarr`
+- **MySQL subchart** bundled HelmForge MySQL dependency
+- **External MySQL/MariaDB** connect to a managed database
+- **Auto installation** unattended setup via `DOLI_*` environment variables
+- **Persistent storage** separate PVCs for documents and custom modules
+- **Ingress support** configurable ingress with TLS
+- **Secret preservation** admin, runtime, and database secrets preserved across upgrades
+
+## Installation
+
+### HTTPS Repository
+
+```bash
+helm repo add helmforge https://repo.helmforge.dev
+helm repo update
+helm install dolibarr helmforge/dolibarr
+```
+
+### OCI Registry
+
+```bash
+helm install dolibarr oci://ghcr.io/helmforgedev/helm/dolibarr
+```
+
+## Basic Example
+
+```yaml
+dolibarr:
+  siteUrl: "https://erp.example.com"
+  companyName: "Example Corp"
+  companyCountryCode: "US"
+  enableModules: "societe,produit,service,propal,commande,facture"
+
+mysql:
+  enabled: true
+  auth:
+    password: "change-me"
+
+ingress:
+  enabled: true
+  ingressClassName: traefik
+  hosts:
+    - host: erp.example.com
+      paths:
+        - path: /
+          pathType: Prefix
+  tls:
+    - secretName: dolibarr-tls
+      hosts:
+        - erp.example.com
+```
+
+## Key Values
+
+| Key | Default | Description |
+|-----|---------|-------------|
+| `dolibarr.siteUrl` | `""` | Full external URL (auto-detected from ingress if empty) |
+| `dolibarr.companyName` | `Dolibarr` | Company name for unattended setup |
+| `dolibarr.companyCountryCode` | `US` | ISO country code |
+| `dolibarr.installAuto` | `true` | Enable unattended installation |
+| `dolibarr.enableModules` | `""` | Comma-separated modules to enable on first boot |
+| `admin.login` | `admin` | Admin login |
+| `admin.password` | `""` | Admin password (auto-generated if empty) |
+| `database.mode` | `auto` | Database mode: `auto`, `external`, `mysql` |
+| `mysql.enabled` | `true` | Deploy MySQL subchart |
+| `persistence.documents.enabled` | `true` | Persist `/var/www/documents` |
+| `persistence.documents.size` | `8Gi` | Documents PVC size |
+| `persistence.custom.enabled` | `true` | Persist `/var/www/html/custom` |
+| `persistence.custom.size` | `2Gi` | Custom modules PVC size |
+| `ingress.enabled` | `false` | Enable ingress |
+| `ingress.ingressClassName` | `""` | Ingress class (`traefik`, `nginx`, etc.) |
+
+## More Information
+
+- [Chart source and full values reference](https://github.com/helmforgedev/charts/tree/main/charts/dolibarr)

--- a/src/pages/docs/comparison.mdx
+++ b/src/pages/docs/comparison.mdx
@@ -1,0 +1,146 @@
+---
+layout: ../../layouts/DocsLayout.astro
+title: HelmForge vs Generic Charts
+description: How HelmForge charts compare to generic community Helm charts and what makes them different.
+---
+
+# HelmForge vs Generic Charts
+
+This page explains the design choices behind HelmForge charts and how they compare to typical community Helm charts. This is not a critique of other projects — many are excellent. The goal is to help you evaluate whether HelmForge fits your needs.
+
+## At a Glance
+
+| Aspect | Generic community charts | HelmForge |
+|--------|--------------------------|-----------|
+| **Container images** | Often custom-built or wrapped images | Official upstream images only |
+| **Backup** | Usually not included; separate tooling needed | Built-in S3-compatible backup via CronJob |
+| **License** | Varies (some restrictive or changed recently) | MIT — always |
+| **Database subcharts** | External dependencies (e.g., Bitnami) | Self-contained HelmForge subcharts |
+| **Values design** | Kubernetes-centric (`containers[].ports[]`) | Product-oriented (`database.host`, `admin.password`) |
+| **Security defaults** | Varies | Non-root, security contexts, network policies |
+| **Schema validation** | Rare | `values.schema.json` on every chart |
+| **CI validation** | Lint + template | Lint + template + unittest + kubeconform |
+
+## Official Upstream Images
+
+HelmForge charts use the official Docker image published by the application maintainer. We do not build, wrap, or patch container images.
+
+This means:
+
+- You get the same image the upstream project tests and supports
+- No supply chain dependency on a third-party image builder
+- Image updates come directly from the source, not through a middleman
+- If the upstream project publishes a CVE fix, you get it immediately
+
+## Built-in S3 Backup
+
+Most Helm charts leave backup as an exercise for the operator. HelmForge takes a different approach: **17 of 24 charts include built-in S3-compatible backup**.
+
+Each backup-capable chart creates an optional CronJob that:
+
+1. Runs the appropriate dump tool for the application (e.g., `pg_dump`, `mysqldump`, `mongodump`, `sqlite3 .backup`)
+2. Compresses the output
+3. Uploads to any S3-compatible endpoint (AWS S3, MinIO, Cloudflare R2, Backblaze B2)
+
+You configure it through values — no extra tools, operators, or scripts needed:
+
+```yaml
+backup:
+  enabled: true
+  schedule: "0 3 * * *"
+  s3:
+    endpoint: https://s3.amazonaws.com
+    bucket: my-backups
+    region: us-east-1
+    existingSecret: backup-s3-credentials
+```
+
+## Self-Contained Dependencies
+
+When a chart needs a database (MySQL, PostgreSQL, MongoDB), HelmForge bundles its own database subcharts. This avoids depending on third-party chart repositories that may change licensing, availability, or compatibility without notice.
+
+For example, installing n8n with a bundled PostgreSQL is a single command:
+
+```bash
+helm install n8n helmforge/n8n --set postgresql.enabled=true
+```
+
+You can also use an external database by disabling the subchart:
+
+```yaml
+postgresql:
+  enabled: false
+database:
+  external:
+    host: db.example.com
+    port: 5432
+```
+
+## Product-Oriented Values
+
+Generic charts often expose Kubernetes primitives directly in values. HelmForge values are designed around the application.
+
+**Generic approach:**
+
+```yaml
+env:
+  - name: DATABASE_URL
+    value: "postgres://user:pass@host:5432/db"
+  - name: ADMIN_EMAIL
+    value: "admin@example.com"
+containers:
+  - ports:
+      - containerPort: 3000
+```
+
+**HelmForge approach:**
+
+```yaml
+database:
+  external:
+    host: host
+    port: 5432
+    username: user
+    name: db
+admin:
+  email: "admin@example.com"
+service:
+  port: 3000
+```
+
+The result is values files that read like application configuration, not Kubernetes manifests.
+
+## Schema Validation
+
+Every HelmForge chart ships with a `values.schema.json` file (JSON Schema draft-07). This means:
+
+- `helm install` validates your values **before** applying anything to the cluster
+- ArtifactHub renders values with types and descriptions
+- IDE autocompletion works when editing values files
+- CI catches misconfigured values during template rendering
+
+## Consistent CI Pipeline
+
+Every chart goes through the same validation pipeline:
+
+1. **`helm lint --strict`** — catches YAML and template issues
+2. **`helm template`** — renders all templates with default and CI-specific values
+3. **`helm unittest`** — runs unit tests for template logic
+4. **`kubeconform`** — validates rendered manifests against Kubernetes OpenAPI schemas
+
+Charts are also validated on a local k3d cluster before release.
+
+## Licensing
+
+HelmForge is MIT licensed. Every chart, every tool, every piece of documentation. This will not change.
+
+We made this choice because operators should not have to worry about license audits when choosing infrastructure tooling. MIT is simple: use it, modify it, redistribute it, commercially or otherwise.
+
+## When HelmForge May Not Be the Right Fit
+
+Be honest about tradeoffs:
+
+- **Enterprise support** — HelmForge is community-maintained. If you need SLA-backed support, a commercial chart vendor may be more appropriate.
+- **Niche applications** — We cover 24 applications today. If your stack includes something we do not chart, you will need to combine HelmForge with other sources.
+- **Custom images** — If your workflow requires patched or customized container images, HelmForge's upstream-only approach may feel limiting. You can still override `image.repository` and `image.tag` in values.
+- **Air-gapped environments** — Charts pull images from public registries by default. You can configure private registries via `imagePullSecrets`, but there is no built-in image mirroring.


### PR DESCRIPTION
## Summary

- Hero subheading updated to mention built-in S3 backup as a key differentiator
- Chart grid cards now display an S3 badge (cloud+arrow icon) for the 17 charts with backup support
- Added Dolibarr ERP/CRM: chart documentation page, sidebar entry, and landing page card
- Updated chart count from 23 to 24

## Test plan

- [ ] Verify build passes in CI
- [ ] Check landing page hero text includes "built-in S3 backup"
- [ ] Check chart grid shows S3 badges on backup-capable charts (e.g., MySQL, PostgreSQL, WordPress)
- [ ] Check chart grid does NOT show S3 badge on non-backup charts (e.g., Generic, Redis, Kafka)
- [ ] Verify Dolibarr page renders at /docs/charts/dolibarr
- [ ] Verify Dolibarr appears in sidebar navigation