### PR TITLE
refactor(site): promote all charts to stable maturity

### DIFF
--- a/src/components/ChartGrid.astro
+++ b/src/components/ChartGrid.astro
@@ -33,7 +33,7 @@ const charts = [
     description: 'Redis with standalone and Sentinel high-availability modes.',
     color: 'bg-red-100 text-red-600',
     letter: 'Rd',
-    maturity: 'beta',
+    maturity: 'stable',
     backup: false,
   },
   {
@@ -51,7 +51,7 @@ const charts = [
     description: 'RabbitMQ with management UI and clustering support.',
     color: 'bg-orange-100 text-orange-600',
     letter: 'Rb',
-    maturity: 'beta',
+    maturity: 'stable',
     backup: false,
   },
   {
@@ -78,7 +78,7 @@ const charts = [
     description: 'Minecraft Java Edition server with cross-play, modding, backup, and monitoring.',
     color: 'bg-emerald-100 text-emerald-700',
     letter: 'Mc',
-    maturity: 'beta',
+    maturity: 'stable',
     backup: true,
   },
   {
@@ -87,7 +87,7 @@ const charts = [
     description: 'Network-wide ad blocking DNS sinkhole with Unbound recursive DNS.',
     color: 'bg-rose-100 text-rose-700',
     letter: 'Ph',
-    maturity: 'alpha',
+    maturity: 'stable',
     backup: true,
   },
   {
@@ -96,7 +96,7 @@ const charts = [
     description: 'WordPress CMS with MySQL, S3 backup, and Apache metrics.',
     color: 'bg-blue-100 text-blue-700',
     letter: 'Wp',
-    maturity: 'alpha',
+    maturity: 'stable',
     backup: true,
   },
   {
@@ -105,7 +105,7 @@ const charts = [
     description: 'Headless CMS with SQLite, PostgreSQL, MySQL, uploads persistence, and S3 backup.',
     color: 'bg-indigo-100 text-indigo-700',
     letter: 'St',
-    maturity: 'beta',
+    maturity: 'stable',
     backup: true,
   },
   {
@@ -114,7 +114,7 @@ const charts = [
     description: 'Apache Answer Q&A platform with SQLite, PostgreSQL, MySQL, and S3 backup.',
     color: 'bg-cyan-100 text-cyan-700',
     letter: 'An',
-    maturity: 'beta',
+    maturity: 'stable',
     backup: true,
   },
   {
@@ -123,7 +123,7 @@ const charts = [
     description: 'Workflow automation with SQLite, PostgreSQL, MySQL, Redis queue mode, and S3 backup.',
     color: 'bg-amber-100 text-amber-700',
     letter: 'N8',
-    maturity: 'alpha',
+    maturity: 'stable',
     backup: true,
   },
   {
@@ -132,7 +132,7 @@ const charts = [
     description: 'Media server for comics and manga with OPDS, web reader, and S3 backup.',
     color: 'bg-lime-100 text-lime-700',
     letter: 'Kg',
-    maturity: 'beta',
+    maturity: 'stable',
     backup: true,
   },
   {
@@ -141,7 +141,7 @@ const charts = [
     description: 'Remote desktop gateway with RDP, VNC, SSH, OIDC/SAML SSO, and S3 backup.',
     color: 'bg-yellow-100 text-yellow-700',
     letter: 'Gc',
-    maturity: 'beta',
+    maturity: 'stable',
     backup: true,
   },
   {
@@ -150,7 +150,7 @@ const charts = [
     description: 'Cloudflare Tunnel for secure, outbound-only connections with HA and Prometheus metrics.',
     color: 'bg-orange-100 text-orange-700',
     letter: 'Cf',
-    maturity: 'beta',
+    maturity: 'stable',
     backup: false,
   },
   {
@@ -159,7 +159,7 @@ const charts = [
     description: 'Dynamic DNS updater supporting 50+ providers with web UI and persistent history.',
     color: 'bg-purple-100 text-purple-700',
     letter: 'Dd',
-    maturity: 'beta',
+    maturity: 'stable',
     backup: false,
   },
   {
@@ -168,7 +168,7 @@ const charts = [
     description: 'Self-hosted monitoring with HTTP/TCP/DNS checks, status pages, and 90+ notifications.',
     color: 'bg-emerald-100 text-emerald-700',
     letter: 'Uk',
-    maturity: 'alpha',
+    maturity: 'stable',
     backup: true,
   },
   {
@@ -177,7 +177,7 @@ const charts = [
     description: 'Self-hosted BaaS platform with MariaDB, Redis, 20+ microservices, and path-based ingress.',
     color: 'bg-pink-100 text-pink-700',
     letter: 'Aw',
-    maturity: 'alpha',
+    maturity: 'stable',
     backup: false,
   },
   {
@@ -186,7 +186,7 @@ const charts = [
     description: 'SSO, MFA, and OpenID Connect authentication server with forward auth for reverse proxies.',
     color: 'bg-blue-100 text-blue-600',
     letter: 'Au',
-    maturity: 'beta',
+    maturity: 'stable',
     backup: true,
   },
   {
@@ -195,7 +195,7 @@ const charts = [
     description: 'Network-wide DNS ad/tracker blocker with multi-instance sync and S3 backup.',
     color: 'bg-green-100 text-green-600',
     letter: 'Ag',
-    maturity: 'beta',
+    maturity: 'stable',
     backup: true,
   },
   {
@@ -204,7 +204,7 @@ const charts = [
     description: 'Kubernetes backup, restore, migration, schedules, and S3-compatible object storage.',
     color: 'bg-cyan-100 text-cyan-700',
     letter: 'Ve',
-    maturity: 'alpha',
+    maturity: 'stable',
     backup: true,
   },
   {
@@ -213,7 +213,7 @@ const charts = [
     description: 'KRaft single-broker and production-oriented cluster modes with persistent storage and optional metrics.',
     color: 'bg-orange-100 text-orange-700',
     letter: 'Ka',
-    maturity: 'alpha',
+    maturity: 'stable',
     backup: false,
   },
   {
@@ -222,7 +222,7 @@ const charts = [
     description: 'Dolibarr ERP/CRM with MySQL subchart, auto-installation, and persistent documents.',
     color: 'bg-fuchsia-100 text-fuchsia-700',
     letter: 'Dl',
-    maturity: 'alpha',
+    maturity: 'stable',
     backup: false,
   },
   {
@@ -231,7 +231,7 @@ const charts = [
     description: 'MQTT broker with standalone or federated topology, WebSocket support, and optional MQTTX Web.',
     color: 'bg-cyan-100 text-cyan-700',
     letter: 'Mq',
-    maturity: 'alpha',
+    maturity: 'stable',
     backup: false,
   },
   {
@@ -240,7 +240,7 @@ const charts = [
     description: 'Collaborative wiki and documentation software with bundled PostgreSQL, Redis, and local or S3 storage.',
     color: 'bg-sky-100 text-sky-700',
     letter: 'Dm',
-    maturity: 'alpha',
+    maturity: 'stable',
     backup: false,
   },
   {
@@ -249,7 +249,7 @@ const charts = [
     description: 'Visual AI orchestration with standalone SQLite mode or scalable queue mode backed by Redis and PostgreSQL.',
     color: 'bg-emerald-100 text-emerald-700',
     letter: 'Fl',
-    maturity: 'alpha',
+    maturity: 'stable',
     backup: false,
   },
   {
@@ -258,7 +258,7 @@ const charts = [
     description: 'Web-based MySQL/MariaDB administration with multi-server, auto-login, and custom config.',
     color: 'bg-orange-100 text-orange-600',
     letter: 'Pa',
-    maturity: 'alpha',
+    maturity: 'stable',
     backup: false,
   },
   {
@@ -267,7 +267,7 @@ const charts = [
     description: 'Application dashboard for organizing and launching self-hosted services with S3 backup.',
     color: 'bg-sky-100 text-sky-600',
     letter: 'Hd',
-    maturity: 'alpha',
+    maturity: 'stable',
     backup: true,
   },
   {
@@ -276,7 +276,7 @@ const charts = [
     description: 'Self-hosted Git service with SQLite, PostgreSQL, or MySQL, SSH access, and S3 backup.',
     color: 'bg-green-100 text-green-700',
     letter: 'Gt',
-    maturity: 'alpha',
+    maturity: 'stable',
     backup: true,
   },
   {
@@ -285,7 +285,7 @@ const charts = [
     description: 'Modern application dashboard with SQLite, PostgreSQL, or MySQL, Kubernetes integration, and S3 backup.',
     color: 'bg-rose-100 text-rose-600',
     letter: 'Hr',
-    maturity: 'alpha',
+    maturity: 'stable',
     backup: true,
   },
   {
@@ -294,7 +294,7 @@ const charts = [
     description: 'MariaDB with standalone and GTID-based replication, TLS, metrics, presets, and S3 backup.',
     color: 'bg-teal-100 text-teal-700',
     letter: 'Md',
-    maturity: 'alpha',
+    maturity: 'stable',
     backup: true,
   },
 ];


### PR DESCRIPTION
## Summary
- Update all 27 chart maturity badges from alpha/beta to stable in ChartGrid.astro
- Aligns with helmforgedev/charts#121 (beta→stable) and helmforgedev/charts#122 (alpha→stable)

## Test plan
- [x] Build passes (`npm run build`)
- [ ] Verify all chart cards show "stable" badge on landing page