### PR TITLE
feat(site): add values playground and multi-format stack builder

### DIFF
--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -34,6 +34,9 @@ const year = new Date().getFullYear();
           <li><a href="/docs/charts" class="text-text-muted transition-colors hover:text-text-base">Charts</a></li>
           <li><a href="/docs" class="text-text-muted transition-colors hover:text-text-base">Docs Overview</a></li>
           <li><a href="/stack" class="text-text-muted transition-colors hover:text-text-base">Stack Builder</a></li>
+          <li>
+            <a href="/playground" class="text-text-muted transition-colors hover:text-text-base">Values Playground</a>
+          </li>
           <li><a href="/changelog" class="text-text-muted transition-colors hover:text-text-base">Changelog</a></li>
         </ul>
       </div>

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -10,6 +10,7 @@ const navItems = [
   { label: 'Home', href: '/' },
   { label: 'Docs', href: '/docs' },
   { label: 'Stack Builder', href: '/stack' },
+  { label: 'Playground', href: '/playground' },
   { label: 'Request', href: '/request' },
   { label: 'Changelog', href: '/changelog' },
 ];

--- a/src/pages/playground.astro
+++ b/src/pages/playground.astro
@@ -1,0 +1,218 @@
+---
+import BaseLayout from '../layouts/BaseLayout.astro';
+import Header from '../components/Header.astro';
+import Footer from '../components/Footer.astro';
+import Container from '../components/Container.astro';
+import SectionHeader from '../components/SectionHeader.astro';
+import { charts, chartIcon } from '../data/charts';
+
+const stableCharts = charts.filter((c) => c.maturity === 'stable');
+
+// Define common configurable values for chart categories
+const chartConfigs: Record<
+  string,
+  {
+    label: string;
+    key: string;
+    type: 'text' | 'number' | 'select' | 'toggle';
+    default: string;
+    options?: string[];
+    description: string;
+  }[]
+> = {
+  postgresql: [
+    {
+      label: 'Architecture',
+      key: 'architecture',
+      type: 'select',
+      default: 'standalone',
+      options: ['standalone', 'replication'],
+      description: 'Deployment architecture',
+    },
+    { label: 'Storage Size', key: 'persistence.size', type: 'text', default: '8Gi', description: 'PVC storage size' },
+    { label: 'Replica Count', key: 'replicaCount', type: 'number', default: '1', description: 'Number of replicas' },
+    {
+      label: 'S3 Backup',
+      key: 'backup.enabled',
+      type: 'toggle',
+      default: 'false',
+      description: 'Enable S3 backup CronJob',
+    },
+  ],
+  mysql: [
+    {
+      label: 'Architecture',
+      key: 'architecture',
+      type: 'select',
+      default: 'standalone',
+      options: ['standalone', 'replication'],
+      description: 'Deployment architecture',
+    },
+    { label: 'Storage Size', key: 'persistence.size', type: 'text', default: '8Gi', description: 'PVC storage size' },
+    { label: 'Replica Count', key: 'replicaCount', type: 'number', default: '1', description: 'Number of replicas' },
+    {
+      label: 'S3 Backup',
+      key: 'backup.enabled',
+      type: 'toggle',
+      default: 'false',
+      description: 'Enable S3 backup CronJob',
+    },
+  ],
+  redis: [
+    {
+      label: 'Architecture',
+      key: 'architecture',
+      type: 'select',
+      default: 'standalone',
+      options: ['standalone', 'sentinel'],
+      description: 'Deployment architecture',
+    },
+    { label: 'Storage Size', key: 'persistence.size', type: 'text', default: '2Gi', description: 'PVC storage size' },
+    { label: 'Replica Count', key: 'replicaCount', type: 'number', default: '1', description: 'Number of replicas' },
+  ],
+  mongodb: [
+    {
+      label: 'Architecture',
+      key: 'architecture',
+      type: 'select',
+      default: 'standalone',
+      options: ['standalone', 'replicaset'],
+      description: 'Deployment architecture',
+    },
+    { label: 'Storage Size', key: 'persistence.size', type: 'text', default: '8Gi', description: 'PVC storage size' },
+    { label: 'Replica Count', key: 'replicaCount', type: 'number', default: '1', description: 'Number of replicas' },
+    {
+      label: 'S3 Backup',
+      key: 'backup.enabled',
+      type: 'toggle',
+      default: 'false',
+      description: 'Enable S3 backup CronJob',
+    },
+  ],
+  _default: [
+    { label: 'Replica Count', key: 'replicaCount', type: 'number', default: '1', description: 'Number of replicas' },
+    { label: 'Storage Size', key: 'persistence.size', type: 'text', default: '8Gi', description: 'PVC storage size' },
+    {
+      label: 'Ingress',
+      key: 'ingress.enabled',
+      type: 'toggle',
+      default: 'false',
+      description: 'Enable Ingress resource',
+    },
+  ],
+};
+
+// Serialize configs for the client
+const configsJson = JSON.stringify(chartConfigs);
+---
+
+<BaseLayout
+  title="Values Playground"
+  description="Interactively configure HelmForge chart values and generate ready-to-use Helm install commands."
+>
+  <Header />
+  <main id="main-content" class="py-16 sm:py-20" data-pagefind-body>
+    <Container>
+      <SectionHeader
+        label="Playground"
+        title="Configure, preview, deploy."
+        description="Pick a chart, tweak the values, and get a ready-to-paste install command with your customizations."
+      />
+
+      <div class="mt-12 grid grid-cols-1 lg:grid-cols-5 gap-8">
+        <!-- Chart Selector -->
+        <div class="lg:col-span-2">
+          <h3 class="text-sm font-bold uppercase tracking-[0.16em] text-text-muted mb-4">Select a chart</h3>
+          <div class="space-y-2 max-h-[560px] overflow-y-auto pr-1">
+            {
+              stableCharts.map((chart) => (
+                <button
+                  class="playground-chart-btn w-full flex items-center gap-3 rounded-xl border border-border bg-bg-surface/40 px-4 py-3 text-left transition-all hover:border-primary/40 hover:bg-bg-surface/80"
+                  data-slug={chart.slug}
+                  data-name={chart.name}
+                >
+                  <img
+                    src={chartIcon(chart.slug)}
+                    alt=""
+                    class="w-7 h-7 object-contain"
+                    loading="lazy"
+                    width="28"
+                    height="28"
+                  />
+                  <div class="min-w-0 flex-1">
+                    <div class="text-sm font-semibold text-text-base">{chart.name}</div>
+                    <div class="text-xs text-text-muted truncate">{chart.description}</div>
+                  </div>
+                </button>
+              ))
+            }
+          </div>
+        </div>
+
+        <!-- Config + Output -->
+        <div class="lg:col-span-3">
+          <!-- Config Panel -->
+          <div id="playground-config" class="glass-panel rounded-2xl p-6 mb-6">
+            <div id="playground-empty" class="text-center py-8 text-text-muted">
+              <svg class="mx-auto h-10 w-10 opacity-40 mb-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  stroke-width="1.5"
+                  d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.066 2.573c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.573 1.066c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.066-2.573c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z"
+                ></path>
+                <path
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  stroke-width="1.5"
+                  d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"></path>
+              </svg>
+              <p class="text-sm font-medium">Select a chart to configure</p>
+              <p class="text-xs mt-1 opacity-60">Values will appear here with controls to customize them</p>
+            </div>
+            <div id="playground-fields" class="hidden">
+              <div class="flex items-center justify-between mb-5">
+                <h3 id="playground-chart-title" class="text-lg font-bold text-text-base heading-font"></h3>
+                <a id="playground-docs-link" href="#" class="text-xs text-primary-light hover:underline">View docs</a>
+              </div>
+              <div id="playground-controls" class="space-y-4"></div>
+            </div>
+          </div>
+
+          <!-- Command Output -->
+          <div class="flex items-center justify-between mb-3">
+            <h3 class="text-sm font-bold uppercase tracking-[0.16em] text-text-muted">Install command</h3>
+            <button
+              id="playground-copy"
+              class="text-xs font-medium text-primary-light hover:text-primary transition-colors disabled:opacity-40"
+              disabled
+            >
+              Copy to clipboard
+            </button>
+          </div>
+          <div class="rounded-2xl border border-border bg-[#1e1e2e] overflow-hidden">
+            <div class="flex items-center px-4 py-2.5 border-b border-white/5 bg-white/5">
+              <div class="flex space-x-1.5">
+                <div class="w-2.5 h-2.5 rounded-full bg-[#ff5f56]"></div>
+                <div class="w-2.5 h-2.5 rounded-full bg-[#ffbd2e]"></div>
+                <div class="w-2.5 h-2.5 rounded-full bg-[#27c93f]"></div>
+              </div>
+              <span class="mx-auto text-[10px] text-zinc-500 font-mono">terminal</span>
+            </div>
+            <pre
+              id="playground-output"
+              class="p-5 font-mono text-sm text-zinc-300 leading-relaxed overflow-x-auto min-h-[120px]"><code id="playground-code" class="block"><span class="text-zinc-500"># Select a chart and configure values</span></code></pre>
+          </div>
+        </div>
+      </div>
+    </Container>
+  </main>
+  <Footer />
+</BaseLayout>
+
+<script define:vars={{ configsJson }}>
+  window.__playgroundConfigs = JSON.parse(configsJson);
+</script>
+<script>
+  import '../scripts/playground';
+</script>

