### PR TITLE
refactor: update institutional tagline to Helm Charts

### DIFF
--- a/public/github-banner.svg
+++ b/public/github-banner.svg
@@ -46,7 +46,7 @@
     
     <!-- Tagline -->
     <text x="220" y="180" font-family="'Outfit', system-ui, sans-serif" font-size="32" font-weight="400" fill="#a1a1aa" letter-spacing="1">
-      PRODUCTION-READY INFRASTRUCTURE
+      PRODUCTION-READY HELM CHARTS
     </text>
   </g>
 </svg>

--- a/src/components/Hero.astro
+++ b/src/components/Hero.astro
@@ -6,7 +6,7 @@
   <div class="relative max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 grid grid-cols-1 lg:grid-cols-2 gap-12 lg:gap-8 items-center">
     <div class="max-w-2xl">
       <p class="text-sm font-semibold tracking-[0.2em] uppercase text-primary-light mb-4">
-        Production-ready infrastructure
+        Production-ready Helm charts
       </p>
 
       <h1 class="text-5xl sm:text-6xl lg:text-7xl font-extrabold tracking-tight leading-tight heading-font text-text-base">


### PR DESCRIPTION
Refactoring phrasing per corporate direction. Removed abstract 'Production-ready Infrastructure' global mentions in favor of the hyper-specific 'Production-ready Helm charts' identity, affecting Hero.astro and public/github-banner.svg