### PR TITLE
feat(site): comparison page, charts page, and homepage comparison table

### DIFF
--- a/src/components/ComparisonTable.astro
+++ b/src/components/ComparisonTable.astro
@@ -1,0 +1,124 @@
+---
+const rows = [
+  {
+    aspect: 'Container images',
+    helmforge: 'Official upstream images',
+    bitnami: 'Custom Bitnami-built images',
+    community: 'Varies',
+    highlight: true,
+  },
+  {
+    aspect: 'Image tags',
+    helmforge: 'Pinned, immutable versions',
+    bitnami: 'Bitnami-specific rolling tags',
+    community: 'Often :latest or unpinned',
+    highlight: true,
+  },
+  {
+    aspect: 'License',
+    helmforge: 'MIT — always',
+    bitnami: 'Apache 2.0 charts; images under EULA',
+    community: 'Varies',
+    highlight: true,
+  },
+  {
+    aspect: 'Vendor lock-in',
+    helmforge: 'None',
+    bitnami: 'Tied to Bitnami images',
+    community: 'Low',
+    highlight: true,
+  },
+  {
+    aspect: 'Built-in backup',
+    helmforge: 'S3-compatible on 17+ charts',
+    bitnami: 'Not included',
+    community: 'Rarely included',
+    highlight: false,
+  },
+  {
+    aspect: 'Values design',
+    helmforge: 'Product-oriented',
+    bitnami: 'Kubernetes-centric abstractions',
+    community: 'Varies',
+    highlight: false,
+  },
+  {
+    aspect: 'Schema validation',
+    helmforge: 'Every chart',
+    bitnami: 'Some charts',
+    community: 'Rare',
+    highlight: false,
+  },
+  {
+    aspect: 'Supply chain signing',
+    helmforge: 'Sigstore Cosign on every artifact',
+    bitnami: 'Image signatures',
+    community: 'Rare',
+    highlight: false,
+  },
+  {
+    aspect: 'CI pipeline',
+    helmforge: 'Lint + template + unittest + kubeconform',
+    bitnami: 'Internal CI',
+    community: 'Minimal or none',
+    highlight: false,
+  },
+];
+---
+
+<section class="bg-white py-16 sm:py-20">
+  <div class="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8">
+    <div class="max-w-2xl mb-10">
+      <p class="text-sm font-medium uppercase tracking-[0.18em] text-primary">Comparison</p>
+      <h2 class="mt-3 text-3xl sm:text-4xl font-bold tracking-tight text-dark">
+        How HelmForge compares
+      </h2>
+      <p class="mt-4 text-base sm:text-lg text-muted leading-relaxed">
+        Official images, no vendor lock-in, MIT licensed. See the <a href="/docs/comparison" class="text-primary hover:text-primary-dark underline underline-offset-2">full comparison</a> for details.
+      </p>
+    </div>
+
+    <div class="overflow-x-auto rounded-2xl border border-slate-200">
+      <table class="w-full text-sm">
+        <thead>
+          <tr class="bg-slate-50">
+            <th class="px-4 py-3 text-left font-semibold text-muted w-[20%]"></th>
+            <th class="px-4 py-3 text-left font-bold text-primary w-[30%]">
+              <span class="flex items-center gap-2">
+                <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z" /></svg>
+                HelmForge
+              </span>
+            </th>
+            <th class="px-4 py-3 text-left font-semibold text-slate-500 w-[25%]">Bitnami</th>
+            <th class="px-4 py-3 text-left font-semibold text-slate-500 w-[25%]">Generic Community</th>
+          </tr>
+        </thead>
+        <tbody>
+          {rows.map((row, i) => (
+            <tr class={`border-t border-slate-100 ${i % 2 === 0 ? 'bg-white' : 'bg-slate-50/50'}`}>
+              <td class="px-4 py-3 font-medium text-dark">{row.aspect}</td>
+              <td class="px-4 py-3 text-dark font-medium">
+                <span class="flex items-start gap-1.5">
+                  <svg class="w-4 h-4 text-emerald-500 mt-0.5 shrink-0" fill="currentColor" viewBox="0 0 20 20"><path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z" clip-rule="evenodd" /></svg>
+                  {row.helmforge}
+                </span>
+              </td>
+              <td class="px-4 py-3 text-muted">{row.bitnami}</td>
+              <td class="px-4 py-3 text-muted">{row.community}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+
+    <div class="mt-6 text-center">
+      <a
+        href="/docs/comparison"
+        class="inline-flex items-center gap-2 text-sm font-medium text-primary hover:text-primary-dark transition-colors"
+      >
+        Read the full comparison
+        <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 7l5 5m0 0l-5 5m5-5H6" /></svg>
+      </a>
+    </div>
+  </div>
+</section>

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -3,6 +3,7 @@ const currentPath = Astro.url.pathname;
 
 const navItems = [
   { label: 'Home', href: '/' },
+  { label: 'Charts', href: '/charts' },
   { label: 'Docs', href: '/docs' },
 ];
 

--- a/src/layouts/DocsLayout.astro
+++ b/src/layouts/DocsLayout.astro
@@ -16,7 +16,7 @@ const sidebarNav = [
   { label: 'Getting Started', href: '/docs/getting-started' },
   { label: 'Charts Overview', href: '/docs/charts' },
   { label: 'Stack Examples', href: '/docs/stack-examples' },
-  { label: 'HelmForge vs Generic Charts', href: '/docs/comparison' },
+  { label: 'HelmForge vs Other Charts', href: '/docs/comparison' },
 ];
 
 const chartNav = [

--- a/src/pages/charts.astro
+++ b/src/pages/charts.astro
@@ -1,0 +1,17 @@
+---
+import BaseLayout from '../layouts/BaseLayout.astro';
+import Header from '../components/Header.astro';
+import ChartGrid from '../components/ChartGrid.astro';
+import Footer from '../components/Footer.astro';
+---
+
+<BaseLayout
+  title="Charts"
+  description="Browse all HelmForge Helm charts — production-ready, MIT licensed, built on official upstream images."
+>
+  <Header />
+  <main>
+    <ChartGrid />
+  </main>
+  <Footer />
+</BaseLayout>

--- a/src/pages/docs/comparison.mdx
+++ b/src/pages/docs/comparison.mdx
@@ -1,48 +1,71 @@
 ---
 layout: ../../layouts/DocsLayout.astro
-title: HelmForge vs Generic Charts
-description: How HelmForge charts compare to generic community Helm charts and what makes them different.
+title: HelmForge vs Other Charts
+description: How HelmForge compares to Bitnami and generic community Helm charts — images, licensing, backup, and more.
 ---
 
-# HelmForge vs Generic Charts
+# HelmForge vs Other Charts
 
-This page explains the design choices behind HelmForge charts and how they compare to typical community Helm charts. This is not a critique of other projects — many are excellent. The goal is to help you evaluate whether HelmForge fits your needs.
+This page compares HelmForge against two common alternatives: **Bitnami** (the largest commercial chart ecosystem) and **generic community charts** (individual maintainers or small projects). This is not a critique — each approach has its place. The goal is to help you choose the right fit.
 
-## At a Glance
+## Comparison Table
 
-| Aspect | Generic community charts | HelmForge |
-|--------|--------------------------|-----------|
-| **Container images** | Often custom-built or wrapped images | Official upstream images only |
-| **Backup** | Usually not included; separate tooling needed | Built-in S3-compatible backup via CronJob |
-| **License** | Varies (some restrictive or changed recently) | MIT — always |
-| **Database subcharts** | External dependencies (e.g., Bitnami) | Self-contained HelmForge subcharts |
-| **Values design** | Kubernetes-centric (`containers[].ports[]`) | Product-oriented (`database.host`, `admin.password`) |
-| **Security defaults** | Varies | Non-root, security contexts, network policies |
-| **Schema validation** | Rare | `values.schema.json` on every chart |
-| **CI validation** | Lint + template | Lint + template + unittest + kubeconform |
+| Aspect | **HelmForge** | Bitnami | Generic Community |
+|--------|---------------|---------|-------------------|
+| **Container images** | Official upstream images from the application maintainer | Custom Bitnami-built images with proprietary layers | Varies — some use official, some use custom |
+| **Image tags** | Pinned, immutable version tags | Bitnami-specific tags, rolling revisions | Often `:latest` or unpinned |
+| **License** | MIT — always | Apache 2.0 for charts; images under Bitnami EULA with usage limits on free tier | Varies — MIT, Apache, unlicensed |
+| **Vendor lock-in** | None — standard images, standard Helm, standard Kubernetes APIs | Charts tightly coupled to Bitnami images; switching images requires rework | Low, but often abandoned or inconsistent |
+| **Database subcharts** | Self-contained HelmForge subcharts (MySQL, PostgreSQL, MongoDB, MariaDB, Redis) | Bitnami subcharts (locked to Bitnami ecosystem) | External dependencies or none |
+| **Backup** | Built-in S3-compatible CronJob on 17+ charts | Not included | Rarely included |
+| **Values design** | Product-oriented (`database.host`, `admin.email`) | Kubernetes-centric with Bitnami abstractions | Varies — often raw env vars |
+| **Schema validation** | `values.schema.json` on every chart (JSON Schema draft-07) | Available on some charts | Rare |
+| **CI pipeline** | Lint + template + unittest + kubeconform on every PR | Extensive internal CI | Minimal or none |
+| **Supply chain signing** | Sigstore Cosign keyless signing on every OCI artifact | Container image signatures via Cosign | Rare |
+| **Maintenance** | Active, consistent standards across all charts | Active, large team | Unpredictable — may be abandoned |
+| **Chart count** | 33 charts (growing) | 100+ charts | One chart per repo typically |
 
 ## Official Upstream Images
 
-HelmForge charts use the official Docker image published by the application maintainer. We do not build, wrap, or patch container images.
+This is the core difference. HelmForge uses the exact Docker image published by the application maintainer — the same image the upstream project tests, documents, and supports.
 
-This means:
+**Why it matters:**
 
-- You get the same image the upstream project tests and supports
-- No supply chain dependency on a third-party image builder
-- Image updates come directly from the source, not through a middleman
-- If the upstream project publishes a CVE fix, you get it immediately
+- **No supply chain middleman** — when the upstream project patches a CVE, you get the fix directly. No waiting for a third party to rebuild.
+- **No proprietary layers** — Bitnami images include custom scripts, init containers, and filesystem layouts that differ from upstream. If you learn how the official image works, that knowledge transfers to HelmForge.
+- **No vendor-specific tags** — Bitnami images use tags like `15.4.0-debian-12-r18` that are specific to their build pipeline. HelmForge uses the same tags you see on Docker Hub or the project's container registry.
+
+```text
+# HelmForge — official upstream image
+image:
+  repository: postgres
+  tag: "17.4"
+
+# Bitnami — proprietary rebuild
+image:
+  repository: bitnami/postgresql
+  tag: "17.4.0-debian-12-r18"
+```
+
+## Licensing and Business Model
+
+HelmForge is MIT licensed — charts, CI, documentation, everything. This will not change.
+
+Bitnami charts are Apache 2.0, but the **container images** are under a separate [Bitnami EULA](https://www.vmware.com/agreements/bitnami) that introduced usage limits. The free tier has restrictions on pulls and commercial use. Enterprise usage requires a paid subscription.
+
+Generic community charts have no consistent licensing. Some are MIT, some are unlicensed, some change terms without notice.
+
+**For operators:** MIT means no license audits, no usage tracking, no surprise terms changes. You use it, modify it, redistribute it — commercially or otherwise.
 
 ## Built-in S3 Backup
 
-Most Helm charts leave backup as an exercise for the operator. HelmForge takes a different approach: **17 of 24 charts include built-in S3-compatible backup**.
+Most Helm charts leave backup to the operator. HelmForge takes a different approach: **17+ charts include built-in S3-compatible backup**.
 
 Each backup-capable chart creates an optional CronJob that:
 
-1. Runs the appropriate dump tool for the application (e.g., `pg_dump`, `mysqldump`, `mongodump`, `sqlite3 .backup`)
+1. Runs the appropriate dump tool (`pg_dump`, `mysqldump`, `mongodump`, `sqlite3 .backup`)
 2. Compresses the output
 3. Uploads to any S3-compatible endpoint (AWS S3, MinIO, Cloudflare R2, Backblaze B2)
-
-You configure it through values — no extra tools, operators, or scripts needed:
 
 ```yaml
 backup:
@@ -55,32 +78,24 @@ backup:
     existingSecret: backup-s3-credentials
 ```
 
+Bitnami charts do not include backup. Generic community charts rarely do.
+
 ## Self-Contained Dependencies
 
-When a chart needs a database (MySQL, PostgreSQL, MongoDB), HelmForge bundles its own database subcharts. This avoids depending on third-party chart repositories that may change licensing, availability, or compatibility without notice.
-
-For example, installing n8n with a bundled PostgreSQL is a single command:
+When a chart needs a database, HelmForge bundles its own database subcharts. This avoids depending on third-party chart repositories that may change licensing, availability, or compatibility without notice.
 
 ```bash
+# n8n with bundled PostgreSQL — single command
 helm install n8n helmforge/n8n --set postgresql.enabled=true
 ```
 
-You can also use an external database by disabling the subchart:
-
-```yaml
-postgresql:
-  enabled: false
-database:
-  external:
-    host: db.example.com
-    port: 5432
-```
+Bitnami charts also bundle database subcharts, but they are locked to the Bitnami ecosystem and Bitnami images. Switching away from Bitnami requires reworking the entire dependency tree.
 
 ## Product-Oriented Values
 
-Generic charts often expose Kubernetes primitives directly in values. HelmForge values are designed around the application.
+HelmForge values are designed around the application, not Kubernetes primitives.
 
-**Generic approach:**
+**Generic / Bitnami approach:**
 
 ```yaml
 env:
@@ -88,9 +103,9 @@ env:
     value: "postgres://user:pass@host:5432/db"
   - name: ADMIN_EMAIL
     value: "admin@example.com"
-containers:
-  - ports:
-      - containerPort: 3000
+extraEnvVars:
+  - name: CUSTOM_SETTING
+    value: "true"
 ```
 
 **HelmForge approach:**
@@ -104,43 +119,39 @@ database:
     name: db
 admin:
   email: "admin@example.com"
-service:
-  port: 3000
 ```
 
 The result is values files that read like application configuration, not Kubernetes manifests.
 
-## Schema Validation
+## Supply Chain Security
 
-Every HelmForge chart ships with a `values.schema.json` file (JSON Schema draft-07). This means:
+Every HelmForge OCI artifact is signed with [Sigstore Cosign](https://www.sigstore.dev/) keyless signing via GitHub Actions OIDC. You can verify any chart before deploying:
 
-- `helm install` validates your values **before** applying anything to the cluster
-- ArtifactHub renders values with types and descriptions
-- IDE autocompletion works when editing values files
-- CI catches misconfigured values during template rendering
+```bash
+cosign verify ghcr.io/helmforgedev/helm/<chart-name>:<version> \
+  --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+  --certificate-identity-regexp https://github.com/helmforgedev/charts
+```
 
-## Consistent CI Pipeline
+[ArtifactHub](https://artifacthub.io/packages/search?repo=helmforge) shows the "Signed" badge on all HelmForge charts.
 
-Every chart goes through the same validation pipeline:
+## When to Choose Each
 
-1. **`helm lint --strict`** — catches YAML and template issues
-2. **`helm template`** — renders all templates with default and CI-specific values
-3. **`helm unittest`** — runs unit tests for template logic
-4. **`kubeconform`** — validates rendered manifests against Kubernetes OpenAPI schemas
+**Choose HelmForge when:**
 
-Charts are also validated on a local k3d cluster before release.
+- You want official upstream images without proprietary layers
+- You need built-in backup without extra tooling
+- You prefer MIT licensing with no usage restrictions
+- You value supply chain signing and schema validation
 
-## Licensing
+**Choose Bitnami when:**
 
-HelmForge is MIT licensed. Every chart, every tool, every piece of documentation. This will not change.
+- You need a chart for an application HelmForge does not cover yet
+- Your organization already standardized on Bitnami and switching cost is high
+- You need commercial support with SLA guarantees
 
-We made this choice because operators should not have to worry about license audits when choosing infrastructure tooling. MIT is simple: use it, modify it, redistribute it, commercially or otherwise.
+**Choose generic community charts when:**
 
-## When HelmForge May Not Be the Right Fit
-
-Be honest about tradeoffs:
-
-- **Enterprise support** — HelmForge is community-maintained. If you need SLA-backed support, a commercial chart vendor may be more appropriate.
-- **Niche applications** — The catalog is growing but does not cover every application. If your stack includes something we do not chart yet, you will need to combine HelmForge with other sources.
-- **Custom images** — If your workflow requires patched or customized container images, HelmForge's upstream-only approach may feel limiting. You can still override `image.repository` and `image.tag` in values.
-- **Air-gapped environments** — Charts pull images from public registries by default. You can configure private registries via `imagePullSecrets`, but there is no built-in image mirroring.
+- You need a very specific or niche application
+- You want a minimal starting point to customize heavily
+- The specific community chart is well-maintained and fits your needs

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -3,6 +3,7 @@ import BaseLayout from '../layouts/BaseLayout.astro';
 import Header from '../components/Header.astro';
 import Hero from '../components/Hero.astro';
 import Features from '../components/Features.astro';
+import ComparisonTable from '../components/ComparisonTable.astro';
 import ChartGrid from '../components/ChartGrid.astro';
 import InstallSection from '../components/InstallSection.astro';
 import Footer from '../components/Footer.astro';
@@ -17,6 +18,7 @@ import Footer from '../components/Footer.astro';
     <Hero />
     <InstallSection />
     <Features />
+    <ComparisonTable />
     <ChartGrid />
   </main>
   <Footer />


### PR DESCRIPTION
## Summary

- Rewrites `/docs/comparison` as a 3-column comparison: **HelmForge** vs **Bitnami** vs **Generic Community**
- Adds a `ComparisonTable` component to the landing page (between Features and Charts sections)
- Creates a dedicated `/charts` page with the full chart catalog
- Adds **Charts** link to the header navigation: Home → Charts → Docs → GitHub
- Updates sidebar label from "HelmForge vs Generic Charts" to "HelmForge vs Other Charts"

## Test plan

- [ ] Verify `/docs/comparison` renders with 3-column table
- [ ] Verify homepage shows comparison table before chart grid
- [ ] Verify `/charts` page loads with all charts
- [ ] Verify header navigation shows Home, Charts, Docs, GitHub
- [ ] Verify mobile menu includes Charts link