### PR TITLE
refactor(site): accessibility improvements (wcag 2.1 aa)

### DIFF
--- a/src/components/ChartGrid.astro
+++ b/src/components/ChartGrid.astro
@@ -18,6 +18,7 @@ import { charts, chartCount, backupCount, stableCount, slugColor } from '../data
 
         <!-- Search Input -->
         <div class="mt-8 relative max-w-md group focus-within:ring-0">
+          <label for="chart-search" class="sr-only">Search charts</label>
           <div class="absolute inset-y-0 left-0 pl-4 flex items-center pointer-events-none">
             <Search class="h-5 w-5 text-text-muted transition-colors group-focus-within:text-primary-light" />
           </div>
@@ -27,6 +28,7 @@ import { charts, chartCount, backupCount, stableCount, slugColor } from '../data
             class="block w-full pl-12 pr-4 py-3.5 border border-border rounded-2xl leading-5 bg-bg-surface/80 backdrop-blur-sm text-text-base placeholder-text-muted focus:outline-none focus:ring-2 focus:ring-primary-light focus:border-transparent transition-all sm:text-sm hover:border-border/80 shadow-sm"
             placeholder="Search charts (e.g. postgres, redis, backup)..."
           />
+          <div id="chart-search-status" class="sr-only" aria-live="polite" role="status"></div>
         </div>
       </div>
 
@@ -106,6 +108,7 @@ import { charts, chartCount, backupCount, stableCount, slugColor } from '../data
     const searchInput = document.getElementById('chart-search');
     const chartCards = document.querySelectorAll('.chart-card');
     const emptyState = document.getElementById('chart-empty-state');
+    const searchStatus = document.getElementById('chart-search-status');
 
     if (searchInput) {
       searchInput.addEventListener('input', (e) => {
@@ -128,6 +131,14 @@ import { charts, chartCount, backupCount, stableCount, slugColor } from '../data
           emptyState.classList.remove('hidden');
         } else {
           emptyState.classList.add('hidden');
+        }
+
+        if (searchStatus && term) {
+          searchStatus.textContent = visibleCount === 0
+            ? 'No charts found'
+            : visibleCount + ' chart' + (visibleCount !== 1 ? 's' : '') + ' found';
+        } else if (searchStatus) {
+          searchStatus.textContent = '';
         }
       });
     }

--- a/src/components/ComparisonTable.astro
+++ b/src/components/ComparisonTable.astro
@@ -24,6 +24,7 @@ import { comparisonFull } from '../data/comparison';
     <div class="overflow-hidden rounded-3xl border border-border bg-bg-surface/40 backdrop-blur-sm shadow-2xl shadow-black/50">
       <div class="overflow-x-auto scrollbar-hide">
         <table class="w-full text-sm text-left border-collapse">
+          <caption class="sr-only">Feature comparison between HelmForge, Bitnami, and generic community charts</caption>
           <thead>
             <tr class="border-b border-border/80 bg-bg-surface/80">
               <th class="px-6 py-5 font-semibold text-text-muted w-[20%] uppercase tracking-wider text-xs">Features</th>

--- a/src/components/CopyButton.astro
+++ b/src/components/CopyButton.astro
@@ -25,7 +25,7 @@ const uid = Math.random().toString(36).slice(2, 8);
   <svg class="w-3.5 h-3.5 check-icon hidden" fill="none" stroke="currentColor" viewBox="0 0 24 24">
     <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7" />
   </svg>
