### PR TITLE
docs(site): add homarr chart documentation

### DIFF
--- a/src/components/ChartGrid.astro
+++ b/src/components/ChartGrid.astro
@@ -252,6 +252,15 @@ const charts = [
     maturity: 'alpha',
     backup: true,
   },
+  {
+    name: 'Homarr',
+    slug: 'homarr',
+    description: 'Modern application dashboard with SQLite, PostgreSQL, or MySQL, Kubernetes integration, and S3 backup.',
+    color: 'bg-rose-100 text-rose-600',
+    letter: 'Hr',
+    maturity: 'alpha',
+    backup: true,
+  },
 ];
 
 const maturityStyles = {

--- a/src/layouts/DocsLayout.astro
+++ b/src/layouts/DocsLayout.astro
@@ -48,6 +48,7 @@ const chartNav = [
   { label: 'phpMyAdmin', href: '/docs/charts/phpmyadmin' },
   { label: 'Heimdall', href: '/docs/charts/heimdall' },
   { label: 'Gitea', href: '/docs/charts/gitea' },
+  { label: 'Homarr', href: '/docs/charts/homarr' },
 ];
 
 const allPages = [

--- a/src/pages/docs/charts/homarr.mdx
+++ b/src/pages/docs/charts/homarr.mdx
@@ -1,0 +1,122 @@
+---
+layout: ../../../layouts/DocsLayout.astro
+title: Homarr
+description: Helm chart for Homarr modern application dashboard on Kubernetes with SQLite, PostgreSQL, or MySQL.
+---
+
+# Homarr
+
+Helm chart for deploying [Homarr](https://homarr.dev/) modern application dashboard on Kubernetes using the official [`ghcr.io/homarr-labs/homarr`](https://github.com/homarr-labs/homarr/pkgs/container/homarr) container image.
+
+## Key Features
+
+- **Official Homarr image** from `ghcr.io/homarr-labs/homarr`
+- **Database backends** SQLite3 (default), PostgreSQL, or MySQL with auto-detection
+- **PostgreSQL and MySQL subcharts** optional bundled database deployments
+- **Encryption key management** auto-generated or existing secret for `SECRET_ENCRYPTION_KEY`
+- **Kubernetes integration** optional workload discovery via `ENABLE_KUBERNETES`
+- **External Redis** optional external Redis for multi-instance setups
+- **S3-compatible backup** database-aware CronJob (SQLite tar, pg_dump, mysqldump)
+- **Ingress support** configurable ingress with TLS
+
+## Installation
+
+### HTTPS Repository
+
+```bash
+helm repo add helmforge https://repo.helmforge.dev
+helm repo update
+helm install homarr helmforge/homarr
+```
+
+### OCI Registry
+
+```bash
+helm install homarr oci://ghcr.io/helmforgedev/helm/homarr
+```
+
+## Basic Example
+
+```yaml
+homarr:
+  enableKubernetes: true
+
+postgresql:
+  enabled: true
+  auth:
+    database: homarr
+    username: homarr
+    password: "db-password"
+
+ingress:
+  enabled: true
+  ingressClassName: traefik
+  hosts:
+    - host: dash.example.com
+      paths:
+        - path: /
+          pathType: Prefix
+  tls:
+    - secretName: homarr-tls
+      hosts:
+        - dash.example.com
+
+backup:
+  enabled: true
+  schedule: "0 3 * * *"
+  s3:
+    endpoint: https://s3.amazonaws.com
+    bucket: my-backups
+    prefix: homarr
+    existingSecret: homarr-s3-credentials
+```
+
+## Key Values
+
+| Key | Default | Description |
+|-----|---------|-------------|
+| `homarr.logLevel` | `info` | Log level |
+| `homarr.authProviders` | `credentials` | Auth providers (credentials, ldap, oidc) |
+| `homarr.enableKubernetes` | `false` | Enable K8s workload discovery |
+| `encryption.key` | `""` | 32-byte hex encryption key (auto-generated) |
+| `encryption.existingSecret` | `""` | Existing secret with encryption key |
+| `database.mode` | `auto` | Database mode: auto, sqlite, external, postgresql, mysql |
+| `database.sqlite.path` | `/appdata/db/db.sqlite` | SQLite file path |
+| `postgresql.enabled` | `false` | Deploy PostgreSQL subchart |
+| `mysql.enabled` | `false` | Deploy MySQL subchart |
+| `redis.external` | `false` | Use external Redis |
+| `redis.host` | `""` | External Redis host |
+| `persistence.enabled` | `true` | Enable persistent storage |
+| `persistence.size` | `1Gi` | Volume size |
+| `service.type` | `ClusterIP` | Service type |
+| `service.port` | `7575` | Service port |
+| `ingress.enabled` | `false` | Enable ingress |
+| `ingress.ingressClassName` | `""` | Ingress class (`traefik`, `nginx`, etc.) |
+| `backup.enabled` | `false` | Enable S3 backup CronJob |
+| `backup.schedule` | `"0 3 * * *"` | Backup cron schedule |
+| `backup.s3.endpoint` | `""` | S3-compatible endpoint URL |
+| `backup.s3.bucket` | `""` | S3 bucket name |
+| `backup.s3.existingSecret` | `""` | Existing secret with S3 credentials |
+
+## Database Auto-Detection
+
+When `database.mode` is `auto` (default), the chart detects which database to use:
+
+1. If `database.external.host` is set → **external** database
+2. If `postgresql.enabled` is `true` → **PostgreSQL subchart**
+3. If `mysql.enabled` is `true` → **MySQL subchart**
+4. Otherwise → **SQLite3** (zero configuration)
+
+## Encryption Key
+
+Homarr requires a `SECRET_ENCRYPTION_KEY` for encrypting integration secrets. The chart auto-generates a 64-character hex key on first install if not provided. To set your own:
+
+```bash
+openssl rand -hex 32
+```
+
+Then pass it via `encryption.key` or an existing secret.
+
+## More Information
+
+- [Chart source and full values reference](https://github.com/helmforgedev/charts/tree/main/charts/homarr)


### PR DESCRIPTION
## Summary
- Add Homarr documentation page with features, installation, values, and database auto-detection
- Add landing page card (rose, Hr, alpha, backup)
- Add sidebar navigation entry

Companion to helmforgedev/charts#114.

## Test plan
- [x] `npm run build` succeeds (36 pages)
- [ ] CI pipeline passes