### PR TITLE
feat(site): add request a chart page with github issue integration

### DIFF
--- a/src/components/ChartGrid.astro
+++ b/src/components/ChartGrid.astro
@@ -103,6 +103,17 @@ import { charts, chartCount, backupCount, stableCount, slugColor, chartIcon } fr
         </a>
       ))}
     </div>
+
+    <!-- Request CTA -->
+    <div class="mt-10 flex justify-center">
+      <a
+        href="/request"
+        class="group inline-flex items-center gap-2 rounded-full border border-border bg-bg-surface px-6 py-3 text-sm font-semibold text-text-base transition-all hover:border-primary/50 hover:text-primary-light hover:shadow-lg hover:shadow-primary/10"
+      >
+        Don't see your app? Request a chart
+        <svg class="w-4 h-4 transition-transform group-hover:translate-x-1" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 7l5 5m0 0l-5 5m5-5H6" /></svg>
+      </a>
+    </div>
   </Container>
 </section>
 

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -10,6 +10,7 @@ const navItems = [
   { label: 'Home', href: '/' },
   { label: 'Docs', href: '/docs' },
   { label: 'Stack Builder', href: '/stack' },
+  { label: 'Request', href: '/request' },
   { label: 'Changelog', href: '/changelog' },
 ];
 

