### PR TITLE
refactor(site): component architecture and shared data extraction

### DIFF
--- a/src/components/Badge.astro
+++ b/src/components/Badge.astro
@@ -1,0 +1,26 @@
+---
+import { maturityStyles } from '../data/charts';
+
+interface Props {
+  variant: 'stable' | 'beta' | 'alpha' | 'feature';
+  label?: string;
+  class?: string;
+}
+
+const { variant, label, class: className = '' } = Astro.props;
+
+const styles: Record<string, string> = {
+  ...maturityStyles,
+  feature: 'bg-sky-500/10 text-sky-400 border-sky-500/30',
+};
+
+const displayLabel = label || (variant !== 'feature' ? variant : '');
+---
+
+<span class:list={[
+  'inline-flex rounded-full border px-1.5 py-0.5 text-[9px] font-bold uppercase tracking-[0.16em]',
+  styles[variant],
+  className,
+]}>
+  {displayLabel}
+</span>

--- a/src/components/ChartGrid.astro
+++ b/src/components/ChartGrid.astro
@@ -1,103 +1,31 @@
 ---
 import { Search } from 'lucide-astro';
-
-// Deterministic color palette for chart icon badges — cycles through 12 distinct hues
-const iconColors = [
-  'bg-violet-500/15 text-violet-400',
-  'bg-sky-500/15 text-sky-400',
-  'bg-emerald-500/15 text-emerald-400',
-  'bg-orange-500/15 text-orange-400',
-  'bg-rose-500/15 text-rose-400',
-  'bg-cyan-500/15 text-cyan-400',
-  'bg-amber-500/15 text-amber-400',
-  'bg-indigo-500/15 text-indigo-400',
-  'bg-teal-500/15 text-teal-400',
-  'bg-pink-500/15 text-pink-400',
-  'bg-lime-500/15 text-lime-400',
-  'bg-fuchsia-500/15 text-fuchsia-400',
-] as const;
-
-function slugColor(slug: string): string {
-  let hash = 0;
-  for (const ch of slug) hash = ((hash << 5) - hash + ch.charCodeAt(0)) | 0;
-  return iconColors[Math.abs(hash) % iconColors.length];
-}
-
-const charts = [
-  { name: 'Generic', slug: 'generic', description: 'Multi-purpose chart for Deployments, StatefulSets, Jobs, and CronJobs.', maturity: 'stable' as const, backup: false },
-  { name: 'MySQL', slug: 'mysql', description: 'MySQL with standalone and source-replica replication architectures.', maturity: 'stable' as const, backup: true },
-  { name: 'PostgreSQL', slug: 'postgresql', description: 'PostgreSQL with standalone and streaming replication support.', maturity: 'stable' as const, backup: true },
-  { name: 'Redis', slug: 'redis', description: 'Redis with standalone and Sentinel high-availability modes.', maturity: 'stable' as const, backup: false },
-  { name: 'MongoDB', slug: 'mongodb', description: 'MongoDB with standalone and replica set configurations.', maturity: 'stable' as const, backup: true },
-  { name: 'RabbitMQ', slug: 'rabbitmq', description: 'RabbitMQ with management UI and clustering support.', maturity: 'stable' as const, backup: false },
-  { name: 'Keycloak', slug: 'keycloak', description: 'Identity and access management for SSO and federation.', maturity: 'stable' as const, backup: true },
-  { name: 'Vaultwarden', slug: 'vaultwarden', description: 'Bitwarden-compatible password manager with self-hosted simplicity.', maturity: 'stable' as const, backup: true },
-  { name: 'Minecraft', slug: 'minecraft', description: 'Minecraft Java Edition server with backup, monitoring, and mod support.', maturity: 'stable' as const, backup: true },
-  { name: 'Pi-hole', slug: 'pihole', description: 'Network-wide ad blocking with DNS sinkhole and optional recursive DNS.', maturity: 'stable' as const, backup: true, icon: 'https://upload.wikimedia.org/wikipedia/commons/1/15/Pi-hole_vector_logo.svg' },
-  { name: 'WordPress', slug: 'wordpress', description: 'WordPress CMS with MySQL, S3 backup, and production-friendly defaults.', maturity: 'stable' as const, backup: true },
-  { name: 'Strapi', slug: 'strapi', description: 'Headless CMS with SQLite, PostgreSQL, MySQL, and persistent uploads.', maturity: 'stable' as const, backup: true },
-  { name: 'Answer', slug: 'answer', description: 'Apache Answer Q&A platform with SQL backends and S3 backup.', maturity: 'stable' as const, backup: true, icon: 'https://cdn.jsdelivr.net/gh/walkxcode/dashboard-icons/png/apache-answer.png' },
-  { name: 'n8n', slug: 'n8n', description: 'Workflow automation with queue mode, SQL backends, and backup support.', maturity: 'stable' as const, backup: true },
-  { name: 'Komga', slug: 'komga', description: 'Comics and manga server with OPDS, web reader, and S3 backup.', maturity: 'stable' as const, backup: true },
-  { name: 'Guacamole', slug: 'guacamole', description: 'Remote desktop gateway with RDP, VNC, SSH, and SSO integration.', maturity: 'stable' as const, backup: true },
-  { name: 'Cloudflared', slug: 'cloudflared', description: 'Cloudflare Tunnel with outbound-only networking and HA options.', maturity: 'stable' as const, backup: false, icon: 'https://svgl.app/library/cloudflare.svg' },
-  { name: 'DDNS Updater', slug: 'ddns-updater', description: 'Dynamic DNS updater with web UI and provider coverage.', maturity: 'stable' as const, backup: false },
-  { name: 'Uptime Kuma', slug: 'uptime-kuma', description: 'Self-hosted monitoring with status pages and broad notification support.', maturity: 'stable' as const, backup: true },
-  { name: 'Appwrite', slug: 'appwrite', description: 'Self-hosted BaaS platform with MariaDB, Redis, and microservices.', maturity: 'stable' as const, backup: false },
-  { name: 'Authelia', slug: 'authelia', description: 'SSO, MFA, and OpenID Connect for reverse proxies and apps.', maturity: 'stable' as const, backup: true },
-  { name: 'AdGuard Home', slug: 'adguard-home', description: 'DNS ad and tracker blocking with sync and backup features.', maturity: 'stable' as const, backup: true },
-  { name: 'Velero', slug: 'velero', description: 'Kubernetes backup, restore, and migration with object storage.', maturity: 'stable' as const, backup: true, icon: 'https://raw.githubusercontent.com/cncf/landscape/master/hosted_logos/velero.svg' },
-  { name: 'Kafka', slug: 'kafka', description: 'KRaft single-broker and cluster modes with persistent storage.', maturity: 'stable' as const, backup: false, icon: 'https://svgl.app/library/apache_kafka.svg' },
-  { name: 'Dolibarr', slug: 'dolibarr', description: 'ERP and CRM with MySQL, auto-installation, and persistent documents.', maturity: 'stable' as const, backup: false },
-  { name: 'Mosquitto', slug: 'mosquitto', description: 'MQTT broker with standalone or federated topology and WebSocket support.', maturity: 'stable' as const, backup: false },
-  { name: 'Docmost', slug: 'docmost', description: 'Collaborative wiki with bundled PostgreSQL, Redis, and local or S3 storage.', maturity: 'stable' as const, backup: false },
-  { name: 'Flowise', slug: 'flowise', description: 'Visual AI orchestration with standalone or scalable queue architecture.', maturity: 'stable' as const, backup: false },
-  { name: 'phpMyAdmin', slug: 'phpmyadmin', description: 'Web-based MySQL and MariaDB administration with multi-server support.', maturity: 'stable' as const, backup: false },
-  { name: 'Heimdall', slug: 'heimdall', description: 'Application dashboard for organizing self-hosted services.', maturity: 'stable' as const, backup: true },
-  { name: 'Gitea', slug: 'gitea', description: 'Self-hosted Git service with SQL backends, SSH access, and S3 backup.', maturity: 'stable' as const, backup: true },
-  { name: 'Homarr', slug: 'homarr', description: 'Modern dashboard with SQL options, integrations, and S3 backup.', maturity: 'stable' as const, backup: true },
-  { name: 'MariaDB', slug: 'mariadb', description: 'MariaDB with standalone and GTID-based replication plus backup support.', maturity: 'stable' as const, backup: true },
-  { name: 'ArchiveBox', slug: 'archivebox', description: 'Self-hosted web archiving with Chromium headless and multi-format capture.', maturity: 'alpha' as const, backup: false },
-  { name: 'Countly', slug: 'countly', description: 'Product analytics with event tracking, crash reporting, and MongoDB backend.', maturity: 'alpha' as const, backup: false },
-  { name: 'Middleware', slug: 'middleware', description: 'DORA metrics platform with PostgreSQL, Redis, and engineering performance tracking.', maturity: 'alpha' as const, backup: false },
-  { name: 'Apache Superset', slug: 'superset', description: 'Data exploration and visualization with Celery workers, PostgreSQL, and Redis.', maturity: 'alpha' as const, backup: false },
-  { name: 'CKAN', slug: 'ckan', description: 'Open data portal with DataPusher, Solr, PostgreSQL, and Redis.', maturity: 'alpha' as const, backup: false },
-  { name: 'Apache Druid', slug: 'druid', description: 'Distributed analytics database with coordinator, broker, historical, and router.', maturity: 'alpha' as const, backup: false },
-];
-
-const maturityStyles = {
-  stable: 'bg-green-500/10 text-green-400 border-green-500/20',
-  beta: 'bg-amber-500/10 text-amber-400 border-amber-500/20',
-  alpha: 'bg-red-500/10 text-red-400 border-red-500/20',
-} as const;
-
-const chartCount = charts.length;
-const backupCount = charts.filter((chart) => chart.backup).length;
-const stableCount = charts.filter((chart) => chart.maturity === 'stable').length;
+import Container from './Container.astro';
+import SectionHeader from './SectionHeader.astro';
+import Badge from './Badge.astro';
+import { charts, chartCount, backupCount, stableCount, slugColor } from '../data/charts';
 ---
 
 <section class="py-16 sm:py-20 relative">
