### PR TITLE
feat(site): add pagefind documentation search with cmd+k modal

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -14,6 +14,7 @@ export default defineConfig({
     plugins: [tailwindcss()],
     build: {
       rollupOptions: {
+        external: ['/pagefind/pagefind.js'],
         onwarn(warning, defaultHandler) {
           if (warning.code === 'UNUSED_EXTERNAL_IMPORT') return;
           defaultHandler(warning);

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,8 @@
         "tailwindcss": "^4.2.2"
       },
       "devDependencies": {
-        "@playwright/test": "^1.59.1"
+        "@playwright/test": "^1.59.1",
+        "pagefind": "^1.4.0"
       },
       "engines": {
         "node": ">=22.0.0"
@@ -1247,6 +1248,90 @@
       "funding": {
         "url": "https://github.com/sponsors/Boshen"
       }
+    },
+    "node_modules/@pagefind/darwin-arm64": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@pagefind/darwin-arm64/-/darwin-arm64-1.4.0.tgz",
+      "integrity": "sha512-2vMqkbv3lbx1Awea90gTaBsvpzgRs7MuSgKDxW0m9oV1GPZCZbZBJg/qL83GIUEN2BFlY46dtUZi54pwH+/pTQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@pagefind/darwin-x64": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@pagefind/darwin-x64/-/darwin-x64-1.4.0.tgz",
+      "integrity": "sha512-e7JPIS6L9/cJfow+/IAqknsGqEPjJnVXGjpGm25bnq+NPdoD3c/7fAwr1OXkG4Ocjx6ZGSCijXEV4ryMcH2E3A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@pagefind/freebsd-x64": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@pagefind/freebsd-x64/-/freebsd-x64-1.4.0.tgz",
+      "integrity": "sha512-WcJVypXSZ+9HpiqZjFXMUobfFfZZ6NzIYtkhQ9eOhZrQpeY5uQFqNWLCk7w9RkMUwBv1HAMDW3YJQl/8OqsV0Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@pagefind/linux-arm64": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@pagefind/linux-arm64/-/linux-arm64-1.4.0.tgz",
+      "integrity": "sha512-PIt8dkqt4W06KGmQjONw7EZbhDF+uXI7i0XtRLN1vjCUxM9vGPdtJc2mUyVPevjomrGz5M86M8bqTr6cgDp1Uw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@pagefind/linux-x64": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@pagefind/linux-x64/-/linux-x64-1.4.0.tgz",
+      "integrity": "sha512-z4oddcWwQ0UHrTHR8psLnVlz6USGJ/eOlDPTDYZ4cI8TK8PgwRUPQZp9D2iJPNIPcS6Qx/E4TebjuGJOyK8Mmg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@pagefind/windows-x64": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@pagefind/windows-x64/-/windows-x64-1.4.0.tgz",
+      "integrity": "sha512-NkT+YAdgS2FPCn8mIA9bQhiBs+xmniMGq1LFPDhcFn0+2yIUEiIG06t7bsZlhdjknEQRTSdT7YitP6fC5qwP0g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
     },
     "node_modules/@playwright/test": {
       "version": "1.59.1",
@@ -5250,6 +5335,24 @@
       "resolved": "https://registry.npmjs.org/package-manager-detector/-/package-manager-detector-1.6.0.tgz",
       "integrity": "sha512-61A5ThoTiDG/C8s8UMZwSorAGwMJ0ERVGj2OjoW5pAalsNOg15+iQiPzrLJ4jhZ1HJzmC2PIHT2oEiH3R5fzNA==",
       "license": "MIT"
+    },
+    "node_modules/pagefind": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/pagefind/-/pagefind-1.4.0.tgz",
+      "integrity": "sha512-z2kY1mQlL4J8q5EIsQkLzQjilovKzfNVhX8De6oyE6uHpfFtyBaqUpcl/XzJC/4fjD8vBDyh1zolimIcVrCn9g==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "pagefind": "lib/runner/bin.cjs"
+      },
+      "optionalDependencies": {
+        "@pagefind/darwin-arm64": "1.4.0",
+        "@pagefind/darwin-x64": "1.4.0",
+        "@pagefind/freebsd-x64": "1.4.0",
+        "@pagefind/linux-arm64": "1.4.0",
+        "@pagefind/linux-x64": "1.4.0",
+        "@pagefind/windows-x64": "1.4.0"
+      }
     },
     "node_modules/parse-entities": {
       "version": "4.0.2",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   },
   "scripts": {
     "dev": "astro dev",
-    "build": "astro build",
+    "build": "astro build && pagefind --site dist",
     "preview": "astro preview",
     "astro": "astro"
   },
@@ -21,6 +21,7 @@
     "tailwindcss": "^4.2.2"
   },
   "devDependencies": {
-    "@playwright/test": "^1.59.1"
+    "@playwright/test": "^1.59.1",
+    "pagefind": "^1.4.0"
   }
 }

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -2,7 +2,7 @@
 import ThemeToggle from './ThemeToggle.astro';
 import Logo from './Logo.astro';
 import Container from './Container.astro';
