### PR TITLE
feat(site): landing page content polish with ecosystem logos

### DIFF
--- a/src/components/ComparisonTable.astro
+++ b/src/components/ComparisonTable.astro
@@ -14,10 +14,10 @@ import { comparisonFull } from '../data/comparison';
         <Scale class="w-6 h-6" />
       </div>
       <h2 class="text-3xl sm:text-4xl lg:text-5xl font-bold tracking-tight text-text-base heading-font">
-        The Open-Source Standard
+        Side-by-side: HelmForge vs the rest.
       </h2>
       <p class="mt-5 text-lg text-text-muted leading-relaxed">
-        Official images, no vendor lock-in, MIT licensed. HelmForge provides a premium experience without enterprise paywalls.
+        Official images, no vendor lock-in, MIT licensed. See exactly where HelmForge leads.
       </p>
     </div>
 

--- a/src/components/EcosystemLogos.astro
+++ b/src/components/EcosystemLogos.astro
@@ -1,0 +1,26 @@
+---
+import Container from './Container.astro';
+
+const logos = [
+  { name: 'Kubernetes', svg: '<svg viewBox="0 0 32 32" fill="currentColor"><path d="M15.9.5a2 2 0 0 0-.7.2L3.6 6.4a2 2 0 0 0-1 1.2L.1 20a2 2 0 0 0 .3 1.5l8 10.4a2 2 0 0 0 1.3.6h12.6a2 2 0 0 0 1.3-.6l8-10.4a2 2 0 0 0 .3-1.5l-2.5-12.4a2 2 0 0 0-1-1.2L16.7.7a2 2 0 0 0-.8-.2zm0 3l.2.1 9.1 4.5.2.2 2 9.7v.3l-6.3 8h-.2H11h-.2l-6.3-8v-.3l2-9.7.2-.2L15.8 3.5h.1zM16 9a1 1 0 0 0-.5.2l-4.4 3a1 1 0 0 0-.4.6L9.6 17a1 1 0 0 0 .2.8l3.1 3.7a1 1 0 0 0 .8.3h4.6a1 1 0 0 0 .8-.3l3.1-3.7a1 1 0 0 0 .2-.8l-1.1-4.2a1 1 0 0 0-.4-.6l-4.4-3A1 1 0 0 0 16 9z"/></svg>' },
+  { name: 'Helm', svg: '<svg viewBox="0 0 32 32" fill="currentColor"><circle cx="16" cy="16" r="14" fill="none" stroke="currentColor" stroke-width="2"/><path d="M16 6v20M10 10l12 12M10 22l12-12" stroke="currentColor" stroke-width="2" stroke-linecap="round"/></svg>' },
+  { name: 'Traefik', svg: '<svg viewBox="0 0 32 32" fill="currentColor"><rect x="4" y="8" width="24" height="4" rx="1"/><rect x="4" y="14" width="24" height="4" rx="1"/><rect x="4" y="20" width="24" height="4" rx="1"/><circle cx="8" cy="10" r="1.5" fill="white"/><circle cx="8" cy="16" r="1.5" fill="white"/><circle cx="8" cy="22" r="1.5" fill="white"/></svg>' },
+  { name: 'cert-manager', svg: '<svg viewBox="0 0 32 32" fill="currentColor"><path d="M16 2l12 6v8c0 7-5 13-12 15C9 29 4 23 4 16V8l12-6z" fill="none" stroke="currentColor" stroke-width="2"/><path d="M12 16l3 3 6-6" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/></svg>' },
+  { name: 'MinIO', svg: '<svg viewBox="0 0 32 32" fill="currentColor"><rect x="3" y="6" width="26" height="20" rx="3" fill="none" stroke="currentColor" stroke-width="2"/><circle cx="10" cy="16" r="3" fill="none" stroke="currentColor" stroke-width="1.5"/><circle cx="22" cy="16" r="3" fill="none" stroke="currentColor" stroke-width="1.5"/><line x1="13" y1="16" x2="19" y2="16" stroke="currentColor" stroke-width="1.5"/></svg>' },
+  { name: 'Docker', svg: '<svg viewBox="0 0 32 32" fill="currentColor"><rect x="14" y="7" width="4" height="4" rx="0.5"/><rect x="14" y="12" width="4" height="4" rx="0.5"/><rect x="9" y="12" width="4" height="4" rx="0.5"/><rect x="4" y="12" width="4" height="4" rx="0.5"/><rect x="19" y="12" width="4" height="4" rx="0.5"/><rect x="9" y="7" width="4" height="4" rx="0.5"/><path d="M2 18c1 4 5 8 14 8s12-4 12-8" fill="none" stroke="currentColor" stroke-width="2"/></svg>' },
+];
+---
+
+<section class="py-12 border-t border-border/50">
+  <Container>
+    <p class="text-center text-xs font-bold uppercase tracking-[0.2em] text-text-muted mb-8">Works with the tools you already use</p>
+    <div class="flex flex-wrap items-center justify-center gap-8 sm:gap-12 opacity-50 hover:opacity-70 transition-opacity">
+      {logos.map((logo) => (
+        <div class="flex items-center gap-2 text-text-muted" title={logo.name}>
+          <span class="w-6 h-6" set:html={logo.svg} />
+          <span class="text-sm font-medium hidden sm:inline">{logo.name}</span>
+        </div>
+      ))}
+    </div>
+  </Container>
+</section>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -6,6 +6,7 @@ import InstallSection from '../components/InstallSection.astro';
 import Features from '../components/Features.astro';
 import ChartGrid from '../components/ChartGrid.astro';
 import ComparisonTable from '../components/ComparisonTable.astro';
+import EcosystemLogos from '../components/EcosystemLogos.astro';
 import Footer from '../components/Footer.astro';
 ---
 
@@ -20,6 +21,7 @@ import Footer from '../components/Footer.astro';
     <Features />
     <ChartGrid />
     <ComparisonTable />
+    <EcosystemLogos />
   </main>
   <Footer />
 </BaseLayout>


### PR DESCRIPTION
## Summary
- Added "Works with" ecosystem logo row: Kubernetes, Helm, Traefik, cert-manager, MinIO, Docker
- Improved comparison table heading to "Side-by-side: HelmForge vs the rest."
- Ecosystem section placed between comparison table and footer as trust signal