### PR TITLE
refactor(site): typography system and docs ux improvements

### DIFF
--- a/src/layouts/DocsLayout.astro
+++ b/src/layouts/DocsLayout.astro
@@ -53,7 +53,7 @@ function isActive(href: string): boolean {
       Menu
     </button>
 
-    <div class="lg:grid lg:grid-cols-[248px_minmax(0,1fr)] lg:gap-12">
+    <div class="lg:grid lg:grid-cols-[248px_minmax(0,1fr)] xl:grid-cols-[248px_minmax(0,1fr)_200px] lg:gap-12">
       <!-- Sidebar -->
       <aside id="docs-sidebar" class="hidden lg:block relative z-10 w-full mb-8">
         <nav class="sticky top-24 space-y-6 rounded-2xl glass-panel p-4 pb-8">
@@ -194,6 +194,14 @@ function isActive(href: string): boolean {
           ) : <span class="hidden sm:block" />}
         </nav>
       </main>
+
+      <!-- Table of Contents (xl screens) -->
+      <aside class="hidden xl:block relative">
+        <nav id="docs-toc" class="toc-nav sticky top-24" aria-label="Table of contents">
+          <div class="mb-3 text-[11px] font-bold uppercase tracking-[0.18em] text-text-muted">On this page</div>
+          <!-- Populated by script from page headings -->
+        </nav>
+      </aside>
     </div>
   </Container>
 
@@ -259,6 +267,40 @@ function isActive(href: string): boolean {
           pre.appendChild(btn);
         });
       }
+    })();
+
+    // Table of Contents generation + scroll spy
+    (() => {
+      const toc = document.getElementById('docs-toc');
+      if (!toc) return;
+      const article = document.querySelector('.prose-docs');
+      if (!article) return;
+
+      const headings = article.querySelectorAll('h2, h3');
+      if (headings.length < 2) { toc.parentElement.style.display = 'none'; return; }
+
+      const links = [];
+      headings.forEach(h => {
+        if (!h.id) h.id = h.textContent.trim().toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/(^-|-$)/g, '');
+        const a = document.createElement('a');
+        a.href = '#' + h.id;
+        a.textContent = h.textContent;
+        a.setAttribute('data-depth', h.tagName === 'H3' ? '3' : '2');
+        toc.appendChild(a);
+        links.push({ el: h, a: a });
+      });
+
+      const observer = new IntersectionObserver(entries => {
+        entries.forEach(entry => {
+          if (entry.isIntersecting) {
+            links.forEach(l => l.a.classList.remove('toc-active'));
+            const match = links.find(l => l.el === entry.target);
+            if (match) match.a.classList.add('toc-active');
+          }
+        });
+      }, { rootMargin: '-80px 0px -70% 0px', threshold: 0 });
+
+      links.forEach(l => observer.observe(l.el));
     })();
   </script>
 </BaseLayout>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -30,6 +30,15 @@
   --font-heading: var(--font-outfit), ui-sans-serif, system-ui, sans-serif;
   --font-mono: var(--font-jetbrains-mono), ui-monospace, monospace;
 
+  /* ===== Type Scale ===== */
+  --text-display: clamp(3rem, 5vw, 4.5rem);
+  --text-h1: clamp(2.25rem, 4vw, 3rem);
+  --text-h2: clamp(1.5rem, 2.5vw, 1.75rem);
+  --text-h3: 1.25rem;
+  --text-body: 1rem;
+  --text-small: 0.875rem;
+  --text-caption: 0.75rem;
+
   /* ===== Transition Speeds ===== */
   --duration-fast: 150ms;
   --duration-normal: 300ms;
