### PR TITLE
feat(site): publish docmost chart docs

### DIFF
--- a/src/components/ChartGrid.astro
+++ b/src/components/ChartGrid.astro
@@ -226,6 +226,15 @@ const charts = [
     backup: false,
   },
   {
+    name: 'Docmost',
+    slug: 'docmost',
+    description: 'Collaborative wiki and documentation software with bundled PostgreSQL, Redis, and local or S3 storage.',
+    color: 'bg-sky-100 text-sky-700',
+    letter: 'Dm',
+    maturity: 'alpha',
+    backup: false,
+  },
+  {
     name: 'phpMyAdmin',
     slug: 'phpmyadmin',
     description: 'Web-based MySQL/MariaDB administration with multi-server, auto-login, and custom config.',

--- a/src/layouts/DocsLayout.astro
+++ b/src/layouts/DocsLayout.astro
@@ -45,6 +45,7 @@ const chartNav = [
   { label: 'Kafka', href: '/docs/charts/kafka' },
   { label: 'Dolibarr', href: '/docs/charts/dolibarr' },
   { label: 'Mosquitto', href: '/docs/charts/mosquitto' },
+  { label: 'Docmost', href: '/docs/charts/docmost' },
   { label: 'phpMyAdmin', href: '/docs/charts/phpmyadmin' },
   { label: 'Heimdall', href: '/docs/charts/heimdall' },
   { label: 'Gitea', href: '/docs/charts/gitea' },

--- a/src/pages/docs/charts/docmost.mdx
+++ b/src/pages/docs/charts/docmost.mdx
@@ -1,0 +1,106 @@
+---
+layout: ../../../layouts/DocsLayout.astro
+title: Docmost
+description: Helm chart for Docmost on Kubernetes with bundled PostgreSQL, Redis, local storage, and optional S3.
+---
+
+# Docmost
+
+Helm chart for deploying [Docmost](https://docmost.com/) on Kubernetes with bundled PostgreSQL and Redis by default, persistent local storage for uploads, and optional S3-compatible object storage.
+
+## Key Features
+
+- **Official Docmost image** based on `docmost/docmost`
+- **Bundled PostgreSQL** default install includes the HelmForge PostgreSQL chart
+- **Bundled Redis** default install includes the HelmForge Redis chart
+- **External services support** managed PostgreSQL and Redis can be used instead of subcharts
+- **Local or S3 storage** choose persistent local storage or S3-compatible object storage for uploads
+- **Ingress support** configurable ingress with stable external URL handling
+- **Bootstrap-ready database** PostgreSQL init scripts grant Docmost the required extension privileges on first startup
+
+## Installation
+
+### HTTPS Repository
+
+```bash
+helm repo add helmforge https://repo.helmforge.dev
+helm repo update
+helm install docmost helmforge/docmost
+```
+
+### OCI Registry
+
+```bash
+helm install docmost oci://ghcr.io/helmforgedev/helm/docmost
+```
+
+## Basic Example
+
+```yaml
+docmost:
+  appUrl: https://docmost.example.com
+
+ingress:
+  enabled: true
+  ingressClassName: traefik
+  hosts:
+    - host: docmost.example.com
+      paths:
+        - path: /
+          pathType: Prefix
+```
+
+## External Services with S3
+
+```yaml
+database:
+  mode: external
+  external:
+    host: postgres.example.internal
+    existingSecret: docmost-db
+
+postgresql:
+  enabled: false
+
+redis:
+  enabled: false
+  external:
+    host: redis.example.internal
+    existingSecret: docmost-redis
+
+storage:
+  mode: s3
+  s3:
+    bucket: docmost
+    endpoint: https://minio.example.internal
+    existingSecret: docmost-s3
+```
+
+## Key Values
+
+| Key | Default | Description |
+|-----|---------|-------------|
+| `replicaCount` | `1` | Number of Docmost application pods |
+| `docmost.appUrl` | `""` | External URL used by Docmost |
+| `database.mode` | `auto` | Database mode: `auto`, `external`, or `postgresql` |
+| `postgresql.enabled` | `true` | Deploy bundled PostgreSQL |
+| `redis.enabled` | `true` | Deploy bundled Redis |
+| `storage.mode` | `local` | Uploads storage mode: `local` or `s3` |
+| `storage.local.size` | `10Gi` | Local uploads PVC size |
+| `storage.s3.bucket` | `""` | S3 bucket name |
+| `ingress.enabled` | `false` | Enable ingress exposure |
+
+## Version Note
+
+- Docker Hub exposed `0.71.0`, while the official GitHub releases page still showed `v0.70.3` during chart creation
+- because HelmForge validates application releases against both sources, the chart currently pins `0.70.3`
+
+## Operational Notes
+
+- this alpha chart currently supports `replicaCount=1` only
+- default installs use bundled PostgreSQL and Redis
+- the PostgreSQL bootstrap enables `unaccent` and `pg_trgm`, which Docmost migrations require
+
+## More Information
+
+- [Chart source and full values reference](https://github.com/helmforgedev/charts/tree/main/charts/docmost)


### PR DESCRIPTION
## Summary
- add the Docmost chart documentation page
- register Docmost in the docs sidebar
- add the Docmost card to the charts grid

## Validation
- npm run build