-import { Github, Menu, X } from 'lucide-astro';
+import { Github, Menu, X, Search } from 'lucide-astro';
 
 const currentPath = Astro.url.pathname;
 
@@ -47,6 +47,16 @@ function isActive(href: string): boolean {
           </a>
         ))}
         <div class="h-5 w-px bg-border mx-2"></div>
+        <button
+          id="search-trigger"
+          class="flex items-center gap-2 rounded-full px-3 py-2 text-sm font-medium text-text-muted transition-all hover:bg-text-base/5 hover:text-text-base"
+          aria-label="Search documentation (Ctrl+K)"
+        >
+          <Search class="w-4 h-4" />
+          <span class="text-xs text-text-muted/60 hidden lg:inline-flex items-center gap-0.5 border border-border rounded-md px-1.5 py-0.5 font-mono">
+            <span class="text-[10px]" id="search-mod-key">Ctrl</span>K
+          </span>
+        </button>
         <a
           href="https://github.com/helmforgedev/charts"
           target="_blank"
@@ -63,6 +73,13 @@ function isActive(href: string): boolean {
 
       <!-- Mobile controls -->
       <div class="flex items-center gap-3 md:hidden">
+        <button
+          id="search-trigger-mobile"
+          class="flex items-center justify-center w-10 h-10 rounded-full border border-border bg-bg-surface text-text-muted transition-colors hover:bg-text-base/5 hover:text-text-base"
+          aria-label="Search documentation"
+        >
+          <Search class="w-4 h-4" />
+        </button>
         <ThemeToggle />
         
         <button
@@ -115,6 +132,25 @@ function isActive(href: string): boolean {
 
 <script>
   document.addEventListener('DOMContentLoaded', () => {
+    // Search triggers
+    const searchBtn = document.getElementById('search-trigger');
+    const searchBtnMobile = document.getElementById('search-trigger-mobile');
+    const modKey = document.getElementById('search-mod-key');
+
+    // Show Cmd on macOS, Ctrl elsewhere
+    if (modKey && navigator.platform?.includes('Mac')) {
+      modKey.textContent = '\u2318';
+    }
+
+    function openSearch() {
+      if (typeof (window as any).__openSearch === 'function') {
+        (window as any).__openSearch();
+      }
+    }
+
+    searchBtn?.addEventListener('click', openSearch);
+    searchBtnMobile?.addEventListener('click', openSearch);
+
     const toggle = document.getElementById('mobile-menu-toggle');
     const menu = document.getElementById('mobile-menu');
     const iconOpen = document.getElementById('menu-icon-open');

--- a/src/components/SearchModal.astro
+++ b/src/components/SearchModal.astro
@@ -1,0 +1,60 @@
+---
+// Search modal powered by Pagefind — triggered by Cmd/Ctrl+K or search button
+---
+
+<div id="search-overlay" class="fixed inset-0 z-[100] hidden" role="dialog" aria-modal="true" aria-label="Search documentation">
+  <!-- Backdrop -->
+  <div id="search-backdrop" class="absolute inset-0 bg-black/60 backdrop-blur-sm"></div>
+
+  <!-- Modal -->
+  <div class="relative flex items-start justify-center pt-[15vh] px-4">
+    <div id="search-modal" class="w-full max-w-2xl rounded-2xl border border-border bg-bg-surface shadow-2xl shadow-black/40 overflow-hidden">
+      <!-- Search input -->
+      <div class="flex items-center gap-3 border-b border-border px-5 py-4">
+        <svg class="w-5 h-5 text-text-muted shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
+        </svg>
+        <input
+          id="search-input"
+          type="text"
+          placeholder="Search docs, charts, guides..."
+          autocomplete="off"
+          class="flex-1 bg-transparent text-text-base text-base placeholder-text-muted outline-none"
+        />
+        <kbd class="hidden sm:inline-flex items-center gap-0.5 rounded-md border border-border bg-bg-base px-2 py-0.5 text-[11px] font-medium text-text-muted">
+          ESC
+        </kbd>
+      </div>
+
+      <!-- Results -->
+      <div id="search-results" class="max-h-[60vh] overflow-y-auto p-2">
+        <div id="search-empty" class="flex flex-col items-center justify-center py-12 text-text-muted">
+          <svg class="w-10 h-10 mb-3 opacity-40" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M9.663 17h4.673M12 3v1m6.364 1.636l-.707.707M21 12h-1M4 12H3m3.343-5.657l-.707-.707m2.828 9.9a5 5 0 117.072 0l-.548.547A3.374 3.374 0 0014 18.469V19a2 2 0 11-4 0v-.531c0-.895-.356-1.754-.988-2.386l-.548-.547z" />
+          </svg>
+          <p class="text-sm font-medium">Type to search the documentation</p>
+          <p class="text-xs mt-1 opacity-60">Search across all charts, guides, and references</p>
+        </div>
+        <div id="search-no-results" class="hidden flex flex-col items-center justify-center py-12 text-text-muted">
+          <p class="text-sm font-medium">No results found</p>
+          <p class="text-xs mt-1 opacity-60">Try different keywords or check the spelling</p>
+        </div>
+        <ul id="search-result-list" class="space-y-1"></ul>
+      </div>
+
+      <!-- Footer -->
+      <div class="flex items-center justify-between border-t border-border px-5 py-3 text-[11px] text-text-muted">
+        <div class="flex items-center gap-3">
+          <span class="flex items-center gap-1"><kbd class="rounded border border-border bg-bg-base px-1.5 py-0.5 font-mono">↑↓</kbd> Navigate</span>
+          <span class="flex items-center gap-1"><kbd class="rounded border border-border bg-bg-base px-1.5 py-0.5 font-mono">↵</kbd> Open</span>
+          <span class="flex items-center gap-1"><kbd class="rounded border border-border bg-bg-base px-1.5 py-0.5 font-mono">esc</kbd> Close</span>
+        </div>
+        <span class="opacity-60">Powered by Pagefind</span>
+      </div>
+    </div>
+  </div>
+</div>
+
+<script>
+  import '../scripts/search-modal';
+</script>

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -1,4 +1,6 @@
 ---
+import SearchModal from '../components/SearchModal.astro';
+
 interface Props {
   title: string;
   description: string;
@@ -108,5 +110,6 @@ const fullTitle = title === siteName ? title : `${title} | ${siteName}`;
       Skip to content
     </a>
     <slot />
+    <SearchModal />
   </body>
 </html>

--- a/src/layouts/DocsLayout.astro
+++ b/src/layouts/DocsLayout.astro
@@ -84,6 +84,16 @@ function isActive(href: string): boolean {
       <!-- Sidebar -->
       <aside id="docs-sidebar" class="hidden lg:block relative z-10 w-full mb-8">
         <nav class="sticky top-24 space-y-5 rounded-2xl glass-panel p-4 pb-8 max-h-[calc(100vh-7rem)] overflow-y-auto">
+          <!-- Search shortcut -->
+          <button
+            id="docs-search-trigger"
+            class="w-full flex items-center gap-2 rounded-xl border border-border bg-bg-base/50 px-3 py-2.5 text-sm text-text-muted transition-colors hover:border-primary/30 hover:text-text-base"
+          >
+            <svg class="w-4 h-4 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" /></svg>
+            <span class="flex-1 text-left">Search docs...</span>
+            <kbd class="hidden lg:inline-flex text-[10px] font-mono border border-border rounded px-1.5 py-0.5 bg-bg-surface"><span id="docs-search-mod">Ctrl</span>K</kbd>
+          </button>
+
           <!-- Breadcrumbs (desktop) -->
           <nav aria-label="Breadcrumb" class="hidden lg:block border-b border-border pb-4">
             <ol class="flex flex-wrap items-center gap-1.5 text-sm text-text-muted">
@@ -172,7 +182,7 @@ function isActive(href: string): boolean {
       </aside>
 
       <!-- Main content -->
-      <main id="main-content" class="min-w-0">
+      <main id="main-content" class="min-w-0" data-pagefind-body>
         <!-- Breadcrumbs (mobile) -->
         <nav aria-label="Breadcrumb" class="mb-6 lg:hidden">
           <ol class="flex flex-wrap items-center gap-1.5 text-sm text-text-muted">

--- a/src/pages/changelog.astro
+++ b/src/pages/changelog.astro
@@ -58,7 +58,7 @@ function renderBody(body: string): string {
   description="Release history for all HelmForge Helm charts. Track new features, bug fixes, and breaking changes."
 >
   <Header />
-  <main id="main-content" class="py-16 sm:py-20">
+  <main id="main-content" class="py-16 sm:py-20" data-pagefind-body>
     <Container>
       <SectionHeader
         label="Changelog"

--- a/src/pages/request.astro
+++ b/src/pages/request.astro
@@ -31,7 +31,7 @@ try {
   description="Suggest a new Helm chart for HelmForge. Community-driven priorities — the most upvoted requests get built first."
 >
   <Header />
-  <main id="main-content" class="py-16 sm:py-20">
+  <main id="main-content" class="py-16 sm:py-20" data-pagefind-body>
     <Container maxWidth="6xl">
       <SectionHeader
         label="Community"

--- a/src/scripts/docs-interactive.ts
+++ b/src/scripts/docs-interactive.ts
@@ -1,3 +1,15 @@
+// Docs search trigger
+const docsSearchBtn = document.getElementById('docs-search-trigger');
+const docsSearchMod = document.getElementById('docs-search-mod');
+if (docsSearchMod && navigator.platform?.includes('Mac')) {
+  docsSearchMod.textContent = '\u2318';
+}
+docsSearchBtn?.addEventListener('click', () => {
+  if (typeof (window as any).__openSearch === 'function') {
+    (window as any).__openSearch();
+  }
+});
+
 // Sidebar toggle
 const toggle = document.getElementById('docs-sidebar-toggle');
 const sidebar = document.getElementById('docs-sidebar');

--- a/src/scripts/search-modal.ts
+++ b/src/scripts/search-modal.ts
@@ -1,0 +1,176 @@
+// Pagefind search modal — Cmd/Ctrl+K to open
+let pagefind: any = null;
+let activeIndex = -1;
+
+const overlay = document.getElementById('search-overlay')!;
+const backdrop = document.getElementById('search-backdrop')!;
+const input = document.getElementById('search-input') as HTMLInputElement;
+const resultList = document.getElementById('search-result-list')!;
+const emptyState = document.getElementById('search-empty')!;
+const noResults = document.getElementById('search-no-results')!;
+
+async function loadPagefind() {
+  if (pagefind) return pagefind;
+  try {
+    pagefind = await import(/* @vite-ignore */ '/pagefind/pagefind.js');
+    await pagefind.init();
+  } catch {
+    // Pagefind not available (dev mode) — show message
+    pagefind = null;
+  }
+  return pagefind;
+}
+
+function openSearch() {
+  overlay.classList.remove('hidden');
+  document.body.style.overflow = 'hidden';
+  input.value = '';
+  resultList.innerHTML = '';
+  emptyState.classList.remove('hidden');
+  noResults.classList.add('hidden');
+  activeIndex = -1;
+  requestAnimationFrame(() => input.focus());
+  loadPagefind();
+}
+
+function closeSearch() {
+  overlay.classList.add('hidden');
+  document.body.style.overflow = '';
+}
+
+function setActiveResult(index: number) {
+  const items = resultList.querySelectorAll('[data-search-result]');
+  items.forEach((el, i) => {
+    if (i === index) {
+      el.classList.add('bg-primary/10', 'border-primary/30');
+      el.classList.remove('border-transparent');
+      el.scrollIntoView({ block: 'nearest' });
+    } else {
+      el.classList.remove('bg-primary/10', 'border-primary/30');
+      el.classList.add('border-transparent');
+    }
+  });
+  activeIndex = index;
+}
+
+function navigateToResult() {
+  const items = resultList.querySelectorAll('[data-search-result]');
+  if (activeIndex >= 0 && activeIndex < items.length) {
+    const link = items[activeIndex].querySelector('a') as HTMLAnchorElement;
+    if (link) {
+      closeSearch();
+      window.location.href = link.href;
+    }
+  }
+}
+
+let debounceTimer: ReturnType<typeof setTimeout>;
+
+async function performSearch(query: string) {
+  if (!pagefind || !query.trim()) {
+    resultList.innerHTML = '';
+    emptyState.classList.toggle('hidden', !!query.trim());
+    noResults.classList.toggle('hidden', !query.trim() || !pagefind);
+    return;
+  }
+
+  const search = await pagefind.search(query);
+  const results = await Promise.all(search.results.slice(0, 12).map((r: any) => r.data()));
+
+  emptyState.classList.add('hidden');
+  resultList.innerHTML = '';
+  activeIndex = -1;
+
+  if (results.length === 0) {
+    noResults.classList.remove('hidden');
+    return;
+  }
+
+  noResults.classList.add('hidden');
+
+  results.forEach((result: any) => {
+    const li = document.createElement('li');
+    li.setAttribute('data-search-result', '');
+    li.className = 'rounded-xl border border-transparent px-4 py-3 transition-colors cursor-pointer';
+
+    // Clean up the URL
+    const url = result.url || result.raw_url || '#';
+
+    // Determine section from URL
+    let section = 'Page';
+    if (url.includes('/docs/charts/')) section = 'Chart';
+    else if (url.includes('/docs/')) section = 'Docs';
+    else if (url.includes('/changelog')) section = 'Changelog';
+    else if (url.includes('/stack')) section = 'Stack Builder';
+
+    li.innerHTML = `
+      <a href="${url}" class="block">
+        <div class="flex items-center gap-2 mb-1">
+          <span class="text-[10px] font-bold uppercase tracking-wider text-primary bg-primary/10 rounded px-1.5 py-0.5">${section}</span>
+          <span class="text-sm font-bold text-text-base">${result.meta?.title || 'Untitled'}</span>
+        </div>
+        ${result.excerpt ? `<p class="text-xs text-text-muted leading-relaxed line-clamp-2">${result.excerpt}</p>` : ''}
+      </a>
+    `;
+
+    li.addEventListener('click', () => {
+      closeSearch();
+      window.location.href = url;
+    });
+
+    li.addEventListener('mouseenter', () => {
+      const items = resultList.querySelectorAll('[data-search-result]');
+      const idx = Array.from(items).indexOf(li);
+      setActiveResult(idx);
+    });
+
+    resultList.appendChild(li);
+  });
+}
+
+// Event listeners
+input.addEventListener('input', () => {
+  clearTimeout(debounceTimer);
+  debounceTimer = setTimeout(() => performSearch(input.value), 150);
+});
+
+backdrop.addEventListener('click', closeSearch);
+
+// Keyboard navigation
+document.addEventListener('keydown', (e) => {
+  // Open with Cmd/Ctrl+K
+  if ((e.metaKey || e.ctrlKey) && e.key === 'k') {
+    e.preventDefault();
+    if (overlay.classList.contains('hidden')) {
+      openSearch();
+    } else {
+      closeSearch();
+    }
+    return;
+  }
+
+  // Only handle these when modal is open
+  if (overlay.classList.contains('hidden')) return;
+
+  if (e.key === 'Escape') {
+    e.preventDefault();
+    closeSearch();
+  } else if (e.key === 'ArrowDown') {
+    e.preventDefault();
+    const items = resultList.querySelectorAll('[data-search-result]');
+    if (items.length > 0) {
+      setActiveResult(Math.min(activeIndex + 1, items.length - 1));
+    }
+  } else if (e.key === 'ArrowUp') {
+    e.preventDefault();
+    if (activeIndex > 0) {
+      setActiveResult(activeIndex - 1);
+    }
+  } else if (e.key === 'Enter') {
+    e.preventDefault();
+    navigateToResult();
+  }
+});
+
+// Expose openSearch globally for the header button
+(window as any).__openSearch = openSearch;


### PR DESCRIPTION
## Summary
- Integrate Pagefind for static, zero-JS search across all documentation, chart pages, changelog, and request pages (46 pages indexed)
- Add Cmd/Ctrl+K keyboard shortcut to open search modal from anywhere
- Add search button in header (desktop with keyboard hint, mobile icon) and docs sidebar
- Search modal features: debounced queries, result categorization (Docs/Chart/Changelog), keyboard navigation (arrow keys + enter), and ESC to close

## Test plan
- [ ] Verify `npm run build` completes with Pagefind indexing output
- [ ] Open the site and press Ctrl+K (or Cmd+K on Mac) — search modal opens
- [ ] Type a query (e.g., "postgresql") — results appear with correct categorization
- [ ] Navigate results with arrow keys and press Enter — navigates to page
- [ ] Click the search button in header (desktop and mobile) — opens modal
- [ ] Click the search trigger in docs sidebar — opens modal
- [ ] Press ESC or click backdrop — closes modal
- [ ] Verify the `dist/pagefind/` directory is created after build