### PR TITLE
docs(site): add gitea chart page and landing card

### DIFF
--- a/src/components/ChartGrid.astro
+++ b/src/components/ChartGrid.astro
@@ -234,6 +234,15 @@ const charts = [
     maturity: 'alpha',
     backup: true,
   },
+  {
+    name: 'Gitea',
+    slug: 'gitea',
+    description: 'Self-hosted Git service with SQLite, PostgreSQL, or MySQL, SSH access, and S3 backup.',
+    color: 'bg-green-100 text-green-700',
+    letter: 'Gt',
+    maturity: 'alpha',
+    backup: true,
+  },
 ];
 
 const maturityStyles = {
@@ -250,7 +259,7 @@ const maturityStyles = {
         Available Charts
       </h2>
       <p class="mt-4 text-lg text-muted leading-relaxed">
-        Twenty-six production-ready charts covering databases, messaging, identity, ERP, CMS, headless CMS, Q&amp;A, automation, media, remote access, tunnels, dynamic DNS, monitoring, game servers, Kubernetes backup, streaming, and general workloads.
+        Production-ready charts covering databases, messaging, identity, ERP, CMS, headless CMS, Q&amp;A, automation, version control, media, remote access, tunnels, dynamic DNS, monitoring, game servers, Kubernetes backup, streaming, and general workloads.
       </p>
     </div>
 

--- a/src/layouts/DocsLayout.astro
+++ b/src/layouts/DocsLayout.astro
@@ -46,6 +46,7 @@ const chartNav = [
   { label: 'Dolibarr', href: '/docs/charts/dolibarr' },
   { label: 'phpMyAdmin', href: '/docs/charts/phpmyadmin' },
   { label: 'Heimdall', href: '/docs/charts/heimdall' },
+  { label: 'Gitea', href: '/docs/charts/gitea' },
 ];
 
 const allPages = [

--- a/src/pages/docs/charts/gitea.mdx
+++ b/src/pages/docs/charts/gitea.mdx
@@ -1,0 +1,123 @@
+---
+layout: ../../../layouts/DocsLayout.astro
+title: Gitea
+description: Helm chart for Gitea self-hosted Git service on Kubernetes with SQLite, PostgreSQL, or MySQL.
+---
+
+# Gitea
+
+Helm chart for deploying [Gitea](https://gitea.io/) self-hosted Git service on Kubernetes using the official [`gitea/gitea`](https://hub.docker.com/r/gitea/gitea) rootless Docker image.
+
+## Key Features
+
+- **Official rootless image** based on `gitea/gitea:<version>-rootless` (UID 1000)
+- **Database backends** SQLite3 (default), PostgreSQL, or MySQL with auto-detection
+- **PostgreSQL and MySQL subcharts** optional bundled database deployments
+- **HTTP + SSH services** separate services for web UI and Git SSH access
+- **Admin user creation** optional post-install Job to bootstrap an admin account
+- **S3-compatible backup** database-aware CronJob (SQLite tar, pg_dump, mysqldump)
+- **Ingress support** configurable ingress with TLS for HTTP access
+
+## Installation
+
+### HTTPS Repository
+
+```bash
+helm repo add helmforge https://repo.helmforge.dev
+helm repo update
+helm install gitea helmforge/gitea
+```
+
+### OCI Registry
+
+```bash
+helm install gitea oci://ghcr.io/helmforgedev/helm/gitea
+```
+
+## Basic Example
+
+```yaml
+gitea:
+  rootUrl: https://git.example.com/
+  sshDomain: git.example.com
+  disableRegistration: true
+
+admin:
+  username: gitea_admin
+  password: "change-me-now"
+  email: admin@example.com
+
+postgresql:
+  enabled: true
+  auth:
+    database: gitea
+    username: gitea
+    password: "db-password"
+
+ingress:
+  enabled: true
+  ingressClassName: traefik
+  hosts:
+    - host: git.example.com
+      paths:
+        - path: /
+          pathType: Prefix
+  tls:
+    - secretName: gitea-tls
+      hosts:
+        - git.example.com
+
+backup:
+  enabled: true
+  schedule: "0 3 * * *"
+  s3:
+    endpoint: https://s3.amazonaws.com
+    bucket: my-backups
+    prefix: gitea
+    existingSecret: gitea-s3-credentials
+```
+
+## Key Values
+
+| Key | Default | Description |
+|-----|---------|-------------|
+| `gitea.appName` | `"Gitea: Git with a cup of tea"` | Application display name |
+| `gitea.runMode` | `prod` | Run mode (dev, prod, test) |
+| `gitea.rootUrl` | `""` | Root URL for links and clone URLs |
+| `gitea.sshDomain` | `""` | SSH domain in clone URLs |
+| `gitea.sshPort` | `2222` | SSH listen port |
+| `gitea.lfsEnabled` | `true` | Enable Git LFS |
+| `gitea.disableRegistration` | `false` | Disable self-registration |
+| `admin.username` | `""` | Admin username (triggers admin creation Job) |
+| `admin.existingSecret` | `""` | Existing secret with admin credentials |
+| `database.mode` | `auto` | Database mode: auto, sqlite, external, postgresql, mysql |
+| `postgresql.enabled` | `false` | Deploy PostgreSQL subchart |
+| `mysql.enabled` | `false` | Deploy MySQL subchart |
+| `persistence.enabled` | `true` | Enable persistent storage for /var/lib/gitea |
+| `persistence.size` | `10Gi` | Volume size |
+| `service.http.type` | `ClusterIP` | HTTP service type |
+| `service.http.port` | `3000` | HTTP service port |
+| `service.ssh.enabled` | `true` | Enable SSH service |
+| `service.ssh.type` | `ClusterIP` | SSH service type |
+| `service.ssh.port` | `2222` | SSH service port |
+| `service.ssh.nodePort` | `""` | SSH NodePort (when type is NodePort) |
+| `ingress.enabled` | `false` | Enable ingress |
+| `ingress.ingressClassName` | `""` | Ingress class (`traefik`, `nginx`, etc.) |
+| `backup.enabled` | `false` | Enable S3 backup CronJob |
+| `backup.schedule` | `"0 3 * * *"` | Backup cron schedule |
+| `backup.s3.endpoint` | `""` | S3-compatible endpoint URL |
+| `backup.s3.bucket` | `""` | S3 bucket name |
+| `backup.s3.existingSecret` | `""` | Existing secret with S3 credentials |
+
+## Database Auto-Detection
+
+When `database.mode` is `auto` (default), the chart detects which database to use:
+
+1. If `database.external.host` is set → **external** database
+2. If `postgresql.enabled` is `true` → **PostgreSQL subchart**
+3. If `mysql.enabled` is `true` → **MySQL subchart**
+4. Otherwise → **SQLite3** (zero configuration)
+
+## More Information
+
+- [Chart source and full values reference](https://github.com/helmforgedev/charts/tree/main/charts/gitea)


### PR DESCRIPTION
## Summary
- Add Gitea chart documentation page at `/docs/charts/gitea`
- Add Gitea card to ChartGrid with S3 backup badge (alpha maturity)
- Register Gitea in DocsLayout sidebar navigation
- Remove hardcoded chart count from landing page description

## Related
- helmforgedev/charts#112 (Gitea chart PR)