### PR TITLE
docs(site): add mariadb chart documentation

### DIFF
--- a/src/components/ChartGrid.astro
+++ b/src/components/ChartGrid.astro
@@ -270,6 +270,15 @@ const charts = [
     maturity: 'alpha',
     backup: true,
   },
+  {
+    name: 'MariaDB',
+    slug: 'mariadb',
+    description: 'MariaDB with standalone and GTID-based replication, TLS, metrics, presets, and S3 backup.',
+    color: 'bg-teal-100 text-teal-700',
+    letter: 'Md',
+    maturity: 'alpha',
+    backup: true,
+  },
 ];
 
 const maturityStyles = {

--- a/src/layouts/DocsLayout.astro
+++ b/src/layouts/DocsLayout.astro
@@ -50,6 +50,7 @@ const chartNav = [
   { label: 'Heimdall', href: '/docs/charts/heimdall' },
   { label: 'Gitea', href: '/docs/charts/gitea' },
   { label: 'Homarr', href: '/docs/charts/homarr' },
+  { label: 'MariaDB', href: '/docs/charts/mariadb' },
 ];
 
 const allPages = [

--- a/src/pages/docs/charts/mariadb.mdx
+++ b/src/pages/docs/charts/mariadb.mdx
@@ -1,0 +1,103 @@
+---
+layout: ../../../layouts/DocsLayout.astro
+title: MariaDB
+description: Helm chart for MariaDB on Kubernetes with standalone and GTID-based replication modes.
+---
+
+# MariaDB
+
+Helm chart for deploying [MariaDB](https://mariadb.org/) on Kubernetes using the official [`mariadb`](https://hub.docker.com/_/mariadb) Docker image. Supports standalone and GTID-based replication architectures.
+
+## Key Features
+
+- **Official MariaDB image** from Docker Hub (11.4 LTS)
+- **Standalone and replication** modes with explicit configuration
+- **GTID-based replication** using MariaDB-native `MASTER_USE_GTID=slave_pos`
+- **Configuration presets** small, medium, large, oltp, read-heavy, analytics
+- **TLS** server-side encryption with optional client enforcement
+- **Prometheus metrics** via mysqld-exporter sidecar and ServiceMonitor
+- **S3-compatible backup** CronJob with mariadb-dump
+- **NetworkPolicy and PDB** for production workloads
+
+## Installation
+
+### HTTPS Repository
+
+```bash
+helm repo add helmforge https://repo.helmforge.dev
+helm repo update
+helm install mariadb helmforge/mariadb
+```
+
+### OCI Registry
+
+```bash
+helm install mariadb oci://ghcr.io/helmforgedev/helm/mariadb
+```
+
+## Basic Example
+
+```yaml
+architecture: replication
+
+auth:
+  rootPassword: "change-me"
+  database: myapp
+  username: myapp
+  password: "change-me"
+  replicationPassword: "change-me"
+
+replication:
+  source:
+    persistence:
+      size: 50Gi
+  readReplicas:
+    replicaCount: 2
+    persistence:
+      size: 50Gi
+
+metrics:
+  enabled: true
+  serviceMonitor:
+    enabled: true
+
+backup:
+  enabled: true
+  schedule: "0 3 * * *"
+  s3:
+    endpoint: https://s3.amazonaws.com
+    bucket: my-backups
+    prefix: mariadb
+    existingSecret: mariadb-backup-creds
+```
+
+## Key Values
+
+| Key | Default | Description |
+|-----|---------|-------------|
+| `architecture` | `standalone` | Deployment mode: standalone or replication |
+| `image.tag` | `11.4` | MariaDB version (LTS) |
+| `auth.rootPassword` | `""` | Root password (auto-generated if empty) |
+| `auth.database` | `app` | Application database |
+| `auth.username` | `app` | Application user |
+| `auth.password` | `""` | Application password (auto-generated if empty) |
+| `auth.existingSecret` | `""` | Existing secret with passwords |
+| `config.preset` | `none` | Configuration preset: small, medium, large, oltp, read-heavy, analytics |
+| `standalone.persistence.size` | `8Gi` | Standalone PVC size |
+| `replication.readReplicas.replicaCount` | `2` | Number of read replicas |
+| `replication.binlog.format` | `ROW` | Binlog format |
+| `service.type` | `ClusterIP` | Service type |
+| `service.port` | `3306` | MariaDB port |
+| `metrics.enabled` | `false` | Enable mysqld-exporter |
+| `tls.enabled` | `false` | Enable server TLS |
+| `backup.enabled` | `false` | Enable S3 backup CronJob |
+| `backup.schedule` | `"0 3 * * *"` | Backup cron schedule |
+| `networkPolicy.enabled` | `false` | Enable NetworkPolicy |
+
+## Architecture Selection
+
+When `architecture` is `standalone` (default), the chart deploys a single MariaDB instance. Set `architecture: replication` for one fixed source with asynchronous GTID-based read replicas.
+
+## More Information
+
+- [Chart source and full values reference](https://github.com/helmforgedev/charts/tree/main/charts/mariadb)


### PR DESCRIPTION
## Summary
- Add MariaDB documentation page with standalone/replication modes, key values, and architecture guide
- Add landing page card (teal, Md, alpha, backup)
- Add sidebar navigation entry

Companion to helmforgedev/charts#116.

## Test plan
- [x] `npm run build` succeeds (38 pages)
- [ ] CI pipeline passes