### PR TITLE
feat(site): add rss feed and future enhancements

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "dependencies": {
         "@astrojs/mdx": "^5.0.2",
+        "@astrojs/rss": "^4.0.18",
         "@astrojs/sitemap": "^3.7.1",
         "@tailwindcss/vite": "^4.2.2",
         "astro": "^6.0.8",
@@ -103,6 +104,17 @@
       },
       "engines": {
         "node": ">=22.12.0"
+      }
+    },
+    "node_modules/@astrojs/rss": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@astrojs/rss/-/rss-4.0.18.tgz",
+      "integrity": "sha512-wc5DwKlbTEdgVAWnHy8krFTeQ42t1v/DJqeq5HtulYK3FYHE4krtRGjoyhS3eXXgfdV6Raoz2RU3wrMTFAitRg==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-xml-parser": "^5.5.7",
+        "piccolore": "^0.1.3",
+        "zod": "^4.3.6"
       }
     },
     "node_modules/@astrojs/sitemap": {
@@ -3195,6 +3207,41 @@
       "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
       "license": "MIT"
     },
+    "node_modules/fast-xml-builder": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.1.4.tgz",
+      "integrity": "sha512-f2jhpN4Eccy0/Uz9csxh3Nu6q4ErKxf0XIsasomfOihuSUa3/xw6w8dnOtCDgEItQFJG8KyXPzQXzcODDrrbOg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "path-expression-matcher": "^1.1.3"
+      }
+    },
+    "node_modules/fast-xml-parser": {
+      "version": "5.5.9",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.5.9.tgz",
+      "integrity": "sha512-jldvxr1MC6rtiZKgrFnDSvT8xuH+eJqxqOBThUVjYrxssYTo1avZLGql5l0a0BAERR01CadYzZ83kVEkbyDg+g==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "fast-xml-builder": "^1.1.4",
+        "path-expression-matcher": "^1.2.0",
+        "strnum": "^2.2.2"
+      },
+      "bin": {
+        "fxparser": "src/cli/cli.js"
+      }
+    },
     "node_modules/fdir": {
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
@@ -5260,6 +5307,21 @@
         "url": "https://github.com/inikulin/parse5?sponsor=1"
       }
     },
+    "node_modules/path-expression-matcher": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.2.0.tgz",
+      "integrity": "sha512-DwmPWeFn+tq7TiyJ2CxezCAirXjFxvaiD03npak3cRjlP9+OjTmSy1EpIrEbh+l6JgUundniloMLDQ/6VTdhLQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/piccolore": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/piccolore/-/piccolore-0.1.3.tgz",
@@ -5967,6 +6029,18 @@
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
       }
+    },
+    "node_modules/strnum": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.2.2.tgz",
+      "integrity": "sha512-DnR90I+jtXNSTXWdwrEy9FakW7UX+qUZg28gj5fk2vxxl7uS/3bpI4fjFYVmdK9etptYBPNkpahuQnEwhwECqA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/style-to-js": {
       "version": "1.1.21",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   },
   "dependencies": {
     "@astrojs/mdx": "^5.0.2",
+    "@astrojs/rss": "^4.0.18",
     "@astrojs/sitemap": "^3.7.1",
     "@tailwindcss/vite": "^4.2.2",
     "astro": "^6.0.8",

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -43,6 +43,11 @@ const year = new Date().getFullYear();
               Helm Repository
             </a>
           </li>
+          <li>
+            <a href="/rss.xml" class="text-text-muted transition-colors hover:text-text-base">
+              RSS Feed
+            </a>
+          </li>
         </ul>
       </div>
     </div>

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -45,6 +45,7 @@ const fullTitle = title === siteName ? title : `${title} | ${siteName}`;
     <link rel="manifest" href="/site.webmanifest" />
     <meta name="theme-color" content="#7c3aed" />
     <link rel="canonical" href={url} />
+    <link rel="alternate" type="application/rss+xml" title="HelmForge Charts" href="/rss.xml" />
 
     <!-- Open Graph -->
     <meta property="og:type" content="website" />

--- a/src/pages/rss.xml.ts
+++ b/src/pages/rss.xml.ts
@@ -1,0 +1,18 @@
+import rss from '@astrojs/rss';
+import type { APIContext } from 'astro';
+import { charts } from '../data/charts';
+
+export function GET(context: APIContext) {
+  return rss({
+    title: 'HelmForge Charts',
+    description:
+      'Production-ready Helm charts for Kubernetes. The open-source alternative to Bitnami.',
+    site: context.site!.toString(),
+    items: charts.map((chart) => ({
+      title: `${chart.name} — ${chart.maturity}`,
+      description: chart.description,
+      link: `/docs/charts/${chart.slug}`,
+    })),
+    customData: '<language>en-us</language>',
+  });
+}


### PR DESCRIPTION
## Summary
- Added `@astrojs/rss` integration with RSS feed at `/rss.xml`
- Feed includes all charts from the catalog with name, maturity, description, and link
- Added `<link rel="alternate">` RSS autodiscovery tag in `<head>`
- Added RSS feed link in footer community section

Phase 11 (Future Enhancements) — RSS feed is the most practical first addition for discoverability and SEO.

## Test plan
- [ ] Verify `/rss.xml` renders valid XML with all charts
- [ ] Verify RSS autodiscovery works in browsers/readers
- [ ] Verify footer RSS link navigates to the feed