-  <span class="copy-text">Copy</span>
+  <span class="copy-text" aria-live="polite">Copy</span>
 </button>
 
 <script is:inline>

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -117,24 +117,34 @@ function isActive(href: string): boolean {
     const iconOpen = document.getElementById('menu-icon-open');
     const iconClose = document.getElementById('menu-icon-close');
 
+    function closeMenu() {
+      menu.style.gridTemplateRows = '0fr';
+      iconOpen.style.opacity = '1';
+      iconOpen.style.transform = 'scale(1)';
+      iconClose.style.opacity = '0';
+      iconClose.style.transform = 'scale(0.5)';
+      toggle.setAttribute('aria-expanded', 'false');
+    }
+
+    function openMenu() {
+      menu.style.gridTemplateRows = '1fr';
+      iconOpen.style.opacity = '0';
+      iconOpen.style.transform = 'scale(0.5)';
+      iconClose.style.opacity = '1';
+      iconClose.style.transform = 'scale(1)';
+      toggle.setAttribute('aria-expanded', 'true');
+    }
+
     if (toggle && menu && iconOpen && iconClose) {
       toggle.addEventListener('click', () => {
         const isExpanded = toggle.getAttribute('aria-expanded') === 'true';
-        
-        toggle.setAttribute('aria-expanded', (!isExpanded).toString());
-        
-        if (!isExpanded) {
-          menu.style.gridTemplateRows = '1fr';
-          iconOpen.style.opacity = '0';
-          iconOpen.style.transform = 'scale(0.5)';
-          iconClose.style.opacity = '1';
-          iconClose.style.transform = 'scale(1)';
-        } else {
-          menu.style.gridTemplateRows = '0fr';
-          iconOpen.style.opacity = '1';
-          iconOpen.style.transform = 'scale(1)';
-          iconClose.style.opacity = '0';
-          iconClose.style.transform = 'scale(0.5)';
+        isExpanded ? closeMenu() : openMenu();
+      });
+
+      document.addEventListener('keydown', (e) => {
+        if (e.key === 'Escape' && toggle.getAttribute('aria-expanded') === 'true') {
+          closeMenu();
+          toggle.focus();
         }
       });
     }

--- a/src/components/HomeComparison.astro
+++ b/src/components/HomeComparison.astro
@@ -19,6 +19,7 @@ import { comparisonSummary } from '../data/comparison';
     <div class="glass-panel rounded-2xl overflow-hidden border border-border shadow-2xl">
       <div class="overflow-x-auto">
         <table class="w-full text-left border-collapse min-w-[800px]">
+          <caption class="sr-only">Summary comparison of HelmForge vs generic charts and Bitnami</caption>
           <thead>
             <tr class="bg-bg-surface border-b border-border">
               <th class="py-5 px-6 font-semibold text-text-muted uppercase tracking-wider text-xs w-1/4">Aspect</th>

--- a/src/components/ThemeToggle.astro
+++ b/src/components/ThemeToggle.astro
@@ -41,14 +41,26 @@
         });
       };
 
+      // Status element for screen reader announcements
+      let statusEl = document.getElementById('theme-status');
+      if (!statusEl) {
+        statusEl = document.createElement('div');
+        statusEl.id = 'theme-status';
+        statusEl.className = 'sr-only';
+        statusEl.setAttribute('role', 'status');
+        statusEl.setAttribute('aria-live', 'polite');
+        document.body.appendChild(statusEl);
+      }
+
       btns.forEach(btn => {
         btn.addEventListener('click', () => {
           const currentTheme = document.documentElement.getAttribute('data-theme');
           const targetTheme = currentTheme === 'light' ? 'dark' : 'light';
-          
+
           document.documentElement.setAttribute('data-theme', targetTheme);
           window.localStorage.setItem('helmforge-theme', targetTheme);
           syncUI();
+          statusEl.textContent = 'Switched to ' + targetTheme + ' mode';
         });
       });
 

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -103,6 +103,9 @@ const fullTitle = title === siteName ? title : `${title} | ${siteName}`;
     </style>
   </head>
   <body class="min-h-screen antialiased">
+    <a href="#main-content" class="sr-only focus:not-sr-only focus:fixed focus:top-4 focus:left-4 focus:z-[200] focus:rounded-lg focus:bg-primary focus:px-4 focus:py-2 focus:text-white focus:text-sm focus:font-bold focus:shadow-lg">
+      Skip to content
+    </a>
     <slot />
   </body>
 </html>