--- a/src/pages/stack.astro
+++ b/src/pages/stack.astro
@@ -75,7 +75,7 @@ const stableCharts = charts.filter((c) => c.maturity === 'stable');
         <!-- Output -->
         <div>
           <div class="flex items-center justify-between mb-4">
-            <h3 class="text-lg font-bold text-text-base heading-font">Install script</h3>
+            <h3 class="text-lg font-bold text-text-base heading-font">Output</h3>
             <button
               id="stack-copy-btn"
               class="text-xs font-medium text-primary-light hover:text-primary transition-colors disabled:opacity-40 disabled:cursor-not-allowed"
@@ -85,6 +85,22 @@ const stableCharts = charts.filter((c) => c.maturity === 'stable');
             </button>
           </div>
 
+          <!-- Format toggle -->
+          <div class="flex gap-1 mb-4 p-1 rounded-xl bg-bg-surface/80 border border-border w-fit">
+            <button
+              class="stack-format-btn px-3 py-1.5 rounded-lg text-xs font-semibold transition-all bg-primary text-white"
+              data-format="bash">Bash</button
+            >
+            <button
+              class="stack-format-btn px-3 py-1.5 rounded-lg text-xs font-semibold transition-all text-text-muted hover:text-text-base"
+              data-format="helmfile">Helmfile</button
+            >
+            <button
+              class="stack-format-btn px-3 py-1.5 rounded-lg text-xs font-semibold transition-all text-text-muted hover:text-text-base"
+              data-format="argocd">ArgoCD</button
+            >
+          </div>
+
           <div class="rounded-2xl border border-border bg-[#1e1e2e] overflow-hidden">
             <div class="flex items-center px-4 py-2.5 border-b border-white/5 bg-white/5">
               <div class="flex space-x-1.5">
