### PR TITLE
fix(site): refine branding and simplify home install copy

### DIFF
--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -7,11 +7,12 @@ const year = new Date().getFullYear();
     <div class="grid grid-cols-1 gap-8 md:grid-cols-[minmax(0,1.25fr)_1fr_1fr]">
       <!-- Brand -->
       <div>
-        <a href="/" class="mb-3 flex items-center gap-3">
-          <img src="/favicon.svg" alt="" class="h-10 w-10 rounded-xl shadow-sm" />
-          <span class="text-xl font-semibold tracking-tight text-dark">
-            Helm<span class="text-primary">Forge</span>
-          </span>
+        <a href="/" class="mb-4 inline-flex items-center" aria-label="HelmForge home">
+          <img
+            src="/helmforge-logo-horizontal.png"
+            alt="HelmForge"
+            class="h-14 w-auto object-contain"
+          />
         </a>
         <p class="max-w-sm text-sm leading-relaxed text-slate-500">
           Open-source Helm charts with practical defaults for real Kubernetes operations.

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -16,11 +16,12 @@ function isActive(href: string): boolean {
   <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
     <div class="flex h-16 items-center justify-between">
       <!-- Logo -->
-      <a href="/" class="flex items-center gap-3 group">
-        <img src="/favicon.svg" alt="" class="h-9 w-9 rounded-xl shadow-sm sm:h-10 sm:w-10" />
-        <span class="text-lg font-semibold tracking-tight text-dark sm:text-xl">
-          Helm<span class="text-primary">Forge</span>
-        </span>
+      <a href="/" class="flex items-center group" aria-label="HelmForge home">
+        <img
+          src="/helmforge-logo-horizontal.png"
+          alt="HelmForge"
+          class="h-12 w-auto object-contain sm:h-14"
+        />
       </a>
 
       <!-- Desktop nav -->

--- a/src/components/Hero.astro
+++ b/src/components/Hero.astro
@@ -30,21 +30,6 @@
           Browse Charts
         </a>
       </div>
-
-      <div class="mt-12 grid gap-4 sm:grid-cols-[minmax(0,1.5fr)_minmax(0,1fr)]">
-        <div class="rounded-2xl border border-white/10 bg-white/5 p-5 backdrop-blur-sm">
-          <p class="text-xs font-semibold uppercase tracking-[0.18em] text-slate-400">Quick install</p>
-          <code class="mt-3 block overflow-x-auto break-all font-mono text-sm text-slate-200 sm:whitespace-nowrap">
-            helm repo add helmforge https://repo.helmforge.dev
-          </code>
-        </div>
-        <div class="rounded-2xl border border-white/10 bg-white/5 p-5 backdrop-blur-sm">
-          <p class="text-xs font-semibold uppercase tracking-[0.18em] text-slate-400">What you get</p>
-          <p class="mt-3 text-sm leading-6 text-slate-300">
-            Consistent charts, documented values, OCI publishing, and validation on real clusters.
-          </p>
-        </div>
-      </div>
     </div>
   </div>
 </section>

--- a/src/components/InstallSection.astro
+++ b/src/components/InstallSection.astro
@@ -1,9 +1,9 @@
 ---
 const httpsCode = `helm repo add helmforge https://repo.helmforge.dev
 helm repo update
-helm install my-release helmforge/<chart-name>`;
+helm install my-release helmforge/redis`;
 
-const ociCode = `helm install my-release oci://ghcr.io/helmforgedev/helm/<chart-name>`;
+const ociCode = `helm install my-release oci://ghcr.io/helmforgedev/helm/redis`;
 ---
 
 <section class="bg-slate-50 py-16 sm:py-20">
@@ -70,7 +70,7 @@ const ociCode = `helm install my-release oci://ghcr.io/helmforgedev/helm/<chart-
             </div>
             <div class="pt-2">
               <span class="text-accent select-none">$</span>
-              <span class="ml-2">helm install my-release helmforge/&lt;chart-name&gt;</span>
+              <span class="ml-2">helm install my-release helmforge/redis</span>
             </div>
           </div>
         </div>
@@ -95,22 +95,16 @@ const ociCode = `helm install my-release oci://ghcr.io/helmforgedev/helm/<chart-
           <div class="px-5 py-5 font-mono text-sm text-slate-300 leading-relaxed overflow-x-auto">
             <div>
               <span class="text-accent select-none">$</span>
-              <span class="ml-2">helm install my-release oci://ghcr.io/helmforgedev/helm/&lt;chart-name&gt;</span>
+              <span class="ml-2">helm install my-release oci://ghcr.io/helmforgedev/helm/redis</span>
             </div>
           </div>
         </div>
       </div>
 
       <p class="mt-6 text-sm text-muted">
-        Replace <code class="bg-slate-100 px-1.5 py-0.5 rounded text-xs font-mono text-primary">&lt;chart-name&gt;</code> with one of:
-        <span class="font-medium text-dark">generic</span>,
-        <span class="font-medium text-dark">mysql</span>,
-        <span class="font-medium text-dark">postgresql</span>,
-        <span class="font-medium text-dark">redis</span>,
-        <span class="font-medium text-dark">mongodb</span>,
-        <span class="font-medium text-dark">rabbitmq</span>,
-        <span class="font-medium text-dark">keycloak</span>, or
-        <span class="font-medium text-dark">vaultwarden</span>.
+        Using <code class="bg-slate-100 px-1.5 py-0.5 rounded text-xs font-mono text-primary">redis</code> here as an example.
+        You can install <span class="font-medium text-dark">komga</span>, <span class="font-medium text-dark">mosquitto</span>,
+        <span class="font-medium text-dark">vaultwarden</span>, or any other chart available in the repository.
       </p>
     </div>
   </div>

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -27,10 +27,10 @@ const fullTitle = title === siteName ? title : `${title} | ${siteName}`;
     <!-- Primary Meta -->
     <title>{fullTitle}</title>
     <meta name="description" content={description} />
-    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32.png" />
     <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16.png" />
-    <link rel="shortcut icon" href="/favicon.svg" />
+    <link rel="icon" type="image/png" sizes="48x48" href="/favicon-48.png" />
+    <link rel="shortcut icon" href="/favicon-32.png" />
     <link rel="apple-touch-icon" sizes="180x180" href="/favicon-256.png" />
     <link rel="canonical" href={url} />
 

--- a/src/pages/docs/getting-started.mdx
+++ b/src/pages/docs/getting-started.mdx
@@ -36,8 +36,10 @@ helm search repo helmforge
 No repository setup is needed for OCI. You can install charts directly:
 
 ```bash
-helm install my-release oci://ghcr.io/helmforgedev/helm/<chart-name>
+helm install my-release oci://ghcr.io/helmforgedev/helm/redis
 ```
+
+You can swap `redis` for `komga`, `mosquitto`, `vaultwarden`, or any other chart published in the repository.
 
 ## Install Your First Chart
 


### PR DESCRIPTION
## Summary
- switch the site back to the new horizontal HelmForge logo in header and footer
- update favicon usage to the new PNG assets
- simplify the hero and install copy, removing the extra info cards and broadening chart examples

## Validation
- npm run build