--- a/src/layouts/DocsLayout.astro
+++ b/src/layouts/DocsLayout.astro
@@ -58,19 +58,21 @@ function isActive(href: string): boolean {
       <aside id="docs-sidebar" class="hidden lg:block relative z-10 w-full mb-8">
         <nav class="sticky top-24 space-y-6 rounded-2xl glass-panel p-4 pb-8">
           <!-- Breadcrumbs (desktop) -->
-          <div class="hidden lg:flex flex-wrap items-center gap-1.5 border-b border-border pb-4 text-sm text-text-muted">
-            <a href="/" class="hover:text-primary-light transition-colors">Home</a>
-            {breadcrumbs.map(crumb => (
-              <>
-                <span class="text-text-muted/50">/</span>
-                {crumb.isLast ? (
-                  <span class="text-text-base font-bold">{crumb.label}</span>
-                ) : (
-                  <a href={crumb.href} class="hover:text-primary-light transition-colors">{crumb.label}</a>
-                )}
-              </>
-            ))}
-          </div>
+          <nav aria-label="Breadcrumb" class="hidden lg:block border-b border-border pb-4">
+            <ol class="flex flex-wrap items-center gap-1.5 text-sm text-text-muted">
+              <li><a href="/" class="hover:text-primary-light transition-colors">Home</a></li>
+              {breadcrumbs.map(crumb => (
+                <li class="flex items-center gap-1.5">
+                  <span class="text-text-muted/50" aria-hidden="true">/</span>
+                  {crumb.isLast ? (
+                    <span class="text-text-base font-bold" aria-current="page">{crumb.label}</span>
+                  ) : (
+                    <a href={crumb.href} class="hover:text-primary-light transition-colors">{crumb.label}</a>
+                  )}
+                </li>
+              ))}
+            </ol>
+          </nav>
 
           <div>
             <div class="mb-2 px-2 text-[11px] font-bold uppercase tracking-[0.18em] text-text-muted">Documentation</div>
@@ -84,6 +86,7 @@ function isActive(href: string): boolean {
                       ? 'bg-primary/20 text-primary-light font-bold'
                       : 'text-text-muted hover:bg-text-base/5 hover:text-text-base',
                   ]}
+                  aria-current={isActive('/docs') ? 'page' : undefined}
                 >
                   Overview
                 </a>
@@ -98,6 +101,7 @@ function isActive(href: string): boolean {
                         ? 'bg-primary/20 text-primary-light font-bold'
                         : 'text-text-muted hover:bg-text-base/5 hover:text-text-base',
                     ]}
+                    aria-current={isActive(item.href) ? 'page' : undefined}
                   >
                     {item.label}
                   </a>
@@ -122,6 +126,7 @@ function isActive(href: string): boolean {
                         ? 'bg-primary/20 text-primary-light font-bold'
                         : 'text-text-muted hover:bg-text-base/5 hover:text-text-base',
                     ]}
+                    aria-current={isActive(item.href) ? 'page' : undefined}
                   >
                     {item.label}
                   </a>