-  <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+  <Container>
     <div class="flex flex-col gap-8 lg:flex-row lg:items-end lg:justify-between">
-      <div class="max-w-2xl">
-        <p class="text-sm font-semibold uppercase tracking-[0.18em] text-primary">Catalog</p>
-        <h2 class="mt-3 text-3xl sm:text-4xl font-bold tracking-tight text-text-base heading-font">
-          A cleaner catalog for common Kubernetes workloads.
-        </h2>
-        <p class="mt-4 text-base sm:text-lg leading-relaxed text-text-muted">
-          Browse application charts with consistent structure, documented values, and production-minded defaults.
-        </p>
-        
+      <div>
+        <SectionHeader
+          label="Catalog"
+          title="A cleaner catalog for common Kubernetes workloads."
+          description="Browse application charts with consistent structure, documented values, and production-minded defaults."
+        />
+
         <!-- Search Input -->
         <div class="mt-8 relative max-w-md group focus-within:ring-0">
           <div class="absolute inset-y-0 left-0 pl-4 flex items-center pointer-events-none">
             <Search class="h-5 w-5 text-text-muted transition-colors group-focus-within:text-primary-light" />
           </div>
-          <input 
-            type="search" 
-            id="chart-search" 
-            class="block w-full pl-12 pr-4 py-3.5 border border-border rounded-2xl leading-5 bg-bg-surface/80 backdrop-blur-sm text-text-base placeholder-text-muted focus:outline-none focus:ring-2 focus:ring-primary-light focus:border-transparent transition-all sm:text-sm hover:border-border/80 shadow-sm" 
-            placeholder="Search charts (e.g. postgres, redis, backup)..." 
+          <input
+            type="search"
+            id="chart-search"
+            class="block w-full pl-12 pr-4 py-3.5 border border-border rounded-2xl leading-5 bg-bg-surface/80 backdrop-blur-sm text-text-base placeholder-text-muted focus:outline-none focus:ring-2 focus:ring-primary-light focus:border-transparent transition-all sm:text-sm hover:border-border/80 shadow-sm"
+            placeholder="Search charts (e.g. postgres, redis, backup)..."
           />
         </div>
       </div>
@@ -137,12 +65,12 @@ const stableCount = charts.filter((chart) => chart.maturity === 'stable').length
         >
           <!-- Glow background -->
           <div class="absolute inset-0 bg-gradient-to-br from-primary/5 via-transparent to-transparent opacity-0 transition-opacity duration-500 group-hover:opacity-100 pointer-events-none"></div>
-          
+
           <div class="relative flex items-start justify-between gap-3">
             <div class="flex items-center gap-3 min-w-0 flex-1">
               <div class={`flex h-11 w-11 shrink-0 items-center justify-center rounded-2xl text-sm font-bold shadow-inner ${slugColor(chart.slug)} opacity-90 group-hover:opacity-100 transition-all duration-300 group-hover:scale-110 backdrop-blur-md border border-white/10 overflow-hidden`}>
-                <img 
-                  src={chart.icon || `https://cdn.jsdelivr.net/gh/walkxcode/dashboard-icons/png/${chart.slug !== 'generic' ? chart.slug : 'kubernetes'}.png`} 
+                <img
+                  src={chart.icon || `https://cdn.jsdelivr.net/gh/walkxcode/dashboard-icons/png/${chart.slug !== 'generic' ? chart.slug : 'kubernetes'}.png`}
                   alt={`${chart.name} icon`}
                   class="w-6 h-6 object-contain drop-shadow-md"
                   onerror="this.onerror=null; this.src='/chart-placeholder.svg';"
@@ -153,14 +81,8 @@ const stableCount = charts.filter((chart) => chart.maturity === 'stable').length
                   {chart.name}
                 </div>
                 <div class="flex flex-wrap items-center gap-1.5 mt-1">
-                  <span class={`inline-flex rounded-full border px-1.5 py-0.5 text-[9px] font-bold uppercase tracking-[0.16em] ${maturityStyles[chart.maturity]}`}>
-                    {chart.maturity}
-                  </span>
-                  {chart.backup && (
-                    <span class="inline-flex rounded-full border border-sky-500/30 bg-sky-500/10 px-1.5 py-0.5 text-[9px] font-bold uppercase tracking-[0.16em] text-sky-400">
-                      S3 backup
-                    </span>
-                  )}
+                  <Badge variant={chart.maturity} />
+                  {chart.backup && <Badge variant="feature" label="S3 backup" />}
                 </div>
               </div>
             </div>
@@ -176,7 +98,7 @@ const stableCount = charts.filter((chart) => chart.maturity === 'stable').length
         </a>
       ))}
     </div>
-  </div>
+  </Container>
 </section>
 
 <script is:inline>
@@ -184,16 +106,16 @@ const stableCount = charts.filter((chart) => chart.maturity === 'stable').length
     const searchInput = document.getElementById('chart-search');
     const chartCards = document.querySelectorAll('.chart-card');
     const emptyState = document.getElementById('chart-empty-state');