@@ -92,7 +108,7 @@ const stableCharts = charts.filter((c) => c.maturity === 'stable');
                 <div class="w-2.5 h-2.5 rounded-full bg-[#ffbd2e]"></div>
                 <div class="w-2.5 h-2.5 rounded-full bg-[#27c93f]"></div>
               </div>
-              <span class="mx-auto text-[10px] text-zinc-500 font-mono">stack-builder.sh</span>
+              <span id="stack-filename" class="mx-auto text-[10px] text-zinc-500 font-mono">stack-builder.sh</span>
             </div>
             <pre
               id="stack-output"
@@ -101,7 +117,8 @@ const stableCharts = charts.filter((c) => c.maturity === 'stable');
           </div>
 
           <div id="stack-empty-hint" class="mt-4 text-sm text-text-muted">
-            Select one or more charts to generate Helm install commands with sensible defaults.
+            Select one or more charts to generate install commands. Switch formats to get Helmfile YAML or ArgoCD
+            manifests.
           </div>
         </div>
       </div>

--- a/src/scripts/playground.ts
+++ b/src/scripts/playground.ts
@@ -1,0 +1,187 @@
+interface FieldConfig {
+  label: string;
+  key: string;
+  type: 'text' | 'number' | 'select' | 'toggle';
+  default: string;
+  options?: string[];
+  description: string;
+}
+
+const configs: Record<string, FieldConfig[]> = (window as any).__playgroundConfigs ?? {};
+
+const chartBtns = document.querySelectorAll<HTMLButtonElement>('.playground-chart-btn');
+const emptyEl = document.getElementById('playground-empty');
+const fieldsEl = document.getElementById('playground-fields');
+const controlsEl = document.getElementById('playground-controls');
+const titleEl = document.getElementById('playground-chart-title');
+const docsLink = document.getElementById('playground-docs-link') as HTMLAnchorElement | null;
+const codeEl = document.getElementById('playground-code');
+const copyBtn = document.getElementById('playground-copy') as HTMLButtonElement | null;
+
+let selectedSlug = '';
+let currentValues: Record<string, string> = {};
+
+function getFields(slug: string): FieldConfig[] {
+  return configs[slug] ?? configs['_default'] ?? [];
+}
+
+function selectChart(slug: string, name: string) {
+  selectedSlug = slug;
+  currentValues = {};
+
+  // Update button states
+  chartBtns.forEach((btn) => {
+    if (btn.dataset.slug === slug) {
+      btn.classList.add('border-primary/60', 'bg-primary/5');
+    } else {
+      btn.classList.remove('border-primary/60', 'bg-primary/5');
+    }
+  });
+
+  // Show config
+  if (emptyEl) emptyEl.classList.add('hidden');
+  if (fieldsEl) fieldsEl.classList.remove('hidden');
+  if (titleEl) titleEl.textContent = name;
+  if (docsLink) docsLink.href = `/docs/charts/${slug}`;
+
+  // Build controls
+  const fields = getFields(slug);
+  if (!controlsEl) return;
+  controlsEl.innerHTML = '';
+
+  fields.forEach((field) => {
+    currentValues[field.key] = field.default;
+    const div = document.createElement('div');
+    div.className = 'flex items-center justify-between gap-4';
+
+    const labelDiv = document.createElement('div');
+    labelDiv.className = 'min-w-0';
+    labelDiv.innerHTML = `
+      <div class="text-sm font-semibold text-text-base">${field.label}</div>
+      <div class="text-xs text-text-muted">${field.description}</div>
+    `;
+
+    const controlDiv = document.createElement('div');
+    controlDiv.className = 'shrink-0';
+
+    if (field.type === 'select') {
+      const select = document.createElement('select');
+      select.className =
+        'rounded-lg border border-border bg-bg-surface/80 px-3 py-1.5 text-sm text-text-base focus:outline-none focus:ring-2 focus:ring-primary-light';
+      (field.options ?? []).forEach((opt) => {
+        const option = document.createElement('option');
+        option.value = opt;
+        option.textContent = opt;
+        if (opt === field.default) option.selected = true;
+        select.appendChild(option);
+      });
+      select.addEventListener('change', () => {
+        currentValues[field.key] = select.value;
+        updateOutput();
+      });
+      controlDiv.appendChild(select);
+    } else if (field.type === 'toggle') {
+      const btn = document.createElement('button');
+      btn.className = `relative inline-flex h-6 w-11 items-center rounded-full transition-colors ${field.default === 'true' ? 'bg-primary' : 'bg-border'}`;
+      btn.innerHTML = `<span class="inline-block h-4 w-4 transform rounded-full bg-white transition-transform ${field.default === 'true' ? 'translate-x-6' : 'translate-x-1'}"></span>`;
+      btn.addEventListener('click', () => {
+        const isOn = currentValues[field.key] === 'true';
+        currentValues[field.key] = isOn ? 'false' : 'true';
+        btn.className = `relative inline-flex h-6 w-11 items-center rounded-full transition-colors ${!isOn ? 'bg-primary' : 'bg-border'}`;
+        const dot = btn.querySelector('span')!;
+        dot.className = `inline-block h-4 w-4 transform rounded-full bg-white transition-transform ${!isOn ? 'translate-x-6' : 'translate-x-1'}`;
+        updateOutput();
+      });
+      controlDiv.appendChild(btn);
+    } else if (field.type === 'number') {
+      const input = document.createElement('input');
+      input.type = 'number';
+      input.min = '1';
+      input.max = '10';
+      input.value = field.default;
+      input.className =
+        'w-20 rounded-lg border border-border bg-bg-surface/80 px-3 py-1.5 text-sm text-text-base text-center focus:outline-none focus:ring-2 focus:ring-primary-light';
+      input.addEventListener('input', () => {
+        currentValues[field.key] = input.value;
+        updateOutput();
+      });
+      controlDiv.appendChild(input);
+    } else {
+      const input = document.createElement('input');
+      input.type = 'text';
+      input.value = field.default;
+      input.className =
+        'w-28 rounded-lg border border-border bg-bg-surface/80 px-3 py-1.5 text-sm text-text-base focus:outline-none focus:ring-2 focus:ring-primary-light';
+      input.addEventListener('input', () => {
+        currentValues[field.key] = input.value;
+        updateOutput();
+      });
+      controlDiv.appendChild(input);
+    }
+
+    div.appendChild(labelDiv);
+    div.appendChild(controlDiv);
+    controlsEl.appendChild(div);
+  });
+
+  updateOutput();
+}
+
+function buildSetFlags(): string[] {
+  const fields = getFields(selectedSlug);
+  const flags: string[] = [];
+  fields.forEach((field) => {
+    const val = currentValues[field.key];
+    if (val !== field.default) {
+      flags.push(`--set ${field.key}=${val}`);
+    }
+  });
+  return flags;
+}
+
+function updateOutput() {
+  if (!codeEl || !selectedSlug) return;
+  if (copyBtn) copyBtn.disabled = false;
+
+  const flags = buildSetFlags();
+  const lines: string[] = [];
+
+  lines.push(`<span class="text-emerald-400">helm</span> install ${selectedSlug} helmforge/${selectedSlug} \\`);
+  lines.push(`  --namespace helmforge \\`);
+
+  flags.forEach((flag) => {
+    lines.push(`  ${flag} \\`);
+  });
+
+  lines.push(`  --wait --timeout 5m`);
+
+  codeEl.innerHTML = lines.join('\n');
+}
+
+function getPlainCommand(): string {
+  const flags = buildSetFlags();
+  const parts = [`helm install ${selectedSlug} helmforge/${selectedSlug}`, '  --namespace helmforge'];
+  flags.forEach((f) => parts.push(`  ${f}`));
+  parts.push('  --wait --timeout 5m');
+  return parts.join(' \\\n');
+}
+
+// Event listeners
+chartBtns.forEach((btn) => {
+  btn.addEventListener('click', () => {
+    selectChart(btn.dataset.slug ?? '', btn.dataset.name ?? '');
+  });
+});
+
+if (copyBtn) {
+  copyBtn.addEventListener('click', async () => {
+    if (!selectedSlug) return;
+    try {
+      await navigator.clipboard.writeText(getPlainCommand());
+      copyBtn.textContent = 'Copied!';
+      setTimeout(() => (copyBtn.textContent = 'Copy to clipboard'), 2000);
+    } catch {
+      // Fallback
+    }
+  });
+}