@@ -133,21 +138,23 @@ function isActive(href: string): boolean {
       </aside>
 
       <!-- Main content -->
-      <main class="min-w-0">
+      <main id="main-content" class="min-w-0">
         <!-- Breadcrumbs (mobile) -->
-        <div class="mb-6 flex flex-wrap items-center gap-1.5 text-sm text-text-muted lg:hidden">
-          <a href="/" class="hover:text-primary-light transition-colors">Home</a>
-          {breadcrumbs.map(crumb => (
-            <>
-              <span class="text-text-muted/50">/</span>
-              {crumb.isLast ? (
-                <span class="text-text-base font-bold">{crumb.label}</span>
-              ) : (
-                <a href={crumb.href} class="hover:text-primary-light transition-colors">{crumb.label}</a>
-              )}
-            </>
+        <nav aria-label="Breadcrumb" class="mb-6 lg:hidden">
+          <ol class="flex flex-wrap items-center gap-1.5 text-sm text-text-muted">
+            <li><a href="/" class="hover:text-primary-light transition-colors">Home</a></li>
+            {breadcrumbs.map(crumb => (
+              <li class="flex items-center gap-1.5">
+                <span class="text-text-muted/50" aria-hidden="true">/</span>
+                {crumb.isLast ? (
+                  <span class="text-text-base font-bold" aria-current="page">{crumb.label}</span>
+                ) : (
+                  <a href={crumb.href} class="hover:text-primary-light transition-colors">{crumb.label}</a>
+                )}
+              </li>
             ))}
-        </div>
+          </ol>
+        </nav>
 
         <article class="glass-panel rounded-2xl px-5 py-8 sm:px-8 lg:px-10">
           <div class="prose prose-docs max-w-3xl">
@@ -197,11 +204,28 @@ function isActive(href: string): boolean {
       const toggle = document.getElementById('docs-sidebar-toggle');
       const sidebar = document.getElementById('docs-sidebar');
       if (toggle && sidebar) {
+        function closeSidebar() {
+          sidebar.classList.add('hidden');
+          sidebar.classList.remove('block');
+          toggle.setAttribute('aria-expanded', 'false');
+        }
+
         toggle.addEventListener('click', () => {
-          sidebar.classList.toggle('hidden');
-          sidebar.classList.toggle('block');
           const expanded = toggle.getAttribute('aria-expanded') === 'true';
-          toggle.setAttribute('aria-expanded', String(!expanded));
+          if (expanded) {
+            closeSidebar();
+          } else {
+            sidebar.classList.remove('hidden');
+            sidebar.classList.add('block');
+            toggle.setAttribute('aria-expanded', 'true');
+          }
+        });
+
+        document.addEventListener('keydown', (e) => {
+          if (e.key === 'Escape' && toggle.getAttribute('aria-expanded') === 'true') {
+            closeSidebar();
+            toggle.focus();
+          }
         });
       }
 

--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -6,7 +6,7 @@ import Footer from '../components/Footer.astro';
 
 <BaseLayout title="Page Not Found" description="The page you are looking for does not exist.">
   <Header />
-  <main class="flex-1 flex items-center justify-center py-32">
+  <main id="main-content" class="flex-1 flex items-center justify-center py-32">
     <div class="text-center px-4">
       <p class="text-6xl font-extrabold text-primary mb-4">404</p>
       <h1 class="text-2xl sm:text-3xl font-bold text-text-base mb-3">Page not found</h1>

--- a/src/pages/charts.astro
+++ b/src/pages/charts.astro
@@ -10,7 +10,7 @@ import Footer from '../components/Footer.astro';
   description="Browse all HelmForge Helm charts — production-ready, MIT licensed, built on official upstream images."
 >
   <Header />
-  <main>
+  <main id="main-content">
     <ChartGrid />
   </main>
   <Footer />

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -12,7 +12,7 @@ import Footer from '../components/Footer.astro';
   description="Production-ready Helm charts, forged for Kubernetes. Open-source charts built with security, observability, and operational excellence."
 >
   <Header />
-  <main>
+  <main id="main-content">
     <Hero />
     <ChartGrid />
     <ComparisonTable />


### PR DESCRIPTION
## Summary
- Add skip-to-content link visible on focus across all pages
- Add accessible `<label>` and `aria-live` search results announcement for chart search
- Add `aria-live="polite"` to copy button feedback text
- Add Escape key handler to close mobile menu and docs sidebar (returns focus to toggle)
- Convert breadcrumbs from `<div>` to semantic `<nav><ol>` with `aria-label="Breadcrumb"`
- Add `aria-current="page"` to all active sidebar navigation links
- Add `<caption>` to both comparison tables for screen reader context
- Add screen reader announcement on theme toggle ("Switched to dark/light mode")
- Add `id="main-content"` to all `<main>` elements across index, charts, 404, and docs layout

## Phase
Phase 4 (Accessibility — WCAG 2.1 AA) of the site refactor backlog.

## Test plan
- [x] `npm run build` passes (47 pages)
- [ ] Tab through landing page — skip link appears on first Tab press
- [ ] Search charts — VoiceOver/NVDA announces result count
- [ ] Copy button — screen reader announces "Copied!"
- [ ] Escape closes mobile menu and docs sidebar
- [ ] Theme toggle announces mode change to screen reader