@@ -67,12 +76,15 @@ html {
 
 body {
   font-family: var(--font-sans);
+  font-size: var(--text-body);
+  line-height: 1.6;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
 }
 
 h1, h2, h3, h4, h5, h6, .heading-font {
   font-family: var(--font-heading);
+  line-height: 1.2;
 }
 
 code, pre, .font-mono {
@@ -121,27 +133,228 @@ code, pre, .font-mono {
 
 /* ===== Prose (MDX Documentation) ===== */
 
-.prose-docs h1 { font-family: var(--font-heading); font-size: clamp(2.25rem, 4vw, 3rem); font-weight: 800; margin-top: 0; margin-bottom: 1rem; color: var(--color-text-base); }
-.prose-docs h2 { font-family: var(--font-heading); font-size: 1.75rem; font-weight: 700; margin-top: 3rem; margin-bottom: 0.75rem; color: var(--color-text-base); border-bottom: 1px solid var(--color-border); padding-bottom: 0.5rem; }
-.prose-docs h3 { font-family: var(--font-heading); font-size: 1.25rem; font-weight: 600; margin-top: 2rem; margin-bottom: 0.5rem; color: #e4e4e7; }
-.prose-docs p { margin-top: 1rem; margin-bottom: 1rem; line-height: 1.8; color: var(--color-text-muted); }
-.prose-docs a { color: var(--color-primary-light); text-decoration: none; border-bottom: 1px solid rgba(167, 139, 250, 0.4); padding-bottom: 2px; transition: all var(--duration-fast); }
-.prose-docs a:hover { color: var(--color-text-base); border-bottom-color: var(--color-primary-light); }
-.prose-docs ul { list-style-type: disc; padding-left: 1.5rem; margin-top: 0.75rem; margin-bottom: 0.75rem; color: var(--color-text-muted); }
-.prose-docs ol { list-style-type: decimal; padding-left: 1.5rem; margin-top: 0.75rem; margin-bottom: 0.75rem; color: var(--color-text-muted); }
-.prose-docs li { margin-top: 0.25rem; margin-bottom: 0.25rem; line-height: 1.7; }
-.prose-docs code:not(pre code) { background-color: var(--color-bg-surface); padding: 0.125rem 0.375rem; border-radius: var(--radius-sm); font-size: 0.875em; color: var(--color-primary-light); border: 1px solid var(--color-border); }
-.prose-docs pre { background-color: #000; color: #e2e8f0; padding: 1.25rem; border-radius: var(--radius-md); overflow-x: auto; margin-top: 1.5rem; margin-bottom: 1.5rem; font-size: 0.875rem; line-height: 1.7; border: 1px solid var(--color-border); position: relative; }
-.prose-docs pre .prose-copy-btn { position: absolute; top: 0.5rem; right: 0.5rem; display: flex; align-items: center; gap: 0.375rem; padding: 0.25rem 0.5rem; font-size: 0.75rem; font-weight: 500; color: #a1a1aa; background: var(--color-border); border: 1px solid rgba(255,255,255,0.1); border-radius: 0.375rem; cursor: pointer; opacity: 0; transition: opacity var(--duration-fast), color var(--duration-fast), background var(--duration-fast); }
-.prose-docs pre:hover .prose-copy-btn, .prose-docs pre .prose-copy-btn:focus { opacity: 1; }
+.prose-docs h1 {
+  font-family: var(--font-heading);
+  font-size: var(--text-h1);
+  font-weight: 800;
+  letter-spacing: -0.025em;
+  margin-top: 0;
+  margin-bottom: 1rem;
+  color: var(--color-text-base);
+}
+
+.prose-docs h2 {
+  font-family: var(--font-heading);
+  font-size: var(--text-h2);
+  font-weight: 700;
+  letter-spacing: -0.02em;
+  margin-top: 3rem;
+  margin-bottom: 0.75rem;
+  color: var(--color-text-base);
+  border-bottom: 1px solid var(--color-border);
+  padding-bottom: 0.5rem;
+  scroll-margin-top: 6rem;
+}
+
+.prose-docs h3 {
+  font-family: var(--font-heading);
+  font-size: var(--text-h3);
+  font-weight: 600;
+  margin-top: 2rem;
+  margin-bottom: 0.5rem;
+  color: #e4e4e7;
+  scroll-margin-top: 6rem;
+}
+
+.prose-docs p {
+  margin-top: 1rem;
+  margin-bottom: 1rem;
+  line-height: 1.8;
+  color: var(--color-text-muted);
+}
+
+.prose-docs a {
+  color: var(--color-primary-light);
+  text-decoration: none;
+  border-bottom: 1px solid rgba(167, 139, 250, 0.4);
+  padding-bottom: 2px;
+  transition: all var(--duration-fast);
+}
+.prose-docs a:hover {
+  color: var(--color-text-base);
+  border-bottom-color: var(--color-primary-light);
+}
+.prose-docs a[href^="http"]::after,
+.prose-docs a[href^="//"]::after {
+  content: '';
+  display: inline-block;
+  width: 0.75em;
+  height: 0.75em;
+  margin-left: 0.2em;
+  vertical-align: middle;
+  background: currentColor;
+  mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='currentColor' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6'/%3E%3Cpolyline points='15 3 21 3 21 9'/%3E%3Cline x1='10' y1='14' x2='21' y2='3'/%3E%3C/svg%3E");
+  mask-size: contain;
+  mask-repeat: no-repeat;
+  -webkit-mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='currentColor' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6'/%3E%3Cpolyline points='15 3 21 3 21 9'/%3E%3Cline x1='10' y1='14' x2='21' y2='3'/%3E%3C/svg%3E");
+  -webkit-mask-size: contain;
+  -webkit-mask-repeat: no-repeat;
+  opacity: 0.5;
+}
+
+.prose-docs ul {
+  list-style-type: disc;
+  padding-left: 1.5rem;
+  margin-top: 0.75rem;
+  margin-bottom: 0.75rem;
+  color: var(--color-text-muted);
+}
+.prose-docs ol {
+  list-style-type: decimal;
+  padding-left: 1.5rem;
+  margin-top: 0.75rem;
+  margin-bottom: 0.75rem;
+  color: var(--color-text-muted);
+}
+.prose-docs li {
+  margin-top: 0.25rem;
+  margin-bottom: 0.25rem;
+  line-height: 1.7;
+}
+
+.prose-docs code:not(pre code) {
+  background-color: var(--color-bg-surface);
+  padding: 0.125rem 0.375rem;
+  border-radius: var(--radius-sm);
+  font-size: 0.875em;
+  color: var(--color-primary-light);
+  border: 1px solid var(--color-border);
+}
+
+.prose-docs pre {
+  background-color: #000;
+  color: #e2e8f0;
+  padding: 1.25rem;
+  border-radius: var(--radius-md);
+  overflow-x: auto;
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  font-size: var(--text-small);
+  line-height: 1.7;
+  border: 1px solid var(--color-border);
+  position: relative;
+}
+.prose-docs pre .prose-copy-btn {
+  position: absolute;
+  top: 0.5rem;
+  right: 0.5rem;
+  display: flex;
+  align-items: center;
+  gap: 0.375rem;
+  padding: 0.25rem 0.5rem;
+  font-size: var(--text-caption);
+  font-weight: 500;
+  color: #a1a1aa;
+  background: var(--color-border);
+  border: 1px solid rgba(255,255,255,0.1);
+  border-radius: 0.375rem;
+  cursor: pointer;
+  opacity: 0;
+  transition: opacity var(--duration-fast), color var(--duration-fast), background var(--duration-fast);
+}
+.prose-docs pre:hover .prose-copy-btn,
+.prose-docs pre .prose-copy-btn:focus { opacity: 1; }
 .prose-docs pre .prose-copy-btn:hover { color: #fff; background: var(--color-primary); border-color: var(--color-primary-light); }
-.prose-docs pre code { background: none; padding: 0; border-radius: 0; font-size: inherit; color: inherit; border: 0; display: block; padding-right: 4rem; }
-.prose-docs blockquote { border-left: 3px solid var(--color-primary); padding: 1rem 1rem 1rem 1.25rem; margin: 1.5rem 0; color: var(--color-text-muted); font-style: italic; background: rgba(124, 58, 237, 0.05); border-radius: 0 var(--radius-sm) var(--radius-sm) 0; }
-.prose-docs hr { border-color: var(--color-border); margin: 2.5rem 0; }
-.prose-docs table { width: 100%; border-collapse: collapse; margin: 1.5rem 0; font-size: 0.875rem; border: 1px solid var(--color-border); border-radius: var(--radius-sm); overflow: hidden; }
-.prose-docs th { background-color: var(--color-bg-surface); padding: 0.875rem 1rem; text-align: left; font-weight: 600; color: var(--color-text-base); border-bottom: 1px solid var(--color-border); }
-.prose-docs td { padding: 0.875rem 1rem; color: var(--color-text-muted); border-bottom: 1px solid var(--color-border); }
-.prose-docs strong { font-weight: 600; color: var(--color-text-base); }
+.prose-docs pre code {
+  background: none;
+  padding: 0;
+  border-radius: 0;
+  font-size: inherit;
+  color: inherit;
+  border: 0;
+  display: block;
+  padding-right: 4rem;
+}
+
+.prose-docs blockquote {
+  border-left: 3px solid var(--color-primary);
+  padding: 1rem 1rem 1rem 1.25rem;
+  margin: 1.5rem 0;
+  color: var(--color-text-muted);
+  font-style: italic;
+  background: rgba(124, 58, 237, 0.05);
+  border-radius: 0 var(--radius-sm) var(--radius-sm) 0;
+}
+
+.prose-docs hr {
+  border-color: var(--color-border);
+  margin: 2.5rem 0;
+}
+
+.prose-docs table {
+  width: 100%;
+  border-collapse: collapse;
+  margin: 1.5rem 0;
+  font-size: var(--text-small);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  overflow: hidden;
+}
+.prose-docs thead {
+  position: sticky;
+  top: 0;
+  z-index: 1;
+}
+.prose-docs th {
+  background-color: var(--color-bg-surface);
+  padding: 0.875rem 1rem;
+  text-align: left;
+  font-weight: 600;
+  color: var(--color-text-base);
+  border-bottom: 1px solid var(--color-border);
+}
+.prose-docs td {
+  padding: 0.875rem 1rem;
+  color: var(--color-text-muted);
+  border-bottom: 1px solid var(--color-border);
+}
+.prose-docs tbody tr:nth-child(even) {
+  background-color: rgba(255, 255, 255, 0.015);
+}
+.prose-docs tbody tr:hover {
+  background-color: rgba(255, 255, 255, 0.03);
+}
+
+.prose-docs strong {
+  font-weight: 600;
+  color: var(--color-text-base);
+}
+
+/* ===== Table of Contents ===== */
+
+.toc-nav {
+  font-size: var(--text-small);
+}
+.toc-nav a {
+  display: block;
+  padding: 0.25rem 0;
+  color: var(--color-text-muted);
+  text-decoration: none;
+  transition: color var(--duration-fast);
+  border-left: 2px solid transparent;
+  padding-left: 0.75rem;
+}
+.toc-nav a:hover {
+  color: var(--color-text-base);
+}
+.toc-nav a.toc-active {
+  color: var(--color-primary-light);
+  border-left-color: var(--color-primary);
+}
+.toc-nav a[data-depth="3"] {
+  padding-left: 1.5rem;
+  font-size: var(--text-caption);
+}
 
 /* ===== Light Mode ===== */
 
@@ -166,8 +379,11 @@ html[data-theme='light'] .prose-docs h1,
 html[data-theme='light'] .prose-docs h2,
 html[data-theme='light'] .prose-docs h3,
 html[data-theme='light'] .prose-docs strong { color: #09090b; }
+html[data-theme='light'] .prose-docs h3 { color: #27272a; }
 html[data-theme='light'] .prose-docs pre { background-color: #f4f4f5; border-color: #e4e4e7; color: #18181b; }
 html[data-theme='light'] .prose-docs th { background-color: #f4f4f5; color: #09090b; }
+html[data-theme='light'] .prose-docs tbody tr:nth-child(even) { background-color: rgba(0, 0, 0, 0.02); }
+html[data-theme='light'] .prose-docs tbody tr:hover { background-color: rgba(0, 0, 0, 0.04); }
 
 html[data-theme='light'] .glass-panel {
   box-shadow: var(--shadow-card);


### PR DESCRIPTION
## Summary
- Define named type scale tokens (`--text-display` through `--text-caption`) for consistent sizing
- Add `letter-spacing` and `line-height` to heading and body base styles
- Add external link icon (arrow) for prose links pointing outside helmforge.dev
- Improve prose table styling: zebra striping, row hover highlight, sticky `<thead>`
- Add `scroll-margin-top` to h2/h3 for correct anchor scroll offset under sticky header
- Add auto-generated Table of Contents with IntersectionObserver scroll spy on xl docs pages
- ToC shows on xl breakpoint as a third column, hidden on smaller screens
- Add light mode overrides for table zebra striping and h3 color

## Phase
Phase 5 (Typography & Content Hierarchy) of the site refactor backlog.

## Test plan
- [x] `npm run build` passes (47 pages)
- [ ] Visual check: prose headings use consistent fluid sizes
- [ ] Visual check: external links show arrow icon
- [ ] Visual check: tables have zebra striping and sticky header
- [ ] Visual check: ToC appears on xl screens with scroll spy highlighting
- [ ] Visual check: anchor links scroll to correct position below header