### PR TITLE
refactor(site): remove chart grid from homepage

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -4,7 +4,6 @@ import Header from '../components/Header.astro';
 import Hero from '../components/Hero.astro';
 import Features from '../components/Features.astro';
 import ComparisonTable from '../components/ComparisonTable.astro';
-import ChartGrid from '../components/ChartGrid.astro';
 import InstallSection from '../components/InstallSection.astro';
 import Footer from '../components/Footer.astro';
 ---
@@ -19,7 +18,6 @@ import Footer from '../components/Footer.astro';
     <InstallSection />
     <Features />
     <ComparisonTable />
-    <ChartGrid />
   </main>
   <Footer />
 </BaseLayout>


### PR DESCRIPTION
## Summary

- Removes the full chart catalog from the homepage since charts now have a dedicated `/charts` page
- Homepage flow: Hero → Install → Features → Comparison Table

## Test plan

- [ ] Verify homepage no longer shows the chart grid
- [ ] Verify `/charts` page still shows the full catalog