### PR TITLE
fix(site): update e2e test for dynamic meta keywords

### DIFF
--- a/e2e/hero.spec.ts
+++ b/e2e/hero.spec.ts
@@ -28,7 +28,7 @@ test.describe('Hero Section and SEO validations', () => {
     // Check meta keywords
     const metaKeywords = await page.locator('meta[name="keywords"]').getAttribute('content');
     expect(metaKeywords).toContain('bitnami alternative');
-    expect(metaKeywords).toContain('postgresql');
+    expect(metaKeywords).toContain('helm chart');
 
     // Check JSON-LD
     const jsonLDTags = await page.locator('script[type="application/ld+json"]').all();


### PR DESCRIPTION
## Summary
- E2E test at `e2e/hero.spec.ts:31` expected `'postgresql'` in meta keywords, but Phase 8 changed keywords to derive dynamically from page title
- Home page title is `HelmForge`, so keywords now contain `helmforge` instead of hardcoded chart names
- Updated assertion to check for `'helm chart'` which is always present

## Test plan
- [ ] CI Playwright E2E passes