--- a/src/scripts/stack-builder.ts
+++ b/src/scripts/stack-builder.ts
@@ -6,6 +6,17 @@ const hintEl = document.getElementById('stack-empty-hint');
 const searchInput = document.getElementById('stack-search') as HTMLInputElement | null;
 const chartItems = document.querySelectorAll<HTMLElement>('.stack-chart-item');
 const presets = document.querySelectorAll<HTMLButtonElement>('.stack-preset');
+const formatBtns = document.querySelectorAll<HTMLButtonElement>('.stack-format-btn');
+const filenameEl = document.getElementById('stack-filename');
+
+type Format = 'bash' | 'helmfile' | 'argocd';
+let currentFormat: Format = 'bash';
+
+const filenames: Record<Format, string> = {
+  bash: 'stack-builder.sh',
+  helmfile: 'helmfile.yaml',
+  argocd: 'applications.yaml',
+};
 
 function getSelected(): { name: string; slug: string }[] {
   const selected: { name: string; slug: string }[] = [];
@@ -20,11 +31,8 @@ function getSelected(): { name: string; slug: string }[] {
   return selected;
 }
 
-function generateScript(charts: { name: string; slug: string }[]): string {
-  if (charts.length === 0) {
-    return '<span class="text-zinc-500"># Select charts on the left to generate your install script</span>\n<span class="text-zinc-500"># Commands will appear here automatically</span>';
-  }
-
+// --- Bash format ---
+function generateBash(charts: { name: string; slug: string }[]): string {
   const lines: string[] = [];
   lines.push('<span class="text-zinc-500">#!/bin/bash</span>');
   lines.push('<span class="text-zinc-500"># HelmForge Stack — generated at helmforge.dev/stack</span>');
@@ -50,12 +58,10 @@ function generateScript(charts: { name: string; slug: string }[]): string {
   lines.push(
     '<span class="text-emerald-400">echo</span> <span class="text-amber-300">"Stack deployed successfully!"</span>',
   );
-
   return lines.join('\n');
 }
 
-function getPlainScript(charts: { name: string; slug: string }[]): string {
-  if (charts.length === 0) return '';
+function getPlainBash(charts: { name: string; slug: string }[]): string {
   const lines: string[] = [];
   lines.push('#!/bin/bash');
   lines.push('# HelmForge Stack — generated at helmforge.dev/stack');
@@ -80,12 +86,140 @@ function getPlainScript(charts: { name: string; slug: string }[]): string {
   return lines.join('\n');
 }
 
+// --- Helmfile format ---
+function generateHelmfile(charts: { name: string; slug: string }[]): string {
+  const lines: string[] = [];
+  lines.push('<span class="text-zinc-500"># helmfile.yaml — generated at helmforge.dev/stack</span>');
+  lines.push('<span class="text-sky-400">repositories</span>:');
+  lines.push('  - <span class="text-sky-400">name</span>: helmforge');
+  lines.push('    <span class="text-sky-400">url</span>: https://repo.helmforge.dev');
+  lines.push('');
+  lines.push('<span class="text-sky-400">releases</span>:');
+
+  charts.forEach((chart) => {
+    lines.push(`  - <span class="text-sky-400">name</span>: ${chart.slug}`);
+    lines.push(`    <span class="text-sky-400">namespace</span>: helmforge`);
+    lines.push(`    <span class="text-sky-400">chart</span>: helmforge/${chart.slug}`);
+    lines.push(`    <span class="text-sky-400">wait</span>: <span class="text-amber-300">true</span>`);
+    lines.push(`    <span class="text-sky-400">timeout</span>: <span class="text-amber-300">300</span>`);
+    lines.push('');
+  });
+
+  return lines.join('\n');
+}
+
+function getPlainHelmfile(charts: { name: string; slug: string }[]): string {
+  const lines: string[] = [];
+  lines.push('# helmfile.yaml — generated at helmforge.dev/stack');
+  lines.push('repositories:');
+  lines.push('  - name: helmforge');
+  lines.push('    url: https://repo.helmforge.dev');
+  lines.push('');
+  lines.push('releases:');
+
+  charts.forEach((chart) => {
+    lines.push(`  - name: ${chart.slug}`);
+    lines.push(`    namespace: helmforge`);
+    lines.push(`    chart: helmforge/${chart.slug}`);
+    lines.push(`    wait: true`);
+    lines.push(`    timeout: 300`);
+    lines.push('');
+  });
+
+  return lines.join('\n');
+}
+
+// --- ArgoCD format ---
+function generateArgoCD(charts: { name: string; slug: string }[]): string {
+  const lines: string[] = [];
+  lines.push('<span class="text-zinc-500"># ArgoCD Applications — generated at helmforge.dev/stack</span>');
+
+  charts.forEach((chart, i) => {
+    if (i > 0) lines.push('<span class="text-zinc-500">---</span>');
+    lines.push('<span class="text-sky-400">apiVersion</span>: argoproj.io/v1alpha1');
+    lines.push('<span class="text-sky-400">kind</span>: Application');
+    lines.push('<span class="text-sky-400">metadata</span>:');
+    lines.push(`  <span class="text-sky-400">name</span>: ${chart.slug}`);
+    lines.push('  <span class="text-sky-400">namespace</span>: argocd');
+    lines.push('<span class="text-sky-400">spec</span>:');
+    lines.push('  <span class="text-sky-400">project</span>: default');
+    lines.push('  <span class="text-sky-400">source</span>:');
+    lines.push('    <span class="text-sky-400">repoURL</span>: https://repo.helmforge.dev');
+    lines.push(`    <span class="text-sky-400">chart</span>: ${chart.slug}`);
+    lines.push(`    <span class="text-sky-400">targetRevision</span>: <span class="text-amber-300">"*"</span>`);
+    lines.push('  <span class="text-sky-400">destination</span>:');
+    lines.push('    <span class="text-sky-400">server</span>: https://kubernetes.default.svc');
+    lines.push('    <span class="text-sky-400">namespace</span>: helmforge');
+    lines.push('  <span class="text-sky-400">syncPolicy</span>:');
+    lines.push('    <span class="text-sky-400">automated</span>:');
+    lines.push('      <span class="text-sky-400">selfHeal</span>: <span class="text-amber-300">true</span>');
+    lines.push('      <span class="text-sky-400">prune</span>: <span class="text-amber-300">true</span>');
+    lines.push('');
+  });
+
+  return lines.join('\n');
+}
+
+function getPlainArgoCD(charts: { name: string; slug: string }[]): string {
+  const lines: string[] = [];
+  lines.push('# ArgoCD Applications — generated at helmforge.dev/stack');
+
+  charts.forEach((chart, i) => {
+    if (i > 0) lines.push('---');
+    lines.push('apiVersion: argoproj.io/v1alpha1');
+    lines.push('kind: Application');
+    lines.push('metadata:');
+    lines.push(`  name: ${chart.slug}`);
+    lines.push('  namespace: argocd');
+    lines.push('spec:');
+    lines.push('  project: default');
+    lines.push('  source:');
+    lines.push('    repoURL: https://repo.helmforge.dev');
+    lines.push(`    chart: ${chart.slug}`);
+    lines.push('    targetRevision: "*"');
+    lines.push('  destination:');
+    lines.push('    server: https://kubernetes.default.svc');
+    lines.push('    namespace: helmforge');
+    lines.push('  syncPolicy:');
+    lines.push('    automated:');
+    lines.push('      selfHeal: true');
+    lines.push('      prune: true');
+    lines.push('');
+  });
+
+  return lines.join('\n');
+}
+
+// --- Generators map ---
+const generators: Record<Format, (c: { name: string; slug: string }[]) => string> = {
+  bash: generateBash,
+  helmfile: generateHelmfile,
+  argocd: generateArgoCD,
+};
+
+const plainGenerators: Record<Format, (c: { name: string; slug: string }[]) => string> = {
+  bash: getPlainBash,
+  helmfile: getPlainHelmfile,
+  argocd: getPlainArgoCD,
+};
+
+const emptyMessages: Record<Format, string> = {
+  bash: '<span class="text-zinc-500"># Select charts on the left to generate your install script</span>\n<span class="text-zinc-500"># Commands will appear here automatically</span>',
+  helmfile:
+    '<span class="text-zinc-500"># Select charts on the left to generate helmfile.yaml</span>\n<span class="text-zinc-500"># YAML will appear here automatically</span>',
+  argocd:
+    '<span class="text-zinc-500"># Select charts on the left to generate ArgoCD Applications</span>\n<span class="text-zinc-500"># Manifests will appear here automatically</span>',
+};
+
 function update() {
   const selected = getSelected();
-  if (codeEl) codeEl.innerHTML = generateScript(selected);
+  if (codeEl) {
+    codeEl.innerHTML = selected.length > 0 ? generators[currentFormat](selected) : emptyMessages[currentFormat];
+  }
   if (countEl) countEl.textContent = `${selected.length} selected`;
   if (copyBtn) copyBtn.disabled = selected.length === 0;
   if (hintEl) hintEl.style.display = selected.length > 0 ? 'none' : '';
+  if (filenameEl) filenameEl.textContent = filenames[currentFormat];
 
   // Update check icons
   checkboxes.forEach((cb) => {
@@ -106,13 +240,30 @@ function update() {
   });
 }
 
+// Format toggle
+formatBtns.forEach((btn) => {
+  btn.addEventListener('click', () => {
+    currentFormat = (btn.dataset.format as Format) ?? 'bash';
+    formatBtns.forEach((b) => {
+      if (b === btn) {
+        b.classList.add('bg-primary', 'text-white');
+        b.classList.remove('text-text-muted');
+      } else {
+        b.classList.remove('bg-primary', 'text-white');
+        b.classList.add('text-text-muted');
+      }
+    });
+    update();
+  });
+});
+
 checkboxes.forEach((cb) => cb.addEventListener('change', update));
 
 // Copy
 if (copyBtn) {
   copyBtn.addEventListener('click', async () => {
     const selected = getSelected();
-    const text = getPlainScript(selected);
+    const text = plainGenerators[currentFormat](selected);
     if (!text) return;
     try {
       await navigator.clipboard.writeText(text);


### PR DESCRIPTION
## Summary
- Add **Values Playground** page (`/playground`) — interactive chart configurator where users select a chart, tweak values (architecture, storage, replicas, backup, ingress) via controls, and get a live-updating `helm install` command with `--set` flags
- Enhance **Stack Builder** with format toggle: Bash script, Helmfile YAML, and ArgoCD Application manifests — each with syntax-highlighted output and copy-to-clipboard support
- Add Playground link to header navigation and footer

## Test plan
- [ ] Navigate to `/playground` and select a chart (e.g., PostgreSQL)
- [ ] Change values (architecture to replication, enable backup) — verify command updates with `--set` flags
- [ ] Click copy — verify clipboard contains plain text command
- [ ] Navigate to `/stack`, select charts, toggle between Bash/Helmfile/ArgoCD formats
- [ ] Verify Helmfile output is valid YAML structure
- [ ] Verify ArgoCD output generates Application manifests per chart
- [ ] Verify copy works for all three formats
- [ ] Verify Playground appears in header and footer navigation