-    
+
     if (searchInput) {
       searchInput.addEventListener('input', (e) => {
         const term = e.target.value.toLowerCase().trim();
         let visibleCount = 0;
-        
+
         chartCards.forEach((card) => {
           const name = card.getAttribute('data-name');
           const desc = card.getAttribute('data-desc');
-          
+
           if (name.includes(term) || desc.includes(term)) {
             card.style.display = '';
             visibleCount++;

--- a/src/components/CodeBlock.astro
+++ b/src/components/CodeBlock.astro
@@ -1,4 +1,6 @@
 ---
+import CopyButton from './CopyButton.astro';
+
 interface Props {
   code: string;
   lang?: string;
@@ -12,50 +14,9 @@ const id = `code-${Math.random().toString(36).slice(2, 9)}`;
   <!-- Language badge -->
   <div class="flex items-center justify-between px-4 py-2 border-b border-slate-700/50">
     <span class="text-xs font-mono text-slate-500 uppercase tracking-wider">{lang}</span>
-    <button
-      data-copy-target={id}
-      class="copy-btn flex items-center gap-1.5 px-2.5 py-1 text-xs font-medium text-slate-400 hover:text-white bg-slate-800 hover:bg-slate-700 rounded-md transition-colors"
-      aria-label="Copy code to clipboard"
-    >
-      <svg class="w-3.5 h-3.5 copy-icon" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z" />
-      </svg>
-      <svg class="w-3.5 h-3.5 check-icon hidden" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7" />
-      </svg>
-      <span class="copy-text">Copy</span>
-    </button>
+    <CopyButton targetId={id} />
   </div>
 
   <!-- Code content -->
   <pre class="px-5 py-4 overflow-x-auto text-sm leading-relaxed"><code id={id} class="text-slate-300 font-mono">{code}</code></pre>
 </div>
-
-<script is:inline>
-  document.querySelectorAll('.copy-btn').forEach(btn => {
-    btn.addEventListener('click', async () => {
-      const targetId = btn.getAttribute('data-copy-target');
-      const codeEl = document.getElementById(targetId);
-      if (!codeEl) return;
-
-      try {
-        await navigator.clipboard.writeText(codeEl.textContent || '');
-        const copyIcon = btn.querySelector('.copy-icon');
-        const checkIcon = btn.querySelector('.check-icon');
-        const copyText = btn.querySelector('.copy-text');
-
-        if (copyIcon) copyIcon.classList.add('hidden');
-        if (checkIcon) checkIcon.classList.remove('hidden');
-        if (copyText) copyText.textContent = 'Copied!';
-
-        setTimeout(() => {
-          if (copyIcon) copyIcon.classList.remove('hidden');
-          if (checkIcon) checkIcon.classList.add('hidden');
-          if (copyText) copyText.textContent = 'Copy';
-        }, 2000);
-      } catch (err) {
-        console.error('Failed to copy:', err);
-      }
-    });
-  });
-</script>

--- a/src/components/ComparisonTable.astro
+++ b/src/components/ComparisonTable.astro
@@ -1,106 +1,14 @@
 ---
 import { CheckCircle2, ChevronRight, Scale } from 'lucide-astro';
-
-const rows = [
-  {
-    aspect: 'Container images',
-    helmforge: 'Official upstream images',
-    bitnami: 'Custom Bitnami-built images',
-    community: 'Varies',
-    highlight: true,
-  },
-  {
-    aspect: 'Image tags',
-    helmforge: 'Pinned, immutable versions',
-    bitnami: 'Bitnami-specific rolling tags',
-    community: 'Often :latest or unpinned',
-    highlight: true,
-  },
-  {
-    aspect: 'License',
-    helmforge: 'MIT — forever open source',
-    bitnami: 'Apache 2.0 charts; images under EULA',
-    community: 'Varies',
-    highlight: true,
-  },
-  {
-    aspect: 'Pricing / Tiering',
-    helmforge: '100% Free forever',
-    bitnami: 'Free only for deprecated legacy images (requires Sales for production)',
-    community: 'Usually Free',
-    highlight: true,
-  },
-  {
-    aspect: 'Free images',
-    helmforge: 'Official upstream, always updated',
-    bitnami: 'Moved to bitnamilegacy/* — no longer updated',
-    community: 'Varies',
-    highlight: true,
-  },
-  {
-    aspect: 'Vendor lock-in',
-    helmforge: 'None',
-    bitnami: 'Tied to Bitnami images',
-    community: 'Low',
-    highlight: true,
-  },
-  {
-    aspect: 'Built-in backup',
-    helmforge: 'S3-compatible on 17+ charts',
-    bitnami: 'Not included',
-    community: 'Rarely included',
-    highlight: false,
-  },
-  {
-    aspect: 'Values design',
-    helmforge: 'Product-oriented (e.g. database.host)',
-    bitnami: 'Kubernetes-centric abstractions',
-    community: 'Varies',
-    highlight: false,
-  },
-  {
-    aspect: 'Database subcharts',
-    helmforge: 'Self-contained HelmForge subcharts',
-    bitnami: 'Self-contained (Bitnami)',
-    community: 'External dependencies',
-    highlight: false,
-  },
-  {
-    aspect: 'Security defaults',
-    helmforge: 'Non-root, tight security contexts',
-    bitnami: 'Non-root',
-    community: 'Varies wildly',
-    highlight: true,
-  },
-  {
-    aspect: 'Schema validation',
-    helmforge: 'Every chart',
-    bitnami: 'Some charts',
-    community: 'Rare',
-    highlight: false,
-  },
-  {
-    aspect: 'Supply chain signing',
-    helmforge: 'Sigstore Cosign on every artifact',
-    bitnami: 'Image signatures',
-    community: 'Rare',
-    highlight: false,
-  },
-  {
-    aspect: 'CI pipeline',
-    helmforge: 'Lint + template + unittest + kubeconform',
-    bitnami: 'Internal CI',
-    community: 'Minimal or none',
-    highlight: false,
-  },
-];
+import Container from './Container.astro';
+import { comparisonFull } from '../data/comparison';
 ---
 
 <section class="bg-bg-base py-20 lg:py-28 relative border-t border-border/50">
   <!-- Subtle Gradient Background -->
   <div class="absolute inset-0 bg-gradient-to-b from-bg-surface/30 to-bg-base pointer-events-none"></div>
 
-  <div class="relative max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+  <Container class="relative">
     <div class="text-center max-w-2xl mx-auto mb-16">
       <div class="inline-flex items-center justify-center p-3 rounded-2xl bg-primary/10 text-primary mb-6 ring-1 ring-primary/20">
         <Scale class="w-6 h-6" />
@@ -130,7 +38,7 @@ const rows = [
             </tr>
           </thead>
           <tbody class="divide-y divide-border/50">
-            {rows.map((row, i) => (
+            {comparisonFull.map((row) => (
               <tr class="group transition-colors hover:bg-white/[0.02]">
                 <td class="px-6 py-4 font-semibold text-text-base whitespace-nowrap">{row.aspect}</td>
                 <td class="px-6 py-4 text-text-base font-medium bg-primary/[0.02] border-x border-primary/10 group-hover:bg-primary/[0.04] transition-colors">
@@ -157,5 +65,5 @@ const rows = [
         <ChevronRight class="w-4 h-4 transition-transform group-hover:translate-x-1" />
       </a>
     </div>
-  </div>
+  </Container>
 </section>

--- a/src/components/Container.astro
+++ b/src/components/Container.astro
@@ -1,0 +1,14 @@
+---
+interface Props {
+  maxWidth?: '6xl' | '7xl';
+  class?: string;
+}
+
+const { maxWidth = '7xl', class: className = '' } = Astro.props;
+
+const widthClass = maxWidth === '6xl' ? 'max-w-6xl' : 'max-w-7xl';
+---
+
+<div class:list={[widthClass, 'mx-auto px-4 sm:px-6 lg:px-8', className]}>
+  <slot />
+</div>

--- a/src/components/CopyButton.astro
+++ b/src/components/CopyButton.astro
@@ -1,0 +1,64 @@
+---
+interface Props {
+  code?: string;
+  targetId?: string;
+  class?: string;
+}
+
+const { code, targetId, class: className = '' } = Astro.props;
+const uid = Math.random().toString(36).slice(2, 8);
+---
+
+<button
+  class:list={[
+    'copy-btn flex items-center gap-1.5 px-2.5 py-1 text-xs font-medium text-slate-400 hover:text-white bg-slate-800 hover:bg-slate-700 rounded-md transition-colors',
+    className,
+  ]}
+  data-copy-uid={uid}
+  data-copy-code={code}
+  data-copy-target={targetId}
+  aria-label="Copy to clipboard"
+>
+  <svg class="w-3.5 h-3.5 copy-icon" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z" />
+  </svg>
+  <svg class="w-3.5 h-3.5 check-icon hidden" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7" />
+  </svg>
+  <span class="copy-text">Copy</span>
+</button>
+
+<script is:inline>
+  if (!window.__copyBtnInit) {
+    window.__copyBtnInit = true;
+    document.addEventListener('click', async (e) => {
+      const btn = e.target.closest('[data-copy-uid]');
+      if (!btn) return;
+
+      let text = btn.getAttribute('data-copy-code') || '';
+      if (!text) {
+        const targetId = btn.getAttribute('data-copy-target');
+        const el = targetId ? document.getElementById(targetId) : null;
+        if (el) text = el.textContent || '';
+      }
+      if (!text) return;
+
+      try {
+        await navigator.clipboard.writeText(text);
+        const copyIcon = btn.querySelector('.copy-icon');
+        const checkIcon = btn.querySelector('.check-icon');
+        const label = btn.querySelector('.copy-text');
+        if (copyIcon) copyIcon.classList.add('hidden');
+        if (checkIcon) checkIcon.classList.remove('hidden');
+        if (label) label.textContent = 'Copied!';
+        setTimeout(() => {
+          if (copyIcon) copyIcon.classList.remove('hidden');
+          if (checkIcon) checkIcon.classList.add('hidden');
+          if (label) label.textContent = 'Copy';
+        }, 2000);
+      } catch (err) {
+        console.error('Copy failed:', err);
+      }
+    });
+  }
+</script>

--- a/src/components/DocsCopyBlock.astro
+++ b/src/components/DocsCopyBlock.astro
@@ -1,4 +1,6 @@
 ---
+import CopyButton from './CopyButton.astro';
+
 interface Props {
   code: string;
   label?: string;
@@ -11,44 +13,7 @@ const id = `dcb-${Math.random().toString(36).slice(2, 9)}`;
 <div class="relative group my-4">
   {label && <div class="text-xs font-mono text-slate-500 mb-1">{label}</div>}
   <div class="bg-slate-900 rounded-lg border border-slate-700/50 overflow-hidden">
-    <button
-      class="docs-copy-btn absolute top-2 right-2 flex items-center gap-1.5 px-2 py-1 text-xs font-medium text-slate-400 hover:text-white bg-slate-800 hover:bg-slate-700 rounded-md transition-colors opacity-0 group-hover:opacity-100 focus:opacity-100 z-10"
-      data-copy-code={code}
-      aria-label="Copy to clipboard"
-    >
-      <svg class="w-3.5 h-3.5 copy-icon" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z" />
-      </svg>
-      <svg class="w-3.5 h-3.5 check-icon hidden" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7" />
-      </svg>
-      <span class="copy-text">Copy</span>
-    </button>
+    <CopyButton code={code} class="absolute top-2 right-2 opacity-0 group-hover:opacity-100 focus:opacity-100 z-10" />
     <pre class="px-4 py-3 overflow-x-auto text-sm leading-relaxed"><code id={id} class="text-slate-300 font-mono">{code}</code></pre>
   </div>
 </div>
-
-<script is:inline>
-  document.querySelectorAll('.docs-copy-btn').forEach(btn => {
-    if (btn.dataset.bound) return;
-    btn.dataset.bound = 'true';
-    btn.addEventListener('click', async () => {
-      const code = btn.getAttribute('data-copy-code');
-      if (!code) return;
-      try {
-        await navigator.clipboard.writeText(code);
-        const copyIcon = btn.querySelector('.copy-icon');
-        const checkIcon = btn.querySelector('.check-icon');
-        const copyText = btn.querySelector('.copy-text');
-        if (copyIcon) copyIcon.classList.add('hidden');
-        if (checkIcon) checkIcon.classList.remove('hidden');
-        if (copyText) copyText.textContent = 'Copied!';
-        setTimeout(() => {
-          if (copyIcon) copyIcon.classList.remove('hidden');
-          if (checkIcon) checkIcon.classList.add('hidden');
-          if (copyText) copyText.textContent = 'Copy';
-        }, 2000);
-      } catch (err) { console.error('Copy failed:', err); }
-    });
-  });
-</script>

--- a/src/components/Features.astro
+++ b/src/components/Features.astro
@@ -1,4 +1,7 @@
 ---
+import Container from './Container.astro';
+import SectionHeader from './SectionHeader.astro';
+
 const features = [
   {
     icon: `<svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M9 12l2 2 4-4m5.618-4.016A11.955 11.955 0 0112 2.944a11.955 11.955 0 01-8.618 3.04A12.02 12.02 0 003 9c0 5.591 3.824 10.29 9 11.622 5.176-1.332 9-6.03 9-11.622 0-1.042-.133-2.052-.382-3.016z" /></svg>`,
@@ -19,16 +22,13 @@ const features = [
 ---
 
 <section class="bg-bg-base py-16 sm:py-20 transition-colors">
-  <div class="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8">
-    <div class="max-w-2xl mb-10">
-      <p class="text-sm font-medium uppercase tracking-[0.18em] text-primary">Principles</p>
-      <h2 class="mt-3 text-3xl sm:text-4xl font-bold tracking-tight text-text-base heading-font">
-        Fewer surprises, better defaults.
-      </h2>
-      <p class="mt-4 text-base sm:text-lg text-text-muted leading-relaxed">
-        Every chart follows the same product direction: predictable installs, clear values, and production-minded behavior.
-      </p>
-    </div>
+  <Container maxWidth="6xl">
+    <SectionHeader
+      label="Principles"
+      title="Fewer surprises, better defaults."
+      description="Every chart follows the same product direction: predictable installs, clear values, and production-minded behavior."
+      class="mb-10"
+    />
 
     <div class="grid grid-cols-1 gap-4 md:grid-cols-3">
       {features.map(feature => (
@@ -41,5 +41,5 @@ const features = [
         </div>
       ))}
     </div>
-  </div>
+  </Container>
 </section>

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -1,12 +1,13 @@
 ---
 import Logo from './Logo.astro';
+import Container from './Container.astro';
 
 const year = new Date().getFullYear();
 ---
 
 <footer class="mt-auto border-t border-border bg-bg-surface/50">
 
-  <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-10">
+  <Container class="py-10">
     <div class="grid grid-cols-1 gap-8 md:grid-cols-[minmax(0,1.25fr)_1fr_1fr]">
       <!-- Brand -->
       <div>
@@ -49,6 +50,6 @@ const year = new Date().getFullYear();
     <div class="mt-8 border-t border-border pt-6 text-center text-sm text-text-muted/60">
       <p>&copy; {year} HelmForge.</p>
     </div>
-  </div>
+  </Container>
 </footer>
 

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -1,6 +1,7 @@
 ---
 import ThemeToggle from './ThemeToggle.astro';
 import Logo from './Logo.astro';
+import Container from './Container.astro';
 import { Github, Menu, X } from 'lucide-astro';
 
 const currentPath = Astro.url.pathname;
@@ -17,7 +18,7 @@ function isActive(href: string): boolean {
 ---
 
 <header class="glass-panel sticky top-0 z-50 border-b border-border shadow-[0_4px_30px_rgba(0,0,0,0.05)] transition-all">
-  <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+  <Container>
     <div class="flex h-[72px] items-center justify-between">
       <!-- Logo -->
       <a href="/" class="flex items-center group text-text-base transition-opacity hover:opacity-90" aria-label="HelmForge home">
@@ -106,7 +107,7 @@ function isActive(href: string): boolean {
         </div>
       </div>
     </nav>
-  </div>
+  </Container>
 </header>
 
 <script>

--- a/src/components/Hero.astro
+++ b/src/components/Hero.astro
@@ -1,5 +1,6 @@
 ---
 import { Terminal, Database } from 'lucide-astro';
+import Container from './Container.astro';
 ---
 
 <section class="relative overflow-hidden py-24 sm:py-32 lg:pb-40 lg:pt-36">
@@ -10,7 +11,7 @@ import { Terminal, Database } from 'lucide-astro';
   <div class="absolute top-0 right-0 -translate-y-12 translate-x-1/3 w-[800px] h-[600px] bg-primary/20 rounded-full blur-[120px] opacity-50 mix-blend-screen pointer-events-none"></div>
   <div class="absolute bottom-0 left-0 translate-y-1/3 -translate-x-1/3 w-[600px] h-[600px] bg-accent/15 rounded-full blur-[100px] opacity-40 mix-blend-screen pointer-events-none"></div>
 
-  <div class="relative max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 grid grid-cols-1 lg:grid-cols-12 gap-16 lg:gap-8 items-center">
+  <Container class="relative grid grid-cols-1 lg:grid-cols-12 gap-16 lg:gap-8 items-center">
     
     <!-- Left Copy -->
     <div class="lg:col-span-6 flex flex-col justify-center text-center lg:text-left">
@@ -82,7 +83,7 @@ import { Terminal, Database } from 'lucide-astro';
         </div>
       </div>
     </div>
-  </div>
+  </Container>
 </section>
 
 <script>

--- a/src/components/HomeComparison.astro
+++ b/src/components/HomeComparison.astro
@@ -1,54 +1,12 @@
 ---
-const comparisons = [
-  {
-    feature: 'Container images',
-    generic: 'Often custom-built or wrapped',
-    bitnami: 'Custom-built Bitnami wrappers',
-    helmforge: 'Official upstream images only',
-  },
-  {
-    feature: 'Backup',
-    generic: 'Separate tooling needed',
-    bitnami: 'Varies, prone to breakages',
-    helmforge: 'Built-in S3-compatible via CronJob',
-  },
-  {
-    feature: 'License',
-    generic: 'Varies (some restrictive)',
-    bitnami: 'Proprietary for production secure images',
-    helmforge: 'MIT — open source',
-  },
-  {
-    feature: 'Pricing / Tiering',
-    generic: 'Usually Free',
-    bitnami: 'Free only for deprecated legacy images (requires Sales for production)',
-    helmforge: '100% Free forever',
-  },
-  {
-    feature: 'Database subcharts',
-    generic: 'External dependencies (e.g., Bitnami)',
-    bitnami: 'Self-contained (Bitnami)',
-    helmforge: 'Self-contained HelmForge subcharts',
-  },
-  {
-    feature: 'Values design',
-    generic: 'Kubernetes-centric (containers[].ports)',
-    bitnami: 'Application-centric but complex',
-    helmforge: 'Product-oriented (e.g. database.host)',
-  },
-  {
-    feature: 'Security defaults',
-    generic: 'Varies wildly',
-    bitnami: 'Non-root',
-    helmforge: 'Non-root, tight security contexts',
-  }
-];
+import Container from './Container.astro';
+import { comparisonSummary } from '../data/comparison';
 ---
 
 <section class="py-20 lg:py-28 relative overflow-hidden bg-bg-base">
   <div class="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 w-[800px] h-[400px] bg-primary/20 blur-[120px] rounded-full pointer-events-none"></div>
 
-  <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 relative z-10">
+  <Container class="relative z-10">
     <div class="text-center mb-16">
       <h2 class="text-3xl sm:text-5xl font-extrabold text-text-base tracking-tight heading-font">
         HelmForge vs The Ecosystem
@@ -70,7 +28,7 @@ const comparisons = [
             </tr>
           </thead>
           <tbody class="divide-y divide-border">
-            {comparisons.map((item, idx) => (
+            {comparisonSummary.map((item) => (
               <tr class="transition-colors hover:bg-text-base/5">
                 <td class="py-5 px-6 text-sm font-semibold text-text-base">
                   {item.feature}
@@ -90,5 +48,5 @@ const comparisons = [
         </table>
       </div>
     </div>
-  </div>
+  </Container>
 </section>

--- a/src/components/InstallSection.astro
+++ b/src/components/InstallSection.astro
@@ -1,4 +1,8 @@
 ---
+import Container from './Container.astro';
+import SectionHeader from './SectionHeader.astro';
+import CopyButton from './CopyButton.astro';
+
 const httpsCode = `helm repo add helmforge https://repo.helmforge.dev
 helm repo update
 helm install my-release helmforge/redis`;
@@ -7,16 +11,13 @@ const ociCode = `helm install my-release oci://ghcr.io/helmforgedev/helm/redis`;
 ---
 
 <section class="bg-bg-surface/30 border-y border-border py-16 sm:py-20">
-  <div class="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8">
-    <div class="max-w-2xl mb-10">
-      <p class="text-sm font-medium uppercase tracking-[0.18em] text-primary">Install</p>
-      <h2 class="mt-3 text-3xl sm:text-4xl font-bold tracking-tight text-text-base">
-        Two ways to start, both simple.
-      </h2>
-      <p class="mt-4 text-base sm:text-lg text-text-muted leading-relaxed">
-        Use the Helm repository for a familiar workflow or install directly from OCI.
-      </p>
-    </div>
+  <Container maxWidth="6xl">
+    <SectionHeader
+      label="Install"
+      title="Two ways to start, both simple."
+      description="Use the Helm repository for a familiar workflow or install directly from OCI."
+      class="mb-10"
+    />
 
     <div class="max-w-3xl">
       <!-- Tab buttons -->
@@ -46,19 +47,7 @@ const ociCode = `helm install my-release oci://ghcr.io/helmforgedev/helm/redis`;
       <!-- HTTPS panel -->
       <div id="panel-https" class="install-panel" role="tabpanel" aria-labelledby="tab-https">
         <div class="bg-slate-900 rounded-b-xl border border-t-0 border-slate-700/50 overflow-hidden relative group">
-          <button
-            class="copy-panel-btn absolute top-3 right-3 flex items-center gap-1.5 px-2.5 py-1 text-xs font-medium text-slate-400 hover:text-white bg-slate-800 hover:bg-slate-700 rounded-md transition-colors opacity-0 group-hover:opacity-100 focus:opacity-100"
-            data-code={httpsCode}
-            aria-label="Copy commands"
-          >
-            <svg class="w-3.5 h-3.5 copy-icon" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z" />
-            </svg>
-            <svg class="w-3.5 h-3.5 check-icon hidden" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7" />
-            </svg>
-            <span class="copy-label">Copy</span>
-          </button>
+          <CopyButton code={httpsCode} class="absolute top-3 right-3 opacity-0 group-hover:opacity-100 focus:opacity-100" />
           <div class="px-5 py-5 space-y-1 font-mono text-sm text-slate-300 leading-relaxed overflow-x-auto">
             <div>
               <span class="text-accent select-none">$</span>
@@ -79,19 +68,7 @@ const ociCode = `helm install my-release oci://ghcr.io/helmforgedev/helm/redis`;
       <!-- OCI panel -->
       <div id="panel-oci" class="install-panel hidden" role="tabpanel" aria-labelledby="tab-oci">
         <div class="bg-slate-900 rounded-b-xl border border-t-0 border-slate-700/50 overflow-hidden relative group">
-          <button
-            class="copy-panel-btn absolute top-3 right-3 flex items-center gap-1.5 px-2.5 py-1 text-xs font-medium text-slate-400 hover:text-white bg-slate-800 hover:bg-slate-700 rounded-md transition-colors opacity-0 group-hover:opacity-100 focus:opacity-100"
-            data-code={ociCode}
-            aria-label="Copy command"
-          >
-            <svg class="w-3.5 h-3.5 copy-icon" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z" />
-            </svg>
-            <svg class="w-3.5 h-3.5 check-icon hidden" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7" />
-            </svg>
-            <span class="copy-label">Copy</span>
-          </button>
+          <CopyButton code={ociCode} class="absolute top-3 right-3 opacity-0 group-hover:opacity-100 focus:opacity-100" />
           <div class="px-5 py-5 font-mono text-sm text-slate-300 leading-relaxed overflow-x-auto">
             <div>
               <span class="text-accent select-none">$</span>
@@ -107,7 +84,7 @@ const ociCode = `helm install my-release oci://ghcr.io/helmforgedev/helm/redis`;
         <span class="font-medium text-text-base">vaultwarden</span>, or any other chart available in the repository.
       </p>
     </div>
-  </div>
+  </Container>
 </section>
 
 <script is:inline>
@@ -129,30 +106,6 @@ const ociCode = `helm install my-release oci://ghcr.io/helmforgedev/helm/redis`;
       panels.forEach(panel => {
         panel.classList.toggle('hidden', panel.id !== `panel-${target}`);
       });
-    });
-  });
-
-  // Copy buttons
-  document.querySelectorAll('.copy-panel-btn').forEach(btn => {
-    btn.addEventListener('click', async () => {
-      const code = btn.getAttribute('data-code');
-      if (!code) return;
-      try {
-        await navigator.clipboard.writeText(code);
-        const copyIcon = btn.querySelector('.copy-icon');
-        const checkIcon = btn.querySelector('.check-icon');
-        const label = btn.querySelector('.copy-label');
-        if (copyIcon) copyIcon.classList.add('hidden');
-        if (checkIcon) checkIcon.classList.remove('hidden');
-        if (label) label.textContent = 'Copied!';
-        setTimeout(() => {
-          if (copyIcon) copyIcon.classList.remove('hidden');
-          if (checkIcon) checkIcon.classList.add('hidden');
-          if (label) label.textContent = 'Copy';
-        }, 2000);
-      } catch (err) {
-        console.error('Copy failed:', err);
-      }
     });
   });
 </script>

--- a/src/components/SectionHeader.astro
+++ b/src/components/SectionHeader.astro
@@ -1,0 +1,28 @@
+---
+interface Props {
+  label?: string;
+  title: string;
+  description?: string;
+  align?: 'left' | 'center';
+  class?: string;
+}
+
+const { label, title, description, align = 'left', class: className = '' } = Astro.props;
+
+const alignClass = align === 'center' ? 'text-center mx-auto' : '';
+---
+
+<div class:list={['max-w-2xl', alignClass, className]}>
+  {label && (
+    <p class="text-sm font-semibold uppercase tracking-[0.18em] text-primary">{label}</p>
+  )}
+  <h2 class:list={[
+    'text-3xl sm:text-4xl font-bold tracking-tight text-text-base heading-font',
+    label && 'mt-3',
+  ]}>
+    <Fragment set:html={title} />
+  </h2>
+  {description && (
+    <p class="mt-4 text-base sm:text-lg text-text-muted leading-relaxed">{description}</p>
+  )}
+</div>

--- a/src/data/charts.ts
+++ b/src/data/charts.ts
@@ -1,0 +1,82 @@
+export interface Chart {
+  name: string;
+  slug: string;
+  description: string;
+  maturity: 'stable' | 'beta' | 'alpha';
+  backup: boolean;
+  icon?: string;
+}
+
+export const charts: Chart[] = [
+  { name: 'Generic', slug: 'generic', description: 'Multi-purpose chart for Deployments, StatefulSets, Jobs, and CronJobs.', maturity: 'stable', backup: false },
+  { name: 'MySQL', slug: 'mysql', description: 'MySQL with standalone and source-replica replication architectures.', maturity: 'stable', backup: true },
+  { name: 'PostgreSQL', slug: 'postgresql', description: 'PostgreSQL with standalone and streaming replication support.', maturity: 'stable', backup: true },
+  { name: 'Redis', slug: 'redis', description: 'Redis with standalone and Sentinel high-availability modes.', maturity: 'stable', backup: false },
+  { name: 'MongoDB', slug: 'mongodb', description: 'MongoDB with standalone and replica set configurations.', maturity: 'stable', backup: true },
+  { name: 'RabbitMQ', slug: 'rabbitmq', description: 'RabbitMQ with management UI and clustering support.', maturity: 'stable', backup: false },
+  { name: 'Keycloak', slug: 'keycloak', description: 'Identity and access management for SSO and federation.', maturity: 'stable', backup: true },
+  { name: 'Vaultwarden', slug: 'vaultwarden', description: 'Bitwarden-compatible password manager with self-hosted simplicity.', maturity: 'stable', backup: true },
+  { name: 'Minecraft', slug: 'minecraft', description: 'Minecraft Java Edition server with backup, monitoring, and mod support.', maturity: 'stable', backup: true },
+  { name: 'Pi-hole', slug: 'pihole', description: 'Network-wide ad blocking with DNS sinkhole and optional recursive DNS.', maturity: 'stable', backup: true, icon: 'https://upload.wikimedia.org/wikipedia/commons/1/15/Pi-hole_vector_logo.svg' },
+  { name: 'WordPress', slug: 'wordpress', description: 'WordPress CMS with MySQL, S3 backup, and production-friendly defaults.', maturity: 'stable', backup: true },
+  { name: 'Strapi', slug: 'strapi', description: 'Headless CMS with SQLite, PostgreSQL, MySQL, and persistent uploads.', maturity: 'stable', backup: true },
+  { name: 'Answer', slug: 'answer', description: 'Apache Answer Q&A platform with SQL backends and S3 backup.', maturity: 'stable', backup: true, icon: 'https://cdn.jsdelivr.net/gh/walkxcode/dashboard-icons/png/apache-answer.png' },
+  { name: 'n8n', slug: 'n8n', description: 'Workflow automation with queue mode, SQL backends, and backup support.', maturity: 'stable', backup: true },
+  { name: 'Komga', slug: 'komga', description: 'Comics and manga server with OPDS, web reader, and S3 backup.', maturity: 'stable', backup: true },
+  { name: 'Guacamole', slug: 'guacamole', description: 'Remote desktop gateway with RDP, VNC, SSH, and SSO integration.', maturity: 'stable', backup: true },
+  { name: 'Cloudflared', slug: 'cloudflared', description: 'Cloudflare Tunnel with outbound-only networking and HA options.', maturity: 'stable', backup: false, icon: 'https://svgl.app/library/cloudflare.svg' },
+  { name: 'DDNS Updater', slug: 'ddns-updater', description: 'Dynamic DNS updater with web UI and provider coverage.', maturity: 'stable', backup: false },
+  { name: 'Uptime Kuma', slug: 'uptime-kuma', description: 'Self-hosted monitoring with status pages and broad notification support.', maturity: 'stable', backup: true },
+  { name: 'Appwrite', slug: 'appwrite', description: 'Self-hosted BaaS platform with MariaDB, Redis, and microservices.', maturity: 'stable', backup: false },
+  { name: 'Authelia', slug: 'authelia', description: 'SSO, MFA, and OpenID Connect for reverse proxies and apps.', maturity: 'stable', backup: true },
+  { name: 'AdGuard Home', slug: 'adguard-home', description: 'DNS ad and tracker blocking with sync and backup features.', maturity: 'stable', backup: true },
+  { name: 'Velero', slug: 'velero', description: 'Kubernetes backup, restore, and migration with object storage.', maturity: 'stable', backup: true, icon: 'https://raw.githubusercontent.com/cncf/landscape/master/hosted_logos/velero.svg' },
+  { name: 'Kafka', slug: 'kafka', description: 'KRaft single-broker and cluster modes with persistent storage.', maturity: 'stable', backup: false, icon: 'https://svgl.app/library/apache_kafka.svg' },
+  { name: 'Dolibarr', slug: 'dolibarr', description: 'ERP and CRM with MySQL, auto-installation, and persistent documents.', maturity: 'stable', backup: false },
+  { name: 'Mosquitto', slug: 'mosquitto', description: 'MQTT broker with standalone or federated topology and WebSocket support.', maturity: 'stable', backup: false },
+  { name: 'Docmost', slug: 'docmost', description: 'Collaborative wiki with bundled PostgreSQL, Redis, and local or S3 storage.', maturity: 'stable', backup: false },
+  { name: 'Flowise', slug: 'flowise', description: 'Visual AI orchestration with standalone or scalable queue architecture.', maturity: 'stable', backup: false },
+  { name: 'phpMyAdmin', slug: 'phpmyadmin', description: 'Web-based MySQL and MariaDB administration with multi-server support.', maturity: 'stable', backup: false },
+  { name: 'Heimdall', slug: 'heimdall', description: 'Application dashboard for organizing self-hosted services.', maturity: 'stable', backup: true },
+  { name: 'Gitea', slug: 'gitea', description: 'Self-hosted Git service with SQL backends, SSH access, and S3 backup.', maturity: 'stable', backup: true },
+  { name: 'Homarr', slug: 'homarr', description: 'Modern dashboard with SQL options, integrations, and S3 backup.', maturity: 'stable', backup: true },
+  { name: 'MariaDB', slug: 'mariadb', description: 'MariaDB with standalone and GTID-based replication plus backup support.', maturity: 'stable', backup: true },
+  { name: 'ArchiveBox', slug: 'archivebox', description: 'Self-hosted web archiving with Chromium headless and multi-format capture.', maturity: 'alpha', backup: false },
+  { name: 'Countly', slug: 'countly', description: 'Product analytics with event tracking, crash reporting, and MongoDB backend.', maturity: 'alpha', backup: false },
+  { name: 'Middleware', slug: 'middleware', description: 'DORA metrics platform with PostgreSQL, Redis, and engineering performance tracking.', maturity: 'alpha', backup: false },
+  { name: 'Apache Superset', slug: 'superset', description: 'Data exploration and visualization with Celery workers, PostgreSQL, and Redis.', maturity: 'alpha', backup: false },
+  { name: 'CKAN', slug: 'ckan', description: 'Open data portal with DataPusher, Solr, PostgreSQL, and Redis.', maturity: 'alpha', backup: false },
+  { name: 'Apache Druid', slug: 'druid', description: 'Distributed analytics database with coordinator, broker, historical, and router.', maturity: 'alpha', backup: false },
+];
+
+export const chartCount = charts.length;
+export const backupCount = charts.filter((c) => c.backup).length;
+export const stableCount = charts.filter((c) => c.maturity === 'stable').length;
+
+/** Deterministic color palette for chart icon badges */
+const iconColors = [
+  'bg-violet-500/15 text-violet-400',
+  'bg-sky-500/15 text-sky-400',
+  'bg-emerald-500/15 text-emerald-400',
+  'bg-orange-500/15 text-orange-400',
+  'bg-rose-500/15 text-rose-400',
+  'bg-cyan-500/15 text-cyan-400',
+  'bg-amber-500/15 text-amber-400',
+  'bg-indigo-500/15 text-indigo-400',
+  'bg-teal-500/15 text-teal-400',
+  'bg-pink-500/15 text-pink-400',
+  'bg-lime-500/15 text-lime-400',
+  'bg-fuchsia-500/15 text-fuchsia-400',
+] as const;
+
+export function slugColor(slug: string): string {
+  let hash = 0;
+  for (const ch of slug) hash = ((hash << 5) - hash + ch.charCodeAt(0)) | 0;
+  return iconColors[Math.abs(hash) % iconColors.length];
+}
+
+export const maturityStyles = {
+  stable: 'bg-green-500/10 text-green-400 border-green-500/20',
+  beta: 'bg-amber-500/10 text-amber-400 border-amber-500/20',
+  alpha: 'bg-red-500/10 text-red-400 border-red-500/20',
+} as const;

--- a/src/data/comparison.ts
+++ b/src/data/comparison.ts
@@ -1,0 +1,40 @@
+export interface ComparisonRow {
+  aspect: string;
+  helmforge: string;
+  bitnami: string;
+  community: string;
+  highlight?: boolean;
+}
+
+export const comparisonFull: ComparisonRow[] = [
+  { aspect: 'Container images', helmforge: 'Official upstream images', bitnami: 'Custom Bitnami-built images', community: 'Varies', highlight: true },
+  { aspect: 'Image tags', helmforge: 'Pinned, immutable versions', bitnami: 'Bitnami-specific rolling tags', community: 'Often :latest or unpinned', highlight: true },
+  { aspect: 'License', helmforge: 'MIT — forever open source', bitnami: 'Apache 2.0 charts; images under EULA', community: 'Varies', highlight: true },
+  { aspect: 'Pricing / Tiering', helmforge: '100% Free forever', bitnami: 'Free only for deprecated legacy images (requires Sales for production)', community: 'Usually Free', highlight: true },
+  { aspect: 'Free images', helmforge: 'Official upstream, always updated', bitnami: 'Moved to bitnamilegacy/* — no longer updated', community: 'Varies', highlight: true },
+  { aspect: 'Vendor lock-in', helmforge: 'None', bitnami: 'Tied to Bitnami images', community: 'Low', highlight: true },
+  { aspect: 'Built-in backup', helmforge: 'S3-compatible on 17+ charts', bitnami: 'Not included', community: 'Rarely included' },
+  { aspect: 'Values design', helmforge: 'Product-oriented (e.g. database.host)', bitnami: 'Kubernetes-centric abstractions', community: 'Varies' },
+  { aspect: 'Database subcharts', helmforge: 'Self-contained HelmForge subcharts', bitnami: 'Self-contained (Bitnami)', community: 'External dependencies' },
+  { aspect: 'Security defaults', helmforge: 'Non-root, tight security contexts', bitnami: 'Non-root', community: 'Varies wildly', highlight: true },
+  { aspect: 'Schema validation', helmforge: 'Every chart', bitnami: 'Some charts', community: 'Rare' },
+  { aspect: 'Supply chain signing', helmforge: 'Sigstore Cosign on every artifact', bitnami: 'Image signatures', community: 'Rare' },
+  { aspect: 'CI pipeline', helmforge: 'Lint + template + unittest + kubeconform', bitnami: 'Internal CI', community: 'Minimal or none' },
+];
+
+export interface ComparisonSummaryRow {
+  feature: string;
+  generic: string;
+  bitnami: string;
+  helmforge: string;
+}
+
+export const comparisonSummary: ComparisonSummaryRow[] = [
+  { feature: 'Container images', generic: 'Often custom-built or wrapped', bitnami: 'Custom-built Bitnami wrappers', helmforge: 'Official upstream images only' },
+  { feature: 'Backup', generic: 'Separate tooling needed', bitnami: 'Varies, prone to breakages', helmforge: 'Built-in S3-compatible via CronJob' },
+  { feature: 'License', generic: 'Varies (some restrictive)', bitnami: 'Proprietary for production secure images', helmforge: 'MIT — open source' },
+  { feature: 'Pricing / Tiering', generic: 'Usually Free', bitnami: 'Free only for deprecated legacy images (requires Sales for production)', helmforge: '100% Free forever' },
+  { feature: 'Database subcharts', generic: 'External dependencies (e.g., Bitnami)', bitnami: 'Self-contained (Bitnami)', helmforge: 'Self-contained HelmForge subcharts' },
+  { feature: 'Values design', generic: 'Kubernetes-centric (containers[].ports)', bitnami: 'Application-centric but complex', helmforge: 'Product-oriented (e.g. database.host)' },
+  { feature: 'Security defaults', generic: 'Varies wildly', bitnami: 'Non-root', helmforge: 'Non-root, tight security contexts' },
+];

--- a/src/data/navigation.ts
+++ b/src/data/navigation.ts
@@ -1,0 +1,53 @@
+export interface NavItem {
+  label: string;
+  href: string;
+}
+
+export const sidebarNav: NavItem[] = [
+  { label: 'Getting Started', href: '/docs/getting-started' },
+  { label: 'Charts Overview', href: '/docs/charts' },
+  { label: 'Stack Examples', href: '/docs/stack-examples' },
+  { label: 'HelmForge vs Other Charts', href: '/docs/comparison' },
+];
+
+export const chartNav: NavItem[] = [
+  { label: 'Generic', href: '/docs/charts/generic' },
+  { label: 'MySQL', href: '/docs/charts/mysql' },
+  { label: 'PostgreSQL', href: '/docs/charts/postgresql' },
+  { label: 'Redis', href: '/docs/charts/redis' },
+  { label: 'MongoDB', href: '/docs/charts/mongodb' },
+  { label: 'RabbitMQ', href: '/docs/charts/rabbitmq' },
+  { label: 'Keycloak', href: '/docs/charts/keycloak' },
+  { label: 'Vaultwarden', href: '/docs/charts/vaultwarden' },
+  { label: 'Minecraft', href: '/docs/charts/minecraft' },
+  { label: 'Pi-hole', href: '/docs/charts/pihole' },
+  { label: 'WordPress', href: '/docs/charts/wordpress' },
+  { label: 'Strapi', href: '/docs/charts/strapi' },
+  { label: 'Answer', href: '/docs/charts/answer' },
+  { label: 'n8n', href: '/docs/charts/n8n' },
+  { label: 'Komga', href: '/docs/charts/komga' },
+  { label: 'Guacamole', href: '/docs/charts/guacamole' },
+  { label: 'Cloudflared', href: '/docs/charts/cloudflared' },
+  { label: 'DDNS Updater', href: '/docs/charts/ddns-updater' },
+  { label: 'Uptime Kuma', href: '/docs/charts/uptime-kuma' },
+  { label: 'Appwrite', href: '/docs/charts/appwrite' },
+  { label: 'Authelia', href: '/docs/charts/authelia' },
+  { label: 'AdGuard Home', href: '/docs/charts/adguard-home' },
+  { label: 'Velero', href: '/docs/charts/velero' },
+  { label: 'Kafka', href: '/docs/charts/kafka' },
+  { label: 'Dolibarr', href: '/docs/charts/dolibarr' },
+  { label: 'Mosquitto', href: '/docs/charts/mosquitto' },
+  { label: 'Docmost', href: '/docs/charts/docmost' },
+  { label: 'Flowise', href: '/docs/charts/flowise' },
+  { label: 'phpMyAdmin', href: '/docs/charts/phpmyadmin' },
+  { label: 'Heimdall', href: '/docs/charts/heimdall' },
+  { label: 'Gitea', href: '/docs/charts/gitea' },
+  { label: 'Homarr', href: '/docs/charts/homarr' },
+  { label: 'MariaDB', href: '/docs/charts/mariadb' },
+];
+
+export const allPages: NavItem[] = [
+  { label: 'Documentation', href: '/docs' },
+  ...sidebarNav,
+  ...chartNav,
+];

--- a/src/layouts/DocsLayout.astro
+++ b/src/layouts/DocsLayout.astro
@@ -2,6 +2,8 @@
 import BaseLayout from './BaseLayout.astro';
 import Header from '../components/Header.astro';
 import Footer from '../components/Footer.astro';
+import Container from '../components/Container.astro';
+import { sidebarNav, chartNav, allPages } from '../data/navigation';
 
 interface Props {
   title: string;
@@ -11,55 +13,6 @@ interface Props {
 const { title, description } = Astro.props.frontmatter || Astro.props;
 
 const currentPath = Astro.url.pathname;
-
-const sidebarNav = [
-  { label: 'Getting Started', href: '/docs/getting-started' },
-  { label: 'Charts Overview', href: '/docs/charts' },
-  { label: 'Stack Examples', href: '/docs/stack-examples' },
-  { label: 'HelmForge vs Other Charts', href: '/docs/comparison' },
-];
-
-const chartNav = [
-  { label: 'Generic', href: '/docs/charts/generic' },
-  { label: 'MySQL', href: '/docs/charts/mysql' },
-  { label: 'PostgreSQL', href: '/docs/charts/postgresql' },
-  { label: 'Redis', href: '/docs/charts/redis' },
-  { label: 'MongoDB', href: '/docs/charts/mongodb' },
-  { label: 'RabbitMQ', href: '/docs/charts/rabbitmq' },
-  { label: 'Keycloak', href: '/docs/charts/keycloak' },
-  { label: 'Vaultwarden', href: '/docs/charts/vaultwarden' },
-  { label: 'Minecraft', href: '/docs/charts/minecraft' },
-  { label: 'Pi-hole', href: '/docs/charts/pihole' },
-  { label: 'WordPress', href: '/docs/charts/wordpress' },
-  { label: 'Strapi', href: '/docs/charts/strapi' },
-  { label: 'Answer', href: '/docs/charts/answer' },
-  { label: 'n8n', href: '/docs/charts/n8n' },
-  { label: 'Komga', href: '/docs/charts/komga' },
-  { label: 'Guacamole', href: '/docs/charts/guacamole' },
-  { label: 'Cloudflared', href: '/docs/charts/cloudflared' },
-  { label: 'DDNS Updater', href: '/docs/charts/ddns-updater' },
-  { label: 'Uptime Kuma', href: '/docs/charts/uptime-kuma' },
-  { label: 'Appwrite', href: '/docs/charts/appwrite' },
-  { label: 'Authelia', href: '/docs/charts/authelia' },
-  { label: 'AdGuard Home', href: '/docs/charts/adguard-home' },
-  { label: 'Velero', href: '/docs/charts/velero' },
-  { label: 'Kafka', href: '/docs/charts/kafka' },
-  { label: 'Dolibarr', href: '/docs/charts/dolibarr' },
-  { label: 'Mosquitto', href: '/docs/charts/mosquitto' },
-  { label: 'Docmost', href: '/docs/charts/docmost' },
-  { label: 'Flowise', href: '/docs/charts/flowise' },
-  { label: 'phpMyAdmin', href: '/docs/charts/phpmyadmin' },
-  { label: 'Heimdall', href: '/docs/charts/heimdall' },
-  { label: 'Gitea', href: '/docs/charts/gitea' },
-  { label: 'Homarr', href: '/docs/charts/homarr' },
-  { label: 'MariaDB', href: '/docs/charts/mariadb' },
-];
-
-const allPages = [
-  { label: 'Documentation', href: '/docs' },
-  ...sidebarNav,
-  ...chartNav,
-];
 
 const currentIndex = allPages.findIndex(p =>
   currentPath.replace(/\/$/, '') === p.href.replace(/\/$/, '')
@@ -85,7 +38,7 @@ function isActive(href: string): boolean {
 <BaseLayout title={title} description={description}>
   <Header />
 
-  <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-6 sm:py-8">
+  <Container class="py-6 sm:py-8">
     <!-- Mobile sidebar toggle -->
     <button
       id="docs-sidebar-toggle"
@@ -235,7 +188,7 @@ function isActive(href: string): boolean {
         </nav>
       </main>
     </div>
-  </div>
+  </Container>
 
   <Footer />
 
@@ -253,34 +206,35 @@ function isActive(href: string): boolean {
       }
 
       // Inject copy buttons into all prose code blocks
-      document.querySelectorAll('.prose-docs pre').forEach(pre => {
-        // Ensure parent 'pre' has the necessary positioning and group classes
-        pre.classList.add('group', 'relative');
-        if (pre.querySelector('.prose-copy-btn')) return;
-        
-        const btn = document.createElement('button');
-        // Usar Tailwind classes puras para garantir consistência e evitar problemas de scope de CSS global
-        btn.className = 'prose-copy-btn absolute top-3 right-3 flex items-center gap-1.5 px-2.5 py-1 text-xs font-medium text-zinc-400 bg-zinc-800/80 backdrop-blur-sm border border-white/10 rounded-md cursor-pointer opacity-0 group-hover:opacity-100 focus:opacity-100 transition-all hover:text-white hover:bg-primary hover:border-primary-light z-10';
-        btn.setAttribute('aria-label', 'Copy code');
-        btn.innerHTML = '<svg width="14" height="14" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z"/></svg><span>Copy</span>';
-        
-        btn.addEventListener('click', async () => {
-          const code = pre.querySelector('code');
-          if (!code) return;
-          try {
-            await navigator.clipboard.writeText(code.textContent || '');
-            btn.querySelector('span').textContent = 'Copied!';
-            btn.querySelector('svg').innerHTML = '<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"/>';
-            btn.classList.add('text-emerald-400', 'border-emerald-500/50');
-            setTimeout(() => {
-              btn.querySelector('span').textContent = 'Copy';
-              btn.querySelector('svg').innerHTML = '<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z"/>';
-              btn.classList.remove('text-emerald-400', 'border-emerald-500/50');
-            }, 2000);
-          } catch (err) { console.error('Copy failed:', err); }
+      if (!window.__proseCopyInit) {
+        window.__proseCopyInit = true;
+        document.querySelectorAll('.prose-docs pre').forEach(pre => {
+          pre.classList.add('group', 'relative');
+          if (pre.querySelector('.prose-copy-btn')) return;
+
+          const btn = document.createElement('button');
+          btn.className = 'prose-copy-btn absolute top-3 right-3 flex items-center gap-1.5 px-2.5 py-1 text-xs font-medium text-zinc-400 bg-zinc-800/80 backdrop-blur-sm border border-white/10 rounded-md cursor-pointer opacity-0 group-hover:opacity-100 focus:opacity-100 transition-all hover:text-white hover:bg-primary hover:border-primary-light z-10';
+          btn.setAttribute('aria-label', 'Copy code');
+          btn.innerHTML = '<svg width="14" height="14" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z"/></svg><span>Copy</span>';
+
+          btn.addEventListener('click', async () => {
+            const code = pre.querySelector('code');
+            if (!code) return;
+            try {
+              await navigator.clipboard.writeText(code.textContent || '');
+              btn.querySelector('span').textContent = 'Copied!';
+              btn.querySelector('svg').innerHTML = '<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"/>';
+              btn.classList.add('text-emerald-400', 'border-emerald-500/50');
+              setTimeout(() => {
+                btn.querySelector('span').textContent = 'Copy';
+                btn.querySelector('svg').innerHTML = '<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z"/>';
+                btn.classList.remove('text-emerald-400', 'border-emerald-500/50');
+              }, 2000);
+            } catch (err) { console.error('Copy failed:', err); }
+          });
+          pre.appendChild(btn);
         });
-        pre.appendChild(btn);
-      });
+      }
     })();
   </script>
 </BaseLayout>


### PR DESCRIPTION
## Summary
- Extract chart catalog, navigation, and comparison data into typed TypeScript modules under `src/data/`
- Create 4 reusable UI components: `Container`, `SectionHeader`, `Badge`, `CopyButton`
- Migrate 11 existing components/layouts to use shared primitives
- Net result: **-376 lines** (108 added, 484 removed)

## New files
- `src/data/charts.ts` — chart catalog, colors, maturity styles (single source for ChartGrid + future consumers)
- `src/data/navigation.ts` — sidebar and chart nav arrays (consumed by DocsLayout)
- `src/data/comparison.ts` — full and summary comparison data (consumed by ComparisonTable + HomeComparison)
- `src/components/Container.astro` — replaces 9 repeated `max-w-7xl mx-auto px-...` patterns
- `src/components/SectionHeader.astro` — replaces 3 duplicated label+heading+description blocks
- `src/components/Badge.astro` — replaces inline maturity/feature badge markup
- `src/components/CopyButton.astro` — unifies 4 separate copy-to-clipboard implementations with event delegation

## Phase
Phase 3 (Component Architecture) of the site refactor backlog.

## Test plan
- [x] `npm run build` passes (47 pages, 9.33s)
- [ ] Visual check: landing page renders identically
- [ ] Visual check: docs pages render identically
- [ ] Copy buttons work across InstallSection, CodeBlock, DocsCopyBlock, and prose code blocks