### PR TITLE
refactor(site): docs ux with categorized sidebar and structured data

### DIFF
--- a/src/data/navigation.ts
+++ b/src/data/navigation.ts
@@ -3,6 +3,10 @@ export interface NavItem {
   href: string;
 }
 
+export interface ChartNavItem extends NavItem {
+  maturity: 'stable' | 'beta' | 'alpha';
+}
+
 export const sidebarNav: NavItem[] = [
   { label: 'Getting Started', href: '/docs/getting-started' },
   { label: 'Charts Overview', href: '/docs/charts' },
@@ -10,44 +14,113 @@ export const sidebarNav: NavItem[] = [
   { label: 'HelmForge vs Other Charts', href: '/docs/comparison' },
 ];
 
-export const chartNav: NavItem[] = [
-  { label: 'Generic', href: '/docs/charts/generic' },
-  { label: 'MySQL', href: '/docs/charts/mysql' },
-  { label: 'PostgreSQL', href: '/docs/charts/postgresql' },
-  { label: 'Redis', href: '/docs/charts/redis' },
-  { label: 'MongoDB', href: '/docs/charts/mongodb' },
-  { label: 'RabbitMQ', href: '/docs/charts/rabbitmq' },
-  { label: 'Keycloak', href: '/docs/charts/keycloak' },
-  { label: 'Vaultwarden', href: '/docs/charts/vaultwarden' },
-  { label: 'Minecraft', href: '/docs/charts/minecraft' },
-  { label: 'Pi-hole', href: '/docs/charts/pihole' },
-  { label: 'WordPress', href: '/docs/charts/wordpress' },
-  { label: 'Strapi', href: '/docs/charts/strapi' },
-  { label: 'Answer', href: '/docs/charts/answer' },
-  { label: 'n8n', href: '/docs/charts/n8n' },
-  { label: 'Komga', href: '/docs/charts/komga' },
-  { label: 'Guacamole', href: '/docs/charts/guacamole' },
-  { label: 'Cloudflared', href: '/docs/charts/cloudflared' },
-  { label: 'DDNS Updater', href: '/docs/charts/ddns-updater' },
-  { label: 'Uptime Kuma', href: '/docs/charts/uptime-kuma' },
-  { label: 'Appwrite', href: '/docs/charts/appwrite' },
-  { label: 'Authelia', href: '/docs/charts/authelia' },
-  { label: 'AdGuard Home', href: '/docs/charts/adguard-home' },
-  { label: 'Velero', href: '/docs/charts/velero' },
-  { label: 'Kafka', href: '/docs/charts/kafka' },
-  { label: 'Dolibarr', href: '/docs/charts/dolibarr' },
-  { label: 'Mosquitto', href: '/docs/charts/mosquitto' },
-  { label: 'Docmost', href: '/docs/charts/docmost' },
-  { label: 'Flowise', href: '/docs/charts/flowise' },
-  { label: 'phpMyAdmin', href: '/docs/charts/phpmyadmin' },
-  { label: 'Heimdall', href: '/docs/charts/heimdall' },
-  { label: 'Gitea', href: '/docs/charts/gitea' },
-  { label: 'Homarr', href: '/docs/charts/homarr' },
-  { label: 'MariaDB', href: '/docs/charts/mariadb' },
+export interface ChartCategory {
+  label: string;
+  charts: ChartNavItem[];
+}
+
+export const chartCategories: ChartCategory[] = [
+  {
+    label: 'Databases',
+    charts: [
+      { label: 'MySQL', href: '/docs/charts/mysql', maturity: 'stable' },
+      { label: 'PostgreSQL', href: '/docs/charts/postgresql', maturity: 'stable' },
+      { label: 'MongoDB', href: '/docs/charts/mongodb', maturity: 'stable' },
+      { label: 'MariaDB', href: '/docs/charts/mariadb', maturity: 'stable' },
+      { label: 'Redis', href: '/docs/charts/redis', maturity: 'stable' },
+    ],
+  },
+  {
+    label: 'Messaging & Streaming',
+    charts: [
+      { label: 'RabbitMQ', href: '/docs/charts/rabbitmq', maturity: 'stable' },
+      { label: 'Kafka', href: '/docs/charts/kafka', maturity: 'stable' },
+      { label: 'Mosquitto', href: '/docs/charts/mosquitto', maturity: 'stable' },
+    ],
+  },
+  {
+    label: 'CMS & Content',
+    charts: [
+      { label: 'WordPress', href: '/docs/charts/wordpress', maturity: 'stable' },
+      { label: 'Strapi', href: '/docs/charts/strapi', maturity: 'stable' },
+      { label: 'Docmost', href: '/docs/charts/docmost', maturity: 'stable' },
+      { label: 'Komga', href: '/docs/charts/komga', maturity: 'stable' },
+    ],
+  },
+  {
+    label: 'Identity & Security',
+    charts: [
+      { label: 'Keycloak', href: '/docs/charts/keycloak', maturity: 'stable' },
+      { label: 'Vaultwarden', href: '/docs/charts/vaultwarden', maturity: 'stable' },
+      { label: 'Authelia', href: '/docs/charts/authelia', maturity: 'stable' },
+    ],
+  },
+  {
+    label: 'Networking & DNS',
+    charts: [
+      { label: 'Cloudflared', href: '/docs/charts/cloudflared', maturity: 'stable' },
+      { label: 'DDNS Updater', href: '/docs/charts/ddns-updater', maturity: 'stable' },
+      { label: 'Pi-hole', href: '/docs/charts/pihole', maturity: 'stable' },
+      { label: 'AdGuard Home', href: '/docs/charts/adguard-home', maturity: 'stable' },
+    ],
+  },
+  {
+    label: 'Automation & AI',
+    charts: [
+      { label: 'n8n', href: '/docs/charts/n8n', maturity: 'stable' },
+      { label: 'Flowise', href: '/docs/charts/flowise', maturity: 'stable' },
+    ],
+  },
+  {
+    label: 'Monitoring & Ops',
+    charts: [
+      { label: 'Uptime Kuma', href: '/docs/charts/uptime-kuma', maturity: 'stable' },
+      { label: 'Velero', href: '/docs/charts/velero', maturity: 'stable' },
+    ],
+  },
+  {
+    label: 'Dashboards & Admin',
+    charts: [
+      { label: 'Heimdall', href: '/docs/charts/heimdall', maturity: 'stable' },
+      { label: 'Homarr', href: '/docs/charts/homarr', maturity: 'stable' },
+      { label: 'phpMyAdmin', href: '/docs/charts/phpmyadmin', maturity: 'stable' },
+    ],
+  },
+  {
+    label: 'Dev Tools',
+    charts: [
+      { label: 'Gitea', href: '/docs/charts/gitea', maturity: 'stable' },
+      { label: 'Guacamole', href: '/docs/charts/guacamole', maturity: 'stable' },
+      { label: 'Answer', href: '/docs/charts/answer', maturity: 'stable' },
+    ],
+  },
+  {
+    label: 'Platform & ERP',
+    charts: [
+      { label: 'Appwrite', href: '/docs/charts/appwrite', maturity: 'stable' },
+      { label: 'Dolibarr', href: '/docs/charts/dolibarr', maturity: 'stable' },
+      { label: 'Minecraft', href: '/docs/charts/minecraft', maturity: 'stable' },
+      { label: 'Generic', href: '/docs/charts/generic', maturity: 'stable' },
+    ],
+  },
+  {
+    label: 'Alpha',
+    charts: [
+      { label: 'ArchiveBox', href: '/docs/charts/archivebox', maturity: 'alpha' },
+      { label: 'Countly', href: '/docs/charts/countly', maturity: 'alpha' },
+      { label: 'Middleware', href: '/docs/charts/middleware', maturity: 'alpha' },
+      { label: 'Apache Superset', href: '/docs/charts/superset', maturity: 'alpha' },
+      { label: 'CKAN', href: '/docs/charts/ckan', maturity: 'alpha' },
+      { label: 'Apache Druid', href: '/docs/charts/druid', maturity: 'alpha' },
+    ],
+  },
 ];
+
+/** Flat list for prev/next navigation */
+const allChartNavItems: NavItem[] = chartCategories.flatMap(cat => cat.charts);
 
 export const allPages: NavItem[] = [
   { label: 'Documentation', href: '/docs' },
   ...sidebarNav,
-  ...chartNav,
+  ...allChartNavItems,
 ];

--- a/src/layouts/DocsLayout.astro
+++ b/src/layouts/DocsLayout.astro
@@ -3,7 +3,7 @@ import BaseLayout from './BaseLayout.astro';
 import Header from '../components/Header.astro';
 import Footer from '../components/Footer.astro';
 import Container from '../components/Container.astro';
-import { sidebarNav, chartNav, allPages } from '../data/navigation';
+import { sidebarNav, chartCategories, allPages } from '../data/navigation';
 
 interface Props {
   title: string;
@@ -28,6 +28,31 @@ const breadcrumbs = segments.map((seg, i) => ({
   isLast: i === segments.length - 1,
 }));
 
+// Edit on GitHub link
+const pathSlug = currentPath.replace(/\/$/, '').replace(/^\//, '');
+const editUrl = `https://github.com/helmforgedev/site/edit/main/src/pages/${pathSlug || 'index'}.mdx`;
+
+// Breadcrumb JSON-LD
+const breadcrumbJsonLd = {
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "itemListElement": [
+    { "@type": "ListItem", "position": 1, "name": "Home", "item": "https://helmforge.dev/" },
+    ...breadcrumbs.map((crumb, i) => ({
+      "@type": "ListItem",
+      "position": i + 2,
+      "name": crumb.label,
+      ...(crumb.isLast ? {} : { "item": `https://helmforge.dev${crumb.href}` }),
+    })),
+  ],
+};
+
+const maturityDot: Record<string, string> = {
+  stable: 'bg-green-400',
+  beta: 'bg-amber-400',
+  alpha: 'bg-red-400',
+};
+
 function isActive(href: string): boolean {
   const clean = currentPath.replace(/\/$/, '');
   const target = href.replace(/\/$/, '');
@@ -37,6 +62,8 @@ function isActive(href: string): boolean {
 
 <BaseLayout title={title} description={description}>
   <Header />
+
+  <script type="application/ld+json" set:html={JSON.stringify(breadcrumbJsonLd)} />
 
   <Container class="py-6 sm:py-8">
     <!-- Mobile sidebar toggle -->
@@ -56,7 +83,7 @@ function isActive(href: string): boolean {
     <div class="lg:grid lg:grid-cols-[248px_minmax(0,1fr)] xl:grid-cols-[248px_minmax(0,1fr)_200px] lg:gap-12">
       <!-- Sidebar -->
       <aside id="docs-sidebar" class="hidden lg:block relative z-10 w-full mb-8">
-        <nav class="sticky top-24 space-y-6 rounded-2xl glass-panel p-4 pb-8">
+        <nav class="sticky top-24 space-y-5 rounded-2xl glass-panel p-4 pb-8 max-h-[calc(100vh-7rem)] overflow-y-auto">
           <!-- Breadcrumbs (desktop) -->
           <nav aria-label="Breadcrumb" class="hidden lg:block border-b border-border pb-4">
             <ol class="flex flex-wrap items-center gap-1.5 text-sm text-text-muted">
@@ -110,29 +137,36 @@ function isActive(href: string): boolean {
             </ul>
           </div>
 
+          <!-- Categorized charts -->
           <div>
             <div class="mb-2 flex items-center justify-between px-2">
               <div class="text-[11px] font-bold uppercase tracking-[0.18em] text-text-muted">Charts</div>
               <a href="/docs/charts" class="text-[10px] font-medium text-primary hover:text-primary-dark transition-colors uppercase tracking-wider">View all</a>
             </div>
-            <ul class="max-h-[32rem] space-y-1 overflow-y-auto pr-1">
-              {chartNav.map(item => (
-                <li>
-                  <a
-                    href={item.href}
-                    class:list={[
-                      'block rounded-lg px-3 py-2 text-sm transition-colors',
-                      isActive(item.href)
-                        ? 'bg-primary/20 text-primary-light font-bold'
-                        : 'text-text-muted hover:bg-text-base/5 hover:text-text-base',
-                    ]}
-                    aria-current={isActive(item.href) ? 'page' : undefined}
-                  >
-                    {item.label}
-                  </a>
-                </li>
-              ))}
-            </ul>
+            {chartCategories.map(cat => (
+              <div class="mb-3">
+                <div class="px-3 py-1 text-[10px] font-semibold uppercase tracking-[0.14em] text-text-muted/60">{cat.label}</div>
+                <ul class="space-y-0.5">
+                  {cat.charts.map(item => (
+                    <li>
+                      <a
+                        href={item.href}
+                        class:list={[
+                          'flex items-center gap-2 rounded-lg px-3 py-1.5 text-sm transition-colors',
+                          isActive(item.href)
+                            ? 'bg-primary/20 text-primary-light font-bold'
+                            : 'text-text-muted hover:bg-text-base/5 hover:text-text-base',
+                        ]}
+                        aria-current={isActive(item.href) ? 'page' : undefined}
+                      >
+                        <span class={`w-1.5 h-1.5 rounded-full shrink-0 ${maturityDot[item.maturity]}`} title={item.maturity}></span>
+                        {item.label}
+                      </a>
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            ))}
           </div>
         </nav>
       </aside>
@@ -159,6 +193,14 @@ function isActive(href: string): boolean {
         <article class="glass-panel rounded-2xl px-5 py-8 sm:px-8 lg:px-10">
           <div class="prose prose-docs max-w-3xl">
             <slot />
+          </div>
+
+          <!-- Edit on GitHub -->
+          <div class="mt-10 pt-6 border-t border-border flex items-center gap-2 text-sm text-text-muted">
+            <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z" /></svg>
+            <a href={editUrl} target="_blank" rel="noopener noreferrer" class="hover:text-primary-light transition-colors">
+              Edit this page on GitHub
+            </a>
           </div>
         </article>
 
@@ -199,7 +241,6 @@ function isActive(href: string): boolean {
       <aside class="hidden xl:block relative">
         <nav id="docs-toc" class="toc-nav sticky top-24" aria-label="Table of contents">
           <div class="mb-3 text-[11px] font-bold uppercase tracking-[0.18em] text-text-muted">On this page</div>
-          <!-- Populated by script from page headings -->
         </nav>
       </aside>
     </div>


### PR DESCRIPTION
## Summary
- Categorize 39 sidebar chart links into 11 semantic groups (Databases, Messaging, CMS, Identity, Networking, Automation, Monitoring, Dashboards, Dev Tools, Platform, Alpha)
- Add colored maturity dot next to each chart name: green (stable), amber (beta), red (alpha)
- Add "Edit this page on GitHub" link at the bottom of every docs article
- Add BreadcrumbList JSON-LD structured data for Google search results
- Add scrollable sidebar container with `max-height` to prevent overflow on long chart lists

## Phase
Phase 7 (Documentation UX) of the site refactor backlog.

## Test plan
- [x] `npm run build` passes (47 pages)
- [ ] Visual check: sidebar shows charts grouped by category with colored dots
- [ ] Visual check: "Edit this page on GitHub" link at article footer
- [ ] Validate JSON-LD with Google Rich Results Test
- [ ] Visual check: sidebar scrolls independently on pages with many charts