### PR TITLE
docs(site): add appwrite chart documentation

### DIFF
--- a/src/components/ChartGrid.astro
+++ b/src/components/ChartGrid.astro
@@ -172,6 +172,15 @@ const charts = [
     backup: true,
   },
   {
+    name: 'Appwrite',
+    slug: 'appwrite',
+    description: 'Self-hosted BaaS platform with MariaDB, Redis, 20+ microservices, and path-based ingress.',
+    color: 'bg-pink-100 text-pink-700',
+    letter: 'Aw',
+    maturity: 'alpha',
+    backup: false,
+  },
+  {
     name: 'Authelia',
     slug: 'authelia',
     description: 'SSO, MFA, and OpenID Connect authentication server with forward auth for reverse proxies.',

--- a/src/layouts/DocsLayout.astro
+++ b/src/layouts/DocsLayout.astro
@@ -39,6 +39,7 @@ const chartNav = [
   { label: 'Cloudflared', href: '/docs/charts/cloudflared' },
   { label: 'DDNS Updater', href: '/docs/charts/ddns-updater' },
   { label: 'Uptime Kuma', href: '/docs/charts/uptime-kuma' },
+  { label: 'Appwrite', href: '/docs/charts/appwrite' },
   { label: 'Authelia', href: '/docs/charts/authelia' },
   { label: 'AdGuard Home', href: '/docs/charts/adguard-home' },
   { label: 'Velero', href: '/docs/charts/velero' },

--- a/src/pages/docs/charts/appwrite.mdx
+++ b/src/pages/docs/charts/appwrite.mdx
@@ -1,0 +1,108 @@
+---
+layout: ../../../layouts/DocsLayout.astro
+title: Appwrite
+description: Helm chart for Appwrite — self-hosted BaaS platform with MariaDB, Redis, and 20+ microservices.
+---
+
+# Appwrite
+
+Helm chart for deploying [Appwrite](https://appwrite.io/) on Kubernetes — a self-hosted Backend-as-a-Service (BaaS) platform providing authentication, databases, storage, functions, messaging, and a real-time API. Ships with bundled MariaDB and Redis by default.
+
+## Key Features
+
+- **Full Appwrite stack** — API, Console (v7.5.7), Realtime, 12 workers, schedulers, and maintenance
+- **Bundled MariaDB** — default install includes the HelmForge MariaDB chart
+- **Bundled Redis** — default install includes the HelmForge Redis chart
+- **External services support** — connect to managed MariaDB/MySQL and Redis instead of subcharts
+- **Path-based ingress routing** — single host with path prefixes for API (`/v1`), Console, and Realtime (`/v1/realtime`)
+- **Shared PVCs** — persistent volumes for uploads, cache, and function builds shared across components
+- **appVersion 1.8.1** — tracks the latest Appwrite open-source release
+
+## Installation
+
+### HTTPS Repository
+
+```bash
+helm repo add helmforge https://repo.helmforge.dev
+helm repo update
+helm install appwrite helmforge/appwrite
+```
+
+### OCI Registry
+
+```bash
+helm install appwrite oci://ghcr.io/helmforgedev/helm/appwrite
+```
+
+## Basic Example
+
+```yaml
+# values.yaml
+appwrite:
+  domain: appwrite.example.com
+  secretKey: "change-me-to-a-random-string"
+
+ingress:
+  enabled: true
+  ingressClassName: traefik
+  hosts:
+    - host: appwrite.example.com
+      paths:
+        - path: /
+          pathType: Prefix
+
+mariadb:
+  enabled: true
+
+redis:
+  enabled: true
+```
+
+## External Database and Cache
+
+```yaml
+mariadb:
+  enabled: false
+
+redis:
+  enabled: false
+
+database:
+  external:
+    host: mariadb.example.internal
+    port: 3306
+    name: appwrite
+    existingSecret: appwrite-db
+
+cache:
+  external:
+    host: redis.example.internal
+    port: 6379
+    existingSecret: appwrite-redis
+```
+
+## Key Values
+
+| Key | Default | Description |
+|-----|---------|-------------|
+| `appwrite.domain` | `""` | Public domain for the Appwrite instance |
+| `appwrite.secretKey` | `""` | Encryption key for Appwrite secrets |
+| `mariadb.enabled` | `true` | Deploy bundled MariaDB |
+| `redis.enabled` | `true` | Deploy bundled Redis |
+| `database.external.host` | `""` | External MariaDB/MySQL host |
+| `cache.external.host` | `""` | External Redis host |
+| `ingress.enabled` | `false` | Enable ingress exposure |
+| `persistence.uploads.size` | `10Gi` | Uploads PVC size |
+| `persistence.cache.size` | `5Gi` | Cache PVC size |
+| `workers.deletes.replicaCount` | `1` | Replicas for each worker type |
+
+## Operational Notes
+
+- this alpha chart deploys approximately 20 Kubernetes workloads — use minimal worker replicas for initial testing
+- the Console is served at the root path, the API at `/v1`, and Realtime at `/v1/realtime`
+- default installs use bundled MariaDB and Redis via HelmForge subcharts
+- all worker pods share the same Appwrite image with different entrypoint commands
+
+## More Information
+
+- [Chart source and full values reference](https://github.com/helmforgedev/charts/tree/main/charts/appwrite)


### PR DESCRIPTION
## Summary

- Add Appwrite chart documentation page with install, config examples, and key values
- Add sidebar entry (alphabetical)
- Add landing page card with alpha maturity badge

Companion to helmforgedev/charts#118

## Test plan

- [ ] Site builds successfully
- [ ] Appwrite page renders at /docs/charts/appwrite
- [ ] Sidebar shows Appwrite entry
- [ ] Landing page shows Appwrite card