### PR TITLE
fix(site): improve logo and favicon legibility

### DIFF
--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -7,8 +7,11 @@ const year = new Date().getFullYear();
     <div class="grid grid-cols-1 gap-8 md:grid-cols-[minmax(0,1.25fr)_1fr_1fr]">
       <!-- Brand -->
       <div>
-        <a href="/" class="mb-3 flex items-center">
-          <img src="/helmforge-logo-horizontal.png" alt="HelmForge" class="h-9 w-auto" />
+        <a href="/" class="mb-3 flex items-center gap-3">
+          <img src="/favicon.svg" alt="" class="h-10 w-10 rounded-xl shadow-sm" />
+          <span class="text-xl font-semibold tracking-tight text-dark">
+            Helm<span class="text-primary">Forge</span>
+          </span>
         </a>
         <p class="max-w-sm text-sm leading-relaxed text-slate-500">
           Open-source Helm charts with practical defaults for real Kubernetes operations.

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -16,8 +16,11 @@ function isActive(href: string): boolean {
   <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
     <div class="flex h-16 items-center justify-between">
       <!-- Logo -->
-      <a href="/" class="flex items-center group">
-        <img src="/helmforge-logo-horizontal.png" alt="HelmForge" class="h-8 w-auto sm:h-9" />
+      <a href="/" class="flex items-center gap-3 group">
+        <img src="/favicon.svg" alt="" class="h-9 w-9 rounded-xl shadow-sm sm:h-10 sm:w-10" />
+        <span class="text-lg font-semibold tracking-tight text-dark sm:text-xl">
+          Helm<span class="text-primary">Forge</span>
+        </span>
       </a>
 
       <!-- Desktop nav -->

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -27,11 +27,11 @@ const fullTitle = title === siteName ? title : `${title} | ${siteName}`;
     <!-- Primary Meta -->
     <title>{fullTitle}</title>
     <meta name="description" content={description} />
-    <link rel="icon" type="image/svg+xml" href="/favicon.svg?v=2" />
-    <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32.png?v=2" />
-    <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16.png?v=2" />
-    <link rel="shortcut icon" href="/favicon.svg?v=2" />
-    <link rel="apple-touch-icon" sizes="180x180" href="/favicon-256.png?v=2" />
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+    <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32.png" />
+    <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16.png" />
+    <link rel="shortcut icon" href="/favicon.svg" />
+    <link rel="apple-touch-icon" sizes="180x180" href="/favicon-256.png" />
     <link rel="canonical" href={url} />
 
     <!-- Open Graph -->

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -27,9 +27,11 @@ const fullTitle = title === siteName ? title : `${title} | ${siteName}`;
     <!-- Primary Meta -->
     <title>{fullTitle}</title>
     <meta name="description" content={description} />
-    <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32.png" />
-    <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16.png" />
-    <link rel="apple-touch-icon" sizes="180x180" href="/favicon-256.png" />
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg?v=2" />
+    <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32.png?v=2" />
+    <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16.png?v=2" />
+    <link rel="shortcut icon" href="/favicon.svg?v=2" />
+    <link rel="apple-touch-icon" sizes="180x180" href="/favicon-256.png?v=2" />
     <link rel="canonical" href={url} />
 
     <!-- Open Graph -->


### PR DESCRIPTION
## Summary
- replace the tiny horizontal logo in header and footer with a readable icon + wordmark lockup
- make favicon.svg the primary browser icon with PNG fallbacks and cache-busting

## Validation
- npm run build