--- a/src/pages/request.astro
+++ b/src/pages/request.astro
@@ -1,0 +1,150 @@
+---
+import BaseLayout from '../layouts/BaseLayout.astro';
+import Header from '../components/Header.astro';
+import Footer from '../components/Footer.astro';
+import Container from '../components/Container.astro';
+import SectionHeader from '../components/SectionHeader.astro';
+
+// Fetch existing chart-request issues at build time
+interface GHIssue {
+  title: string;
+  html_url: string;
+  reactions: { total_count: number; '+1': number };
+  labels: { name: string }[];
+  created_at: string;
+}
+
+let requests: GHIssue[] = [];
+try {
+  const res = await fetch(
+    'https://api.github.com/repos/helmforgedev/charts/issues?labels=chart-request&state=open&per_page=20&sort=reactions-%2B1&direction=desc',
+    { headers: { Accept: 'application/vnd.github+json' } },
+  );
+  if (res.ok) requests = await res.json();
+} catch {
+  // Build continues without requests
+}
+---
+
+<BaseLayout
+  title="Request a Chart"
+  description="Suggest a new Helm chart for HelmForge. Community-driven priorities — the most upvoted requests get built first."
+>
+  <Header />
+  <main id="main-content" class="py-16 sm:py-20">
+    <Container maxWidth="6xl">
+      <SectionHeader
+        label="Community"
+        title={'Missing a chart? <span class="bg-gradient-to-r from-primary-light to-accent bg-clip-text text-transparent">Request it.</span>'}
+        description="Suggest a chart and the community votes. The most requested apps get built first."
+      />
+
+      <!-- Request Form -->
+      <div class="mt-12 max-w-2xl mx-auto">
+        <div class="glass-panel rounded-2xl p-8">
+          <h3 class="text-lg font-bold text-text-base heading-font mb-6">Submit a chart request</h3>
+
+          <form id="request-form" class="space-y-5">
+            <div>
+              <label for="chart-name" class="block text-sm font-medium text-text-base mb-1.5">Application name</label>
+              <input
+                type="text"
+                id="chart-name"
+                required
+                placeholder="e.g. Grafana, Minio, Loki"
+                class="block w-full px-4 py-2.5 border border-border rounded-xl bg-bg-surface/80 text-text-base placeholder-text-muted focus:outline-none focus:ring-2 focus:ring-primary-light focus:border-transparent text-sm"
+              />
+            </div>
+
+            <div>
+              <label for="project-url" class="block text-sm font-medium text-text-base mb-1.5">Upstream project URL</label>
+              <input
+                type="url"
+                id="project-url"
+                required
+                placeholder="https://github.com/org/project"
+                class="block w-full px-4 py-2.5 border border-border rounded-xl bg-bg-surface/80 text-text-base placeholder-text-muted focus:outline-none focus:ring-2 focus:ring-primary-light focus:border-transparent text-sm"
+              />
+            </div>
+
+            <div>
+              <label for="reason" class="block text-sm font-medium text-text-base mb-1.5">Why should HelmForge include this?</label>
+              <textarea
+                id="reason"
+                rows="3"
+                placeholder="e.g. Popular self-hosted app, no good Helm chart exists, would benefit from S3 backups..."
+                class="block w-full px-4 py-2.5 border border-border rounded-xl bg-bg-surface/80 text-text-base placeholder-text-muted focus:outline-none focus:ring-2 focus:ring-primary-light focus:border-transparent text-sm resize-y"
+              ></textarea>
+            </div>
+
+            <button
+              type="submit"
+              class="inline-flex items-center gap-2 rounded-xl bg-primary px-6 py-3 text-sm font-bold text-white transition-all hover:bg-primary-dark hover:shadow-lg hover:shadow-primary/20"
+            >
+              <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v3m0 0v3m0-3h3m-3 0H9m12 0a9 9 0 11-18 0 9 9 0 0118 0z" /></svg>
+              Open GitHub Issue
+            </button>
+
+            <p class="text-xs text-text-muted">
+              This will open a pre-filled issue on the <a href="https://github.com/helmforgedev/charts" target="_blank" rel="noopener noreferrer" class="text-primary-light hover:underline">helmforgedev/charts</a> repository. You'll need a GitHub account.
+            </p>
+          </form>
+        </div>
+      </div>
+
+      <!-- Existing Requests -->
+      {requests.length > 0 && (
+        <div class="mt-16">
+          <h3 class="text-lg font-bold text-text-base heading-font mb-2">Open requests</h3>
+          <p class="text-sm text-text-muted mb-6">Upvote with a reaction on GitHub to help prioritize.</p>
+
+          <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+            {requests.map((issue) => (
+              <a
+                href={issue.html_url}
+                target="_blank"
+                rel="noopener noreferrer"
+                class="glass-panel rounded-xl p-5 transition-all hover:border-primary/30 hover:-translate-y-0.5 hover:shadow-lg group"
+              >
+                <div class="flex items-start justify-between gap-3">
+                  <h4 class="text-sm font-bold text-text-base group-hover:text-primary-light transition-colors line-clamp-2">
+                    {issue.title.replace(/^\[chart-request\]\s*/i, '')}
+                  </h4>
+                  <span class="flex items-center gap-1 shrink-0 text-xs font-bold text-primary-light bg-primary/10 rounded-full px-2 py-0.5">
+                    👍 {issue.reactions['+1']}
+                  </span>
+                </div>
+                <time class="mt-2 block text-xs text-text-muted">
+                  {new Date(issue.created_at).toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' })}
+                </time>
+              </a>
+            ))}
+          </div>
+        </div>
+      )}
+    </Container>
+  </main>
+  <Footer />
+</BaseLayout>
+
+<script>
+  const form = document.getElementById('request-form') as HTMLFormElement | null;
+  if (form) {
+    form.addEventListener('submit', (e) => {
+      e.preventDefault();
+      const name = (document.getElementById('chart-name') as HTMLInputElement).value.trim();
+      const url = (document.getElementById('project-url') as HTMLInputElement).value.trim();
+      const reason = (document.getElementById('reason') as HTMLTextAreaElement).value.trim();
+
+      const title = encodeURIComponent(`[chart-request] ${name}`);
+      const body = encodeURIComponent(
+        `## Chart Request\n\n**Application:** ${name}\n**Upstream URL:** ${url}\n\n**Reason:**\n${reason || 'N/A'}\n\n---\n_Submitted from helmforge.dev/request_`
+      );
+
+      window.open(
+        `https://github.com/helmforgedev/charts/issues/new?title=${title}&body=${body}&labels=chart-request`,
+        '_blank',
+      );
+    });
+  }
+</script>


### PR DESCRIPTION
## Summary
- New `/request` page with form: app name, upstream URL, reason
- Form generates pre-filled GitHub Issue URL (no backend needed)
- Fetches existing `chart-request` labeled issues at build time
- Shows community requests with upvote counts
- Added "Request" link to header nav
- Added "Don't see your app? Request a chart" CTA to chart grid