### PR TITLE
refactor(site): light mode polish across all components

### DIFF
--- a/src/components/ComparisonTable.astro
+++ b/src/components/ComparisonTable.astro
@@ -21,7 +21,7 @@ import { comparisonFull } from '../data/comparison';
       </p>
     </div>
 
-    <div class="overflow-hidden rounded-3xl border border-border bg-bg-surface/40 backdrop-blur-sm shadow-2xl shadow-black/50">
+    <div class="comparison-wrapper overflow-hidden rounded-3xl border border-border bg-bg-surface/40 backdrop-blur-sm shadow-2xl shadow-black/50">
       <div class="overflow-x-auto scrollbar-hide">
         <table class="w-full text-sm text-left border-collapse">
           <caption class="sr-only">Feature comparison between HelmForge, Bitnami, and generic community charts</caption>
@@ -40,7 +40,7 @@ import { comparisonFull } from '../data/comparison';
           </thead>
           <tbody class="divide-y divide-border/50">
             {comparisonFull.map((row) => (
-              <tr class="group transition-colors hover:bg-white/[0.02]">
+              <tr class="comparison-row group transition-colors hover:bg-white/[0.02]">
                 <td class="px-6 py-4 font-semibold text-text-base whitespace-nowrap">{row.aspect}</td>
                 <td class="px-6 py-4 text-text-base font-medium bg-primary/[0.02] border-x border-primary/10 group-hover:bg-primary/[0.04] transition-colors">
                   <span class="flex items-start gap-2">

--- a/src/components/Hero.astro
+++ b/src/components/Hero.astro
@@ -9,8 +9,8 @@ import { chartCount, stableCount } from '../data/charts';
   <div class="absolute inset-0 bg-[url('data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMjQiIGhlaWdodD0iMjQiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+PHBhdGggZD0iTTAgMGgyNHYyNEgwem0xIDF2MjJoMjJWMXoiIGZpbGw9InJnYmEoMjU1LDI1NSwyNTUsMC4wMSkiIGZpbGwtcnVsZT0iZXZlbm9kZCIvPjwvc3ZnPg==')] [mask-image:linear-gradient(to_bottom,white,transparent)]"></div>
 
   <!-- Animated Mesh Gradients -->
-  <div class="absolute top-0 right-0 -translate-y-12 translate-x-1/3 w-[800px] h-[600px] bg-primary/20 rounded-full blur-[120px] opacity-50 mix-blend-screen pointer-events-none"></div>
-  <div class="absolute bottom-0 left-0 translate-y-1/3 -translate-x-1/3 w-[600px] h-[600px] bg-accent/15 rounded-full blur-[100px] opacity-40 mix-blend-screen pointer-events-none"></div>
+  <div class="hero-mesh absolute top-0 right-0 -translate-y-12 translate-x-1/3 w-[800px] h-[600px] bg-primary/20 rounded-full blur-[120px] opacity-50 mix-blend-screen pointer-events-none"></div>
+  <div class="hero-mesh absolute bottom-0 left-0 translate-y-1/3 -translate-x-1/3 w-[600px] h-[600px] bg-accent/15 rounded-full blur-[100px] opacity-40 mix-blend-screen pointer-events-none"></div>
 
   <Container class="relative grid grid-cols-1 lg:grid-cols-12 gap-16 lg:gap-8 items-center">
 

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -387,6 +387,7 @@ html[data-theme='light'] .prose-docs tbody tr:hover { background-color: rgba(0, 
 
 html[data-theme='light'] .glass-panel {
   box-shadow: var(--shadow-card);
+  border-color: #d4d4d8;
 }
 
 html[data-theme='light'] .glow-effect::before {
@@ -395,6 +396,72 @@ html[data-theme='light'] .glow-effect::before {
 }
 html[data-theme='light'] .glow-effect:hover::before {
   opacity: 0.6;
+}
+
+/* Light mode: code blocks */
+html[data-theme='light'] .prose-docs code:not(pre code) {
+  background-color: #f4f4f5;
+  color: #6d28d9;
+  border-color: #d4d4d8;
+}
+
+/* Light mode: blockquotes */
+html[data-theme='light'] .prose-docs blockquote {
+  background: rgba(109, 40, 217, 0.04);
+}
+
+/* Light mode: links */
+html[data-theme='light'] .prose-docs a {
+  color: #6d28d9;
+  border-bottom-color: rgba(109, 40, 217, 0.3);
+}
+html[data-theme='light'] .prose-docs a:hover {
+  color: #5b21b6;
+  border-bottom-color: #6d28d9;
+}
+
+/* Light mode: hero mesh gradients */
+html[data-theme='light'] .hero-mesh {
+  mix-blend-mode: multiply;
+  opacity: 0.15;
+}
+
+/* Light mode: comparison table */
+html[data-theme='light'] .comparison-wrapper {
+  shadow: var(--shadow-elevated);
+  box-shadow: 0 8px 30px rgba(0, 0, 0, 0.08);
+}
+html[data-theme='light'] .comparison-row:hover {
+  background-color: rgba(0, 0, 0, 0.02) !important;
+}
+html[data-theme='light'] .comparison-row td[class*="bg-primary"] {
+  background-color: rgba(109, 40, 217, 0.06);
+}
+html[data-theme='light'] .comparison-row:hover td[class*="bg-primary"] {
+  background-color: rgba(109, 40, 217, 0.1);
+}
+html[data-theme='light'] th[class*="bg-primary"] {
+  background-color: rgba(109, 40, 217, 0.08);
+}
+
+/* Light mode: chart cards */
+html[data-theme='light'] .chart-card {
+  background-color: rgba(255, 255, 255, 0.8);
+  border-color: #e4e4e7;
+}
+html[data-theme='light'] .chart-card:hover {
+  box-shadow: 0 12px 40px rgba(109, 40, 217, 0.1);
+  border-color: rgba(109, 40, 217, 0.3);
+}
+
+/* Light mode: stat cards (glass-panel counters) */
+html[data-theme='light'] .glass-panel p.text-3xl {
+  color: var(--color-text-base);
+}
+
+/* Light mode: install code blocks stay dark */
+html[data-theme='light'] .install-panel .bg-slate-900 {
+  background-color: #1e1e2e;
 }
 
 /* ===== Scrollbar ===== */


### PR DESCRIPTION
## Summary
- Fixed hero mesh gradients: switched from `mix-blend-screen` (invisible on white) to `multiply` with reduced opacity in light mode
- Strengthened comparison table HelmForge column highlight (`bg-primary/5` was invisible in light mode)
- Added proper light mode hover states for comparison rows and chart cards
- Polished prose styles: code blocks, links, and blockquotes now use darker purple tones in light mode
- Improved glass-panel border visibility with stronger border color
- Install and hero terminal code blocks stay dark in both themes (intentional)

## Test plan
- [ ] Toggle between dark and light mode on landing page — verify all sections look intentional
- [ ] Check comparison table HelmForge column is visually distinguished in light mode
- [ ] Verify chart cards have visible hover shadows in light mode
- [ ] Check docs pages: code blocks, links, tables, and blockquotes in light mode
- [ ] Confirm hero mesh gradients are subtle but visible in light mode