### PR TITLE
fix(site): remove hardcoded chart count from comparison page

### DIFF
--- a/src/pages/docs/comparison.mdx
+++ b/src/pages/docs/comparison.mdx
@@ -141,6 +141,6 @@ We made this choice because operators should not have to worry about license aud
 Be honest about tradeoffs:
 
 - **Enterprise support** — HelmForge is community-maintained. If you need SLA-backed support, a commercial chart vendor may be more appropriate.
-- **Niche applications** — We cover 24 applications today. If your stack includes something we do not chart, you will need to combine HelmForge with other sources.
+- **Niche applications** — The catalog is growing but does not cover every application. If your stack includes something we do not chart yet, you will need to combine HelmForge with other sources.
 - **Custom images** — If your workflow requires patched or customized container images, HelmForge's upstream-only approach may feel limiting. You can still override `image.repository` and `image.tag` in values.
 - **Air-gapped environments** — Charts pull images from public registries by default. You can configure private registries via `imagePullSecrets`, but there is no built-in image mirroring.


### PR DESCRIPTION
## Summary

- Removed hardcoded "24 applications" from comparison page
- Replaced with "The catalog is growing but does not cover every application"
- Avoids stale content as new charts are added

## Test plan

- [ ] Verify build passes