### PR TITLE
docs(site): add Bitnami legacy images context to comparison

### DIFF
--- a/src/components/ComparisonTable.astro
+++ b/src/components/ComparisonTable.astro
@@ -16,8 +16,15 @@ const rows = [
   },
   {
     aspect: 'License',
-    helmforge: 'MIT — always',
+    helmforge: 'MIT — forever open source',
     bitnami: 'Apache 2.0 charts; images under EULA',
+    community: 'Varies',
+    highlight: true,
+  },
+  {
+    aspect: 'Free images',
+    helmforge: 'Official upstream, always updated',
+    bitnami: 'Moved to bitnamilegacy/* — no longer updated',
     community: 'Varies',
     highlight: true,
   },

--- a/src/pages/docs/comparison.mdx
+++ b/src/pages/docs/comparison.mdx
@@ -14,7 +14,8 @@ This page compares HelmForge against two common alternatives: **Bitnami** (the l
 |--------|---------------|---------|-------------------|
 | **Container images** | Official upstream images from the application maintainer | Custom Bitnami-built images with proprietary layers | Varies — some use official, some use custom |
 | **Image tags** | Pinned, immutable version tags | Bitnami-specific tags, rolling revisions | Often `:latest` or unpinned |
-| **License** | MIT — always | Apache 2.0 for charts; images under Bitnami EULA with usage limits on free tier | Varies — MIT, Apache, unlicensed |
+| **License** | MIT — always, forever open source | Apache 2.0 for charts; images under Bitnami EULA with usage limits | Varies — MIT, Apache, unlicensed |
+| **Free images** | Official upstream — always updated, no restrictions | Moved to `bitnamilegacy/*` — no longer updated, may be removed | Varies |
 | **Vendor lock-in** | None — standard images, standard Helm, standard Kubernetes APIs | Charts tightly coupled to Bitnami images; switching images requires rework | Low, but often abandoned or inconsistent |
 | **Database subcharts** | Self-contained HelmForge subcharts (MySQL, PostgreSQL, MongoDB, MariaDB, Redis) | Bitnami subcharts (locked to Bitnami ecosystem) | External dependencies or none |
 | **Backup** | Built-in S3-compatible CronJob on 17+ charts | Not included | Rarely included |
@@ -52,6 +53,12 @@ image:
 HelmForge is MIT licensed — charts, CI, documentation, everything. This will not change.
 
 Bitnami charts are Apache 2.0, but the **container images** are under a separate [Bitnami EULA](https://www.vmware.com/agreements/bitnami) that introduced usage limits. The free tier has restrictions on pulls and commercial use. Enterprise usage requires a paid subscription.
+
+The previously free open-source Bitnami images were moved to `bitnamilegacy/*` repositories on Docker Hub (e.g., `bitnamilegacy/phpmyadmin`). These legacy images are **no longer updated**, receive no security patches, and carry an explicit warning:
+
+> *"This repository may be removed in the future. For production workloads and long-term support, users are encouraged to adopt Bitnami Secure Images."*
+
+In practice, this means Bitnami's open-source image path is a dead end. Users who want maintained images must adopt the commercial Bitnami Secure Images tier.
 
 Generic community charts have no consistent licensing. Some are MIT, some are unlicensed, some change terms without notice.
 


### PR DESCRIPTION
## Summary

- Adds new "Free images" row to both the comparison page table and homepage comparison table
- Highlights that Bitnami's free open-source images were moved to `bitnamilegacy/*` — no longer updated, may be removed
- Expands the Licensing section with the full context about the legacy repository deprecation
- Updates HelmForge license description to "MIT — forever open source"

## Test plan

- [ ] Verify `/docs/comparison` renders with the new row and expanded licensing section
- [ ] Verify homepage comparison table shows the new "Free images" row