### PR TITLE
feat(site): add changelog page and stack builder

### DIFF
--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -26,6 +26,8 @@ const year = new Date().getFullYear();
           <li><a href="/docs/getting-started" class="text-text-muted transition-colors hover:text-text-base">Getting Started</a></li>
           <li><a href="/docs/charts" class="text-text-muted transition-colors hover:text-text-base">Charts</a></li>
           <li><a href="/docs" class="text-text-muted transition-colors hover:text-text-base">Docs Overview</a></li>
+          <li><a href="/stack" class="text-text-muted transition-colors hover:text-text-base">Stack Builder</a></li>
+          <li><a href="/changelog" class="text-text-muted transition-colors hover:text-text-base">Changelog</a></li>
         </ul>
       </div>
 

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -9,6 +9,8 @@ const currentPath = Astro.url.pathname;
 const navItems = [
   { label: 'Home', href: '/' },
   { label: 'Docs', href: '/docs' },
+  { label: 'Stack Builder', href: '/stack' },
+  { label: 'Changelog', href: '/changelog' },
 ];
 
 function isActive(href: string): boolean {

--- a/src/pages/changelog.astro
+++ b/src/pages/changelog.astro
@@ -1,0 +1,118 @@
+---
+import BaseLayout from '../layouts/BaseLayout.astro';
+import Header from '../components/Header.astro';
+import Footer from '../components/Footer.astro';
+import Container from '../components/Container.astro';
+import SectionHeader from '../components/SectionHeader.astro';
+
+interface Release {
+  tag_name: string;
+  name: string;
+  published_at: string;
+  body: string;
+  html_url: string;
+}
+
+let releases: Release[] = [];
+try {
+  const res = await fetch('https://api.github.com/repos/helmforgedev/charts/releases?per_page=50', {
+    headers: { Accept: 'application/vnd.github+json' },
+  });
+  if (res.ok) {
+    releases = await res.json();
+  }
+} catch {
+  // Build continues with empty releases
+}
+
+// Group releases by chart name
+function parseChart(tagName: string) {
+  const match = tagName.match(/^(.+)-v(.+)$/);
+  return match ? { chart: match[1], version: match[2] } : { chart: tagName, version: '' };
+}
+
+function formatDate(iso: string) {
+  return new Date(iso).toLocaleDateString('en-US', {
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric',
+  });
+}
+
+// Simple markdown to HTML for release bodies
+function renderBody(body: string): string {
+  return body
+    .replace(/^### (.+)$/gm, '<h4 class="text-sm font-bold text-text-base mt-3 mb-1">$1</h4>')
+    .replace(/^## (.+)$/gm, '')
+    .replace(/^- (.+)$/gm, '<li class="text-text-muted text-sm leading-relaxed">$1</li>')
+    .replace(/(<li[^>]*>.*<\/li>\n?)+/g, '<ul class="list-disc pl-4 space-y-0.5">$&</ul>')
+    .replace(/\*\*([^*]+)\*\*/g, '<strong class="text-text-base font-semibold">$1</strong>')
+    .replace(/`([^`]+)`/g, '<code class="bg-bg-surface border border-border px-1 py-0.5 rounded text-xs font-mono text-primary-light">$1</code>')
+    .replace(/\n\n/g, '<br>')
+    .trim();
+}
+---
+
+<BaseLayout
+  title="Changelog"
+  description="Release history for all HelmForge Helm charts. Track new features, bug fixes, and breaking changes."
+>
+  <Header />
+  <main id="main-content" class="py-16 sm:py-20">
+    <Container>
+      <SectionHeader
+        label="Changelog"
+        title="What's new in HelmForge charts."
+        description="Every release, automatically documented. Powered by Conventional Commits."
+      />
+
+      {releases.length === 0 && (
+        <div class="mt-12 glass-panel rounded-2xl py-16 text-center">
+          <p class="text-text-muted">Unable to load releases. Check back later or visit
+            <a href="https://github.com/helmforgedev/charts/releases" target="_blank" rel="noopener noreferrer" class="text-primary-light hover:underline">GitHub Releases</a>.
+          </p>
+        </div>
+      )}
+
+      <div class="mt-12 space-y-4">
+        {releases.map((release) => {
+          const { chart, version } = parseChart(release.tag_name);
+          return (
+            <details class="group glass-panel rounded-2xl overflow-hidden transition-all hover:border-primary/30">
+              <summary class="flex items-center gap-4 px-6 py-4 cursor-pointer select-none list-none [&::-webkit-details-marker]:hidden">
+                <div class="flex items-center gap-3 flex-1 min-w-0">
+                  <span class="inline-flex items-center justify-center h-8 w-8 rounded-lg bg-primary/10 text-primary text-xs font-bold shrink-0">
+                    {chart.slice(0, 2).toUpperCase()}
+                  </span>
+                  <div class="min-w-0 flex-1">
+                    <span class="font-bold text-text-base">{chart}</span>
+                    <span class="ml-2 text-sm font-mono text-primary-light">v{version}</span>
+                  </div>
+                </div>
+                <time class="text-xs text-text-muted shrink-0" datetime={release.published_at}>
+                  {formatDate(release.published_at)}
+                </time>
+                <svg class="w-4 h-4 text-text-muted transition-transform group-open:rotate-180 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" />
+                </svg>
+              </summary>
+              <div class="px-6 pb-5 pt-1 border-t border-border/50">
+                <div class="prose-changelog" set:html={renderBody(release.body)} />
+                <a
+                  href={release.html_url}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  class="inline-flex items-center gap-1.5 mt-3 text-xs text-primary-light hover:underline"
+                >
+                  View on GitHub
+                  <svg class="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14" /></svg>
+                </a>
+              </div>
+            </details>
+          );
+        })}
+      </div>
+    </Container>
+  </main>
+  <Footer />
+</BaseLayout>

--- a/src/pages/stack.astro
+++ b/src/pages/stack.astro
@@ -1,0 +1,142 @@
+---
+import BaseLayout from '../layouts/BaseLayout.astro';
+import Header from '../components/Header.astro';
+import Footer from '../components/Footer.astro';
+import Container from '../components/Container.astro';
+import SectionHeader from '../components/SectionHeader.astro';
+import { charts } from '../data/charts';
+
+const stableCharts = charts.filter((c) => c.maturity === 'stable');
+---
+
+<BaseLayout
+  title="Stack Builder"
+  description="Select HelmForge charts and generate a ready-to-use install script for your Kubernetes stack."
+>
+  <Header />
+  <main id="main-content" class="py-16 sm:py-20">
+    <Container>
+      <SectionHeader
+        label="Stack Builder"
+        title="Build your stack in clicks, deploy in seconds."
+        description="Pick the charts you need and get a copy-paste install script."
+      />
+
+      <div class="mt-12 grid grid-cols-1 lg:grid-cols-2 gap-8">
+        <!-- Chart Picker -->
+        <div>
+          <div class="flex items-center justify-between mb-4">
+            <h3 class="text-lg font-bold text-text-base heading-font">Select charts</h3>
+            <span id="stack-count" class="text-xs text-text-muted">0 selected</span>
+          </div>
+
+          <div class="relative mb-4">
+            <input
+              type="search"
+              id="stack-search"
+              class="block w-full pl-4 pr-4 py-2.5 border border-border rounded-xl bg-bg-surface/80 text-text-base placeholder-text-muted focus:outline-none focus:ring-2 focus:ring-primary-light focus:border-transparent text-sm"
+              placeholder="Filter charts..."
+            />
+          </div>
+
+          <div id="stack-chart-list" class="space-y-2 max-h-[480px] overflow-y-auto pr-1">
+            {stableCharts.map((chart) => (
+              <label
+                class="stack-chart-item flex items-center gap-3 rounded-xl border border-border bg-bg-surface/40 px-4 py-3 cursor-pointer transition-all hover:border-primary/40 hover:bg-bg-surface/80 has-[:checked]:border-primary/60 has-[:checked]:bg-primary/5"
+                data-name={chart.slug}
+              >
+                <input
+                  type="checkbox"
+                  name="charts"
+                  value={chart.slug}
+                  class="sr-only stack-checkbox"
+                  data-chart-name={chart.name}
+                  data-chart-slug={chart.slug}
+                />
+                <div class="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg bg-primary/10 text-primary text-xs font-bold">
+                  {chart.name.slice(0, 2).toUpperCase()}
+                </div>
+                <div class="flex-1 min-w-0">
+                  <div class="text-sm font-semibold text-text-base">{chart.name}</div>
+                  <div class="text-xs text-text-muted truncate">{chart.description}</div>
+                </div>
+                <div class="stack-check-icon w-5 h-5 rounded-full border-2 border-border shrink-0 flex items-center justify-center transition-all">
+                  <svg class="w-3 h-3 text-white hidden" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="3" d="M5 13l4 4L19 7" />
+                  </svg>
+                </div>
+              </label>
+            ))}
+          </div>
+        </div>
+
+        <!-- Output -->
+        <div>
+          <div class="flex items-center justify-between mb-4">
+            <h3 class="text-lg font-bold text-text-base heading-font">Install script</h3>
+            <button
+              id="stack-copy-btn"
+              class="text-xs font-medium text-primary-light hover:text-primary transition-colors disabled:opacity-40 disabled:cursor-not-allowed"
+              disabled
+            >
+              Copy to clipboard
+            </button>
+          </div>
+
+          <div class="rounded-2xl border border-border bg-[#1e1e2e] overflow-hidden">
+            <div class="flex items-center px-4 py-2.5 border-b border-white/5 bg-white/5">
+              <div class="flex space-x-1.5">
+                <div class="w-2.5 h-2.5 rounded-full bg-[#ff5f56]"></div>
+                <div class="w-2.5 h-2.5 rounded-full bg-[#ffbd2e]"></div>
+                <div class="w-2.5 h-2.5 rounded-full bg-[#27c93f]"></div>
+              </div>
+              <span class="mx-auto text-[10px] text-zinc-500 font-mono">stack-builder.sh</span>
+            </div>
+            <pre id="stack-output" class="p-5 font-mono text-sm text-zinc-300 leading-relaxed overflow-x-auto min-h-[320px]"><code id="stack-code" class="block"><span class="text-zinc-500"># Select charts on the left to generate your install script</span>
+<span class="text-zinc-500"># Commands will appear here automatically</span></code></pre>
+          </div>
+
+          <div id="stack-empty-hint" class="mt-4 text-sm text-text-muted">
+            Select one or more charts to generate Helm install commands with sensible defaults.
+          </div>
+        </div>
+      </div>
+
+      <!-- Preset Stacks -->
+      <div class="mt-16">
+        <h3 class="text-lg font-bold text-text-base heading-font mb-6">Popular stacks</h3>
+        <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+          <button class="stack-preset glass-panel rounded-2xl p-5 text-left transition-all hover:border-primary/40 hover:-translate-y-0.5" data-charts="postgresql,redis,n8n">
+            <div class="text-sm font-bold text-text-base">Automation Stack</div>
+            <p class="mt-1 text-xs text-text-muted">PostgreSQL + Redis + n8n</p>
+          </button>
+          <button class="stack-preset glass-panel rounded-2xl p-5 text-left transition-all hover:border-primary/40 hover:-translate-y-0.5" data-charts="postgresql,redis,keycloak">
+            <div class="text-sm font-bold text-text-base">Auth Stack</div>
+            <p class="mt-1 text-xs text-text-muted">PostgreSQL + Redis + Keycloak</p>
+          </button>
+          <button class="stack-preset glass-panel rounded-2xl p-5 text-left transition-all hover:border-primary/40 hover:-translate-y-0.5" data-charts="mysql,wordpress,redis">
+            <div class="text-sm font-bold text-text-base">CMS Stack</div>
+            <p class="mt-1 text-xs text-text-muted">MySQL + WordPress + Redis</p>
+          </button>
+          <button class="stack-preset glass-panel rounded-2xl p-5 text-left transition-all hover:border-primary/40 hover:-translate-y-0.5" data-charts="postgresql,gitea,redis">
+            <div class="text-sm font-bold text-text-base">Dev Platform</div>
+            <p class="mt-1 text-xs text-text-muted">PostgreSQL + Gitea + Redis</p>
+          </button>
+          <button class="stack-preset glass-panel rounded-2xl p-5 text-left transition-all hover:border-primary/40 hover:-translate-y-0.5" data-charts="postgresql,redis,flowise">
+            <div class="text-sm font-bold text-text-base">AI Stack</div>
+            <p class="mt-1 text-xs text-text-muted">PostgreSQL + Redis + Flowise</p>
+          </button>
+          <button class="stack-preset glass-panel rounded-2xl p-5 text-left transition-all hover:border-primary/40 hover:-translate-y-0.5" data-charts="pihole,cloudflared,uptime-kuma">
+            <div class="text-sm font-bold text-text-base">Network Stack</div>
+            <p class="mt-1 text-xs text-text-muted">Pi-hole + Cloudflared + Uptime Kuma</p>
+          </button>
+        </div>
+      </div>
+    </Container>
+  </main>
+  <Footer />
+</BaseLayout>
+
+<script>
+  import '../scripts/stack-builder';
+</script>

--- a/src/scripts/stack-builder.ts
+++ b/src/scripts/stack-builder.ts
@@ -1,0 +1,145 @@
+const checkboxes = document.querySelectorAll<HTMLInputElement>('.stack-checkbox');
+const codeEl = document.getElementById('stack-code');
+const countEl = document.getElementById('stack-count');
+const copyBtn = document.getElementById('stack-copy-btn') as HTMLButtonElement | null;
+const hintEl = document.getElementById('stack-empty-hint');
+const searchInput = document.getElementById('stack-search') as HTMLInputElement | null;
+const chartItems = document.querySelectorAll<HTMLElement>('.stack-chart-item');
+const presets = document.querySelectorAll<HTMLButtonElement>('.stack-preset');
+
+function getSelected(): { name: string; slug: string }[] {
+  const selected: { name: string; slug: string }[] = [];
+  checkboxes.forEach((cb) => {
+    if (cb.checked) {
+      selected.push({
+        name: cb.dataset.chartName ?? cb.value,
+        slug: cb.dataset.chartSlug ?? cb.value,
+      });
+    }
+  });
+  return selected;
+}
+
+function generateScript(charts: { name: string; slug: string }[]): string {
+  if (charts.length === 0) {
+    return '<span class="text-zinc-500"># Select charts on the left to generate your install script</span>\n<span class="text-zinc-500"># Commands will appear here automatically</span>';
+  }
+
+  const lines: string[] = [];
+  lines.push('<span class="text-zinc-500">#!/bin/bash</span>');
+  lines.push('<span class="text-zinc-500"># HelmForge Stack — generated at helmforge.dev/stack</span>');
+  lines.push('');
+  lines.push('<span class="text-zinc-500"># Add the HelmForge repository</span>');
+  lines.push('<span class="text-emerald-400">helm</span> repo add helmforge https://repo.helmforge.dev');
+  lines.push('<span class="text-emerald-400">helm</span> repo update');
+  lines.push('');
+  lines.push('<span class="text-zinc-500"># Create namespace</span>');
+  lines.push('<span class="text-emerald-400">kubectl</span> create namespace helmforge --dry-run=client -o yaml | <span class="text-emerald-400">kubectl</span> apply -f -');
+  lines.push('');
+  lines.push('<span class="text-zinc-500"># Install charts</span>');
+
+  charts.forEach((chart) => {
+    lines.push(
+      `<span class="text-emerald-400">helm</span> install ${chart.slug} helmforge/${chart.slug} \\`,
+    );
+    lines.push(`  --namespace helmforge \\`);
+    lines.push(`  --wait --timeout 5m`);
+    lines.push('');
+  });
+
+  lines.push('<span class="text-emerald-400">echo</span> <span class="text-amber-300">"Stack deployed successfully!"</span>');
+
+  return lines.join('\n');
+}
+
+function getPlainScript(charts: { name: string; slug: string }[]): string {
+  if (charts.length === 0) return '';
+  const lines: string[] = [];
+  lines.push('#!/bin/bash');
+  lines.push('# HelmForge Stack — generated at helmforge.dev/stack');
+  lines.push('');
+  lines.push('# Add the HelmForge repository');
+  lines.push('helm repo add helmforge https://repo.helmforge.dev');
+  lines.push('helm repo update');
+  lines.push('');
+  lines.push('# Create namespace');
+  lines.push('kubectl create namespace helmforge --dry-run=client -o yaml | kubectl apply -f -');
+  lines.push('');
+  lines.push('# Install charts');
+
+  charts.forEach((chart) => {
+    lines.push(`helm install ${chart.slug} helmforge/${chart.slug} \\`);
+    lines.push(`  --namespace helmforge \\`);
+    lines.push(`  --wait --timeout 5m`);
+    lines.push('');
+  });
+
+  lines.push('echo "Stack deployed successfully!"');
+  return lines.join('\n');
+}
+
+function update() {
+  const selected = getSelected();
+  if (codeEl) codeEl.innerHTML = generateScript(selected);
+  if (countEl) countEl.textContent = `${selected.length} selected`;
+  if (copyBtn) copyBtn.disabled = selected.length === 0;
+  if (hintEl) hintEl.style.display = selected.length > 0 ? 'none' : '';
+
+  // Update check icons
+  checkboxes.forEach((cb) => {
+    const label = cb.closest('label');
+    if (!label) return;
+    const icon = label.querySelector('.stack-check-icon');
+    const svg = icon?.querySelector('svg');
+    if (!icon || !svg) return;
+    if (cb.checked) {
+      icon.classList.add('bg-primary', 'border-primary');
+      icon.classList.remove('border-border');
+      svg.classList.remove('hidden');
+    } else {
+      icon.classList.remove('bg-primary', 'border-primary');
+      icon.classList.add('border-border');
+      svg.classList.add('hidden');
+    }
+  });
+}
+
+checkboxes.forEach((cb) => cb.addEventListener('change', update));
+
+// Copy
+if (copyBtn) {
+  copyBtn.addEventListener('click', async () => {
+    const selected = getSelected();
+    const text = getPlainScript(selected);
+    if (!text) return;
+    try {
+      await navigator.clipboard.writeText(text);
+      copyBtn.textContent = 'Copied!';
+      setTimeout(() => (copyBtn.textContent = 'Copy to clipboard'), 2000);
+    } catch {
+      // Fallback
+    }
+  });
+}
+
+// Search filter
+if (searchInput) {
+  searchInput.addEventListener('input', () => {
+    const term = searchInput.value.toLowerCase().trim();
+    chartItems.forEach((item) => {
+      const name = item.dataset.name ?? '';
+      item.style.display = name.includes(term) ? '' : 'none';
+    });
+  });
+}
+
+// Preset stacks
+presets.forEach((preset) => {
+  preset.addEventListener('click', () => {
+    const slugs = (preset.dataset.charts ?? '').split(',');
+    checkboxes.forEach((cb) => {
+      cb.checked = slugs.includes(cb.value);
+    });
+    update();
+  });
+});


### PR DESCRIPTION
## Summary
- **Changelog** (`/changelog`): Fetches all GitHub Releases from `helmforgedev/charts` at build time, renders as expandable cards with chart name, version, date, and formatted release notes
- **Stack Builder** (`/stack`): Interactive page where users select charts via checkboxes, generates a copy-paste `helm install` shell script. Includes 6 preset stacks (Automation, Auth, CMS, Dev Platform, AI, Network)
- Both pages added to Header nav and Footer links

## Test plan
- [ ] `/changelog` shows release entries with correct chart names and versions
- [ ] Release cards expand/collapse to show release notes
- [ ] `/stack` chart selection generates correct helm install commands
- [ ] Copy to clipboard works on the stack builder
- [ ] Preset stack buttons select the right charts
- [ ] Search filter works on the chart picker
- [ ] Both pages render correctly in dark and light mode