### PR TITLE
docs(site): add heimdall chart page and landing card

### DIFF
--- a/src/components/ChartGrid.astro
+++ b/src/components/ChartGrid.astro
@@ -225,6 +225,15 @@ const charts = [
     maturity: 'alpha',
     backup: false,
   },
+  {
+    name: 'Heimdall',
+    slug: 'heimdall',
+    description: 'Application dashboard for organizing and launching self-hosted services with S3 backup.',
+    color: 'bg-sky-100 text-sky-600',
+    letter: 'Hd',
+    maturity: 'alpha',
+    backup: true,
+  },
 ];
 
 const maturityStyles = {
@@ -241,7 +250,7 @@ const maturityStyles = {
         Available Charts
       </h2>
       <p class="mt-4 text-lg text-muted leading-relaxed">
-        Twenty-five production-ready charts covering databases, messaging, identity, ERP, CMS, headless CMS, Q&amp;A, automation, media, remote access, tunnels, dynamic DNS, monitoring, game servers, Kubernetes backup, streaming, and general workloads.
+        Twenty-six production-ready charts covering databases, messaging, identity, ERP, CMS, headless CMS, Q&amp;A, automation, media, remote access, tunnels, dynamic DNS, monitoring, game servers, Kubernetes backup, streaming, and general workloads.
       </p>
     </div>
 

--- a/src/layouts/DocsLayout.astro
+++ b/src/layouts/DocsLayout.astro
@@ -45,6 +45,7 @@ const chartNav = [
   { label: 'Kafka', href: '/docs/charts/kafka' },
   { label: 'Dolibarr', href: '/docs/charts/dolibarr' },
   { label: 'phpMyAdmin', href: '/docs/charts/phpmyadmin' },
+  { label: 'Heimdall', href: '/docs/charts/heimdall' },
 ];
 
 const allPages = [

--- a/src/pages/docs/charts/heimdall.mdx
+++ b/src/pages/docs/charts/heimdall.mdx
@@ -1,0 +1,84 @@
+---
+layout: ../../../layouts/DocsLayout.astro
+title: Heimdall
+description: Helm chart for Heimdall application dashboard on Kubernetes with S3 backup.
+---
+
+# Heimdall
+
+Helm chart for deploying [Heimdall](https://heimdall.site/) application dashboard on Kubernetes using the [`linuxserver/heimdall`](https://hub.docker.com/r/linuxserver/heimdall) Docker image.
+
+## Key Features
+
+- **LinuxServer.io image** based on `linuxserver/heimdall`
+- **Persistent storage** SQLite database and settings in `/config`
+- **S3-compatible backup** CronJob that archives `/config` and uploads to any S3 endpoint
+- **PUID/PGID** file ownership control
+- **Ingress support** configurable ingress with TLS
+
+## Installation
+
+### HTTPS Repository
+
+```bash
+helm repo add helmforge https://repo.helmforge.dev
+helm repo update
+helm install heimdall helmforge/heimdall
+```
+
+### OCI Registry
+
+```bash
+helm install heimdall oci://ghcr.io/helmforgedev/helm/heimdall
+```
+
+## Basic Example
+
+```yaml
+heimdall:
+  timezone: "America/New_York"
+
+ingress:
+  enabled: true
+  ingressClassName: traefik
+  hosts:
+    - host: dashboard.example.com
+      paths:
+        - path: /
+          pathType: Prefix
+  tls:
+    - secretName: heimdall-tls
+      hosts:
+        - dashboard.example.com
+
+backup:
+  enabled: true
+  schedule: "0 3 * * *"
+  s3:
+    endpoint: https://s3.amazonaws.com
+    bucket: my-backups
+    prefix: heimdall
+    existingSecret: heimdall-s3-credentials
+```
+
+## Key Values
+
+| Key | Default | Description |
+|-----|---------|-------------|
+| `heimdall.puid` | `1000` | User ID for file permissions |
+| `heimdall.pgid` | `1000` | Group ID for file permissions |
+| `heimdall.timezone` | `"UTC"` | Timezone |
+| `persistence.enabled` | `true` | Enable persistent storage for /config |
+| `persistence.size` | `1Gi` | Volume size |
+| `backup.enabled` | `false` | Enable S3 backup CronJob |
+| `backup.schedule` | `"0 3 * * *"` | Cron schedule |
+| `backup.s3.endpoint` | `""` | S3-compatible endpoint URL |
+| `backup.s3.bucket` | `""` | S3 bucket name |
+| `backup.s3.existingSecret` | `""` | Existing secret with S3 credentials |
+| `service.type` | `ClusterIP` | Service type |
+| `ingress.enabled` | `false` | Enable ingress |
+| `ingress.ingressClassName` | `""` | Ingress class (`traefik`, `nginx`, etc.) |
+
+## More Information
+
+- [Chart source and full values reference](https://github.com/helmforgedev/charts/tree/main/charts/heimdall)


### PR DESCRIPTION
## Summary
- Add Heimdall chart documentation page at `/docs/charts/heimdall`
- Add Heimdall card to ChartGrid with S3 backup badge (alpha maturity)
- Register Heimdall in DocsLayout sidebar navigation

## Related
- helmforgedev/charts#111 (Heimdall chart PR)