### PR TITLE
feat(site): add blog section with content collection and initial posts

### DIFF
--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -38,6 +38,7 @@ const year = new Date().getFullYear();
             <a href="/playground" class="text-text-muted transition-colors hover:text-text-base">Values Playground</a>
           </li>
           <li><a href="/changelog" class="text-text-muted transition-colors hover:text-text-base">Changelog</a></li>
+          <li><a href="/blog" class="text-text-muted transition-colors hover:text-text-base">Blog</a></li>
         </ul>
       </div>
 

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -11,6 +11,7 @@ const navItems = [
   { label: 'Docs', href: '/docs' },
   { label: 'Stack Builder', href: '/stack' },
   { label: 'Playground', href: '/playground' },
+  { label: 'Blog', href: '/blog' },
   { label: 'Request', href: '/request' },
   { label: 'Changelog', href: '/changelog' },
 ];

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -1,0 +1,16 @@
+import { defineCollection, z } from 'astro:content';
+import { glob } from 'astro/loaders';
+
+const blog = defineCollection({
+  loader: glob({ base: './src/content/blog', pattern: '**/*.{md,mdx}' }),
+  schema: z.object({
+    title: z.string(),
+    description: z.string(),
+    date: z.coerce.date(),
+    author: z.string().default('HelmForge Team'),
+    tags: z.array(z.string()).default([]),
+    image: z.string().optional(),
+  }),
+});
+
+export const collections = { blog };

--- a/src/content/blog/helmforge-vs-bitnami.mdx
+++ b/src/content/blog/helmforge-vs-bitnami.mdx
@@ -1,9 +1,9 @@
 ---
-title: "HelmForge vs Bitnami: A Practical Comparison"
-description: "An honest look at how HelmForge charts compare to Bitnami — images, licensing, backup, and operational trade-offs."
+title: 'HelmForge vs Bitnami: A Practical Comparison'
+description: 'An honest look at how HelmForge charts compare to Bitnami — images, licensing, backup, and operational trade-offs.'
 date: 2025-02-10
-author: "HelmForge Team"
-tags: ["comparison", "bitnami", "kubernetes"]
+author: 'HelmForge Team'
+tags: ['comparison', 'bitnami', 'kubernetes']
 ---
 
 ## Two approaches to Helm charts
@@ -20,12 +20,12 @@ The biggest difference between HelmForge and Bitnami is what runs inside your po
 
 **HelmForge** uses the official upstream image directly. Our charts configure the application through environment variables, config maps, and init containers — without modifying the image itself.
 
-| Aspect | HelmForge | Bitnami |
-|--------|-----------|---------|
-| Base image | Official upstream | Bitnami-rebuilt |
-| Image source | Docker Hub / upstream registry | Bitnami registry |
-| Entrypoint | Upstream default | Custom Bitnami scripts |
-| Update lag | Same day as upstream | Days to weeks |
+| Aspect       | HelmForge                      | Bitnami                |
+| ------------ | ------------------------------ | ---------------------- |
+| Base image   | Official upstream              | Bitnami-rebuilt        |
+| Image source | Docker Hub / upstream registry | Bitnami registry       |
+| Entrypoint   | Upstream default               | Custom Bitnami scripts |
+| Update lag   | Same day as upstream           | Days to weeks          |
 
 ## Licensing
 
@@ -40,7 +40,7 @@ This is where HelmForge takes a strong stance. Every data-bearing chart includes
 ```yaml
 backup:
   enabled: true
-  schedule: "0 3 * * *"
+  schedule: '0 3 * * *'
   s3:
     endpoint: https://minio.internal:9000
     bucket: db-backups
@@ -52,12 +52,14 @@ Bitnami charts do not include backup functionality. You need to build your own b
 ## When to choose each
 
 **Choose HelmForge when:**
+
 - You want official upstream images with no modifications
 - You need built-in backup for databases and stateful apps
 - You prefer MIT licensing with no vendor dependency
 - You value security defaults (non-root, read-only FS)
 
 **Choose Bitnami when:**
+
 - You need a chart that HelmForge does not offer yet
 - Your organization already standardizes on Bitnami images
 - You need the broader ecosystem of 100+ charts

--- a/src/content/blog/helmforge-vs-bitnami.mdx
+++ b/src/content/blog/helmforge-vs-bitnami.mdx
@@ -1,0 +1,69 @@
+---
+title: "HelmForge vs Bitnami: A Practical Comparison"
+description: "An honest look at how HelmForge charts compare to Bitnami — images, licensing, backup, and operational trade-offs."
+date: 2025-02-10
+author: "HelmForge Team"
+tags: ["comparison", "bitnami", "kubernetes"]
+---
+
+## Two approaches to Helm charts
+
+Bitnami has been the default choice for Helm charts for years. They offer hundreds of charts with consistent tooling and regular updates. So why would you consider an alternative?
+
+The answer comes down to three things: **images**, **licensing**, and **operational philosophy**.
+
+## Official images vs rebuilt images
+
+The biggest difference between HelmForge and Bitnami is what runs inside your pods.
+
+**Bitnami** rebuilds every upstream image with their own base layer, entrypoint scripts, and configuration system. This means the PostgreSQL you deploy is not the official `postgres` image — it is `bitnami/postgresql` with custom scripts layered on top.
+
+**HelmForge** uses the official upstream image directly. Our charts configure the application through environment variables, config maps, and init containers — without modifying the image itself.
+
+| Aspect | HelmForge | Bitnami |
+|--------|-----------|---------|
+| Base image | Official upstream | Bitnami-rebuilt |
+| Image source | Docker Hub / upstream registry | Bitnami registry |
+| Entrypoint | Upstream default | Custom Bitnami scripts |
+| Update lag | Same day as upstream | Days to weeks |
+
+## Licensing
+
+HelmForge charts are MIT licensed. The chart code, templates, documentation — everything is MIT with no exceptions.
+
+Bitnami charts are Apache 2.0 licensed, which is also permissive. However, some Bitnami images include components with different licensing terms, and the dependency on Bitnami's image infrastructure creates a soft vendor lock-in.
+
+## Built-in backup
+
+This is where HelmForge takes a strong stance. Every data-bearing chart includes an optional S3-compatible backup CronJob. Enable it with a few lines of YAML:
+
+```yaml
+backup:
+  enabled: true
+  schedule: "0 3 * * *"
+  s3:
+    endpoint: https://minio.internal:9000
+    bucket: db-backups
+    existingSecret: s3-credentials
+```
+
+Bitnami charts do not include backup functionality. You need to build your own backup solution or use a separate tool like Velero.
+
+## When to choose each
+
+**Choose HelmForge when:**
+- You want official upstream images with no modifications
+- You need built-in backup for databases and stateful apps
+- You prefer MIT licensing with no vendor dependency
+- You value security defaults (non-root, read-only FS)
+
+**Choose Bitnami when:**
+- You need a chart that HelmForge does not offer yet
+- Your organization already standardizes on Bitnami images
+- You need the broader ecosystem of 100+ charts
+
+## The bottom line
+
+Both projects serve the Kubernetes community well. HelmForge is not trying to replace Bitnami — it is offering an alternative for teams that want official images, built-in backup, and a more opinionated approach to production readiness.
+
+Explore the [full comparison table](/docs/comparison) for a detailed feature-by-feature breakdown.

--- a/src/content/blog/introducing-helmforge.mdx
+++ b/src/content/blog/introducing-helmforge.mdx
@@ -1,0 +1,54 @@
+---
+title: "Introducing HelmForge: Why We Built It"
+description: "The story behind HelmForge — production-ready Helm charts built with security, backups, and operational excellence as first-class features."
+date: 2025-01-15
+author: "HelmForge Team"
+tags: ["announcement", "open-source", "kubernetes"]
+---
+
+## The problem with Helm charts today
+
+If you have run Kubernetes in production, you have probably experienced the pain of finding a good Helm chart. The ecosystem is fragmented: official charts are abandoned, community charts vary wildly in quality, and the dominant player wraps everything in proprietary images.
+
+We built HelmForge because we believed there should be a better option.
+
+## What makes HelmForge different
+
+Every HelmForge chart is built around three principles:
+
+### 1. Official upstream images only
+
+We never rebuild or wrap upstream Docker images. When you deploy PostgreSQL with HelmForge, you get the official `postgres` image from Docker Hub. No custom entrypoints, no vendor lock-in, no wondering what was added to the image.
+
+### 2. Built-in S3 backup from day one
+
+Backup should not be an afterthought. Charts that manage data include a configurable CronJob for S3-compatible backup out of the box. Point it at MinIO, AWS S3, or any compatible endpoint and your data is protected.
+
+```yaml
+backup:
+  enabled: true
+  schedule: "0 2 * * *"
+  s3:
+    endpoint: https://s3.amazonaws.com
+    bucket: my-backups
+    existingSecret: backup-credentials
+```
+
+### 3. Security as default
+
+Every container runs as non-root with read-only root filesystems where possible. Security contexts, network policies, and pod disruption budgets are not hidden behind flags — they are the default.
+
+## The numbers
+
+Since our first release, HelmForge has grown to over 30 stable charts covering databases, CMS platforms, identity management, monitoring, and more. Every chart goes through:
+
+- Automated CI with `helm lint`, `helm template`, and unit tests
+- Local k3d validation before every release
+- Cosign keyless signing for OCI artifacts
+- Conventional Commits powering automated semantic versioning
+
+## What is next
+
+We are actively building more charts based on community requests. If there is an application you want to see in HelmForge, [request it](/request) and the community votes on priorities.
+
+HelmForge is MIT licensed and always will be. Check out the [getting started guide](/docs/getting-started) or browse the [chart catalog](/) to find what you need.

--- a/src/content/blog/introducing-helmforge.mdx
+++ b/src/content/blog/introducing-helmforge.mdx
@@ -1,9 +1,9 @@
 ---
-title: "Introducing HelmForge: Why We Built It"
-description: "The story behind HelmForge — production-ready Helm charts built with security, backups, and operational excellence as first-class features."
+title: 'Introducing HelmForge: Why We Built It'
+description: 'The story behind HelmForge — production-ready Helm charts built with security, backups, and operational excellence as first-class features.'
 date: 2025-01-15
-author: "HelmForge Team"
-tags: ["announcement", "open-source", "kubernetes"]
+author: 'HelmForge Team'
+tags: ['announcement', 'open-source', 'kubernetes']
 ---
 
 ## The problem with Helm charts today
@@ -27,7 +27,7 @@ Backup should not be an afterthought. Charts that manage data include a configur
 ```yaml
 backup:
   enabled: true
-  schedule: "0 2 * * *"
+  schedule: '0 2 * * *'
   s3:
     endpoint: https://s3.amazonaws.com
     bucket: my-backups

--- a/src/content/blog/production-postgresql-kubernetes.mdx
+++ b/src/content/blog/production-postgresql-kubernetes.mdx
@@ -1,9 +1,9 @@
 ---
-title: "Deploy Production-Ready PostgreSQL on Kubernetes"
-description: "Step-by-step guide to deploying PostgreSQL with replication, automated backups, and monitoring using the HelmForge chart."
+title: 'Deploy Production-Ready PostgreSQL on Kubernetes'
+description: 'Step-by-step guide to deploying PostgreSQL with replication, automated backups, and monitoring using the HelmForge chart.'
 date: 2025-03-05
-author: "HelmForge Team"
-tags: ["tutorial", "postgresql", "database", "kubernetes"]
+author: 'HelmForge Team'
+tags: ['tutorial', 'postgresql', 'database', 'kubernetes']
 ---
 
 ## What you will build
@@ -60,7 +60,7 @@ primary:
       cpu: 250m
       memory: 512Mi
     limits:
-      cpu: "1"
+      cpu: '1'
       memory: 1Gi
   persistence:
     size: 20Gi
@@ -72,14 +72,14 @@ readReplicas:
       cpu: 250m
       memory: 512Mi
     limits:
-      cpu: "1"
+      cpu: '1'
       memory: 1Gi
   persistence:
     size: 20Gi
 
 backup:
   enabled: true
-  schedule: "0 2 * * *"
+  schedule: '0 2 * * *'
   s3:
     endpoint: https://s3.amazonaws.com
     bucket: my-pg-backups

--- a/src/content/blog/production-postgresql-kubernetes.mdx
+++ b/src/content/blog/production-postgresql-kubernetes.mdx
@@ -1,0 +1,157 @@
+---
+title: "Deploy Production-Ready PostgreSQL on Kubernetes"
+description: "Step-by-step guide to deploying PostgreSQL with replication, automated backups, and monitoring using the HelmForge chart."
+date: 2025-03-05
+author: "HelmForge Team"
+tags: ["tutorial", "postgresql", "database", "kubernetes"]
+---
+
+## What you will build
+
+By the end of this guide, you will have a PostgreSQL deployment with:
+
+- Streaming replication (1 primary + 1 replica)
+- Automated nightly S3 backups
+- Persistent storage with proper resource limits
+- Ingress-ready configuration
+
+## Prerequisites
+
+- A running Kubernetes cluster (k3d, kind, EKS, GKE, etc.)
+- `helm` v3.12+ and `kubectl` installed
+- An S3-compatible endpoint for backups (AWS S3, MinIO, etc.)
+
+## Step 1: Add the HelmForge repository
+
+```bash
+helm repo add helmforge https://repo.helmforge.dev
+helm repo update
+```
+
+## Step 2: Create the namespace and secrets
+
+```bash
+kubectl create namespace databases
+
+kubectl create secret generic postgresql-credentials \
+  --namespace databases \
+  --from-literal=postgres-password=your-secure-password \
+  --from-literal=replication-password=repl-secure-password
+
+kubectl create secret generic backup-s3-credentials \
+  --namespace databases \
+  --from-literal=access-key=YOUR_ACCESS_KEY \
+  --from-literal=secret-key=YOUR_SECRET_KEY
+```
+
+## Step 3: Create the values file
+
+Create a file called `postgresql-values.yaml`:
+
+```yaml
+architecture: replication
+
+auth:
+  existingSecret: postgresql-credentials
+
+primary:
+  resources:
+    requests:
+      cpu: 250m
+      memory: 512Mi
+    limits:
+      cpu: "1"
+      memory: 1Gi
+  persistence:
+    size: 20Gi
+
+readReplicas:
+  replicaCount: 1
+  resources:
+    requests:
+      cpu: 250m
+      memory: 512Mi
+    limits:
+      cpu: "1"
+      memory: 1Gi
+  persistence:
+    size: 20Gi
+
+backup:
+  enabled: true
+  schedule: "0 2 * * *"
+  s3:
+    endpoint: https://s3.amazonaws.com
+    bucket: my-pg-backups
+    existingSecret: backup-s3-credentials
+```
+
+## Step 4: Install
+
+```bash
+helm install postgresql helmforge/postgresql \
+  --namespace databases \
+  --values postgresql-values.yaml \
+  --wait --timeout 5m
+```
+
+## Step 5: Verify the deployment
+
+Check that all pods are running:
+
+```bash
+kubectl get pods -n databases -l app.kubernetes.io/name=postgresql
+```
+
+You should see two pods: one primary and one replica.
+
+Test the connection:
+
+```bash
+kubectl run pg-test --rm -it --restart=Never \
+  --namespace databases \
+  --image=postgres:17 \
+  -- psql -h postgresql-primary -U postgres -c "SELECT version();"
+```
+
+## Step 6: Verify replication
+
+Connect to the replica and confirm it is streaming:
+
+```bash
+kubectl run pg-test --rm -it --restart=Never \
+  --namespace databases \
+  --image=postgres:17 \
+  -- psql -h postgresql-read -U postgres -c "SELECT * FROM pg_stat_wal_receiver;"
+```
+
+## Step 7: Verify backup
+
+Check the backup CronJob:
+
+```bash
+kubectl get cronjob -n databases
+```
+
+Trigger a manual backup run to verify:
+
+```bash
+kubectl create job --from=cronjob/postgresql-backup manual-backup -n databases
+kubectl logs -n databases job/manual-backup -f
+```
+
+## Operational tips
+
+**Monitoring:** Export PostgreSQL metrics by enabling the metrics sidecar and scraping with Prometheus.
+
+**Scaling replicas:** Increase `readReplicas.replicaCount` and run `helm upgrade` — new replicas automatically sync from the primary.
+
+**Disaster recovery:** Restore from S3 backup by downloading the dump and running `pg_restore` against a fresh instance.
+
+**Upgrades:** Always review the [upgrade notes](/docs/charts/postgresql) before changing the chart version. PostgreSQL major version upgrades require `pg_upgrade` — the chart handles minor version bumps automatically.
+
+## Next steps
+
+- Read the full [PostgreSQL chart documentation](/docs/charts/postgresql)
+- Explore other database charts: [MySQL](/docs/charts/mysql), [MongoDB](/docs/charts/mongodb), [MariaDB](/docs/charts/mariadb)
+- Try the [Stack Builder](/stack) to generate install scripts for your full stack

--- a/src/layouts/BlogLayout.astro
+++ b/src/layouts/BlogLayout.astro
@@ -1,0 +1,124 @@
+---
+import BaseLayout from './BaseLayout.astro';
+import Header from '../components/Header.astro';
+import Footer from '../components/Footer.astro';
+import Container from '../components/Container.astro';
+
+interface Props {
+  title: string;
+  description: string;
+  date: Date;
+  author: string;
+  tags: string[];
+}
+
+const { title, description, date, author, tags } = Astro.props;
+
+const formattedDate = date.toLocaleDateString('en-US', {
+  year: 'numeric',
+  month: 'long',
+  day: 'numeric',
+});
+
+const readingTime = Math.max(1, Math.ceil((Astro.props.title.length + 500) / 200));
+
+const articleJsonLd = {
+  '@context': 'https://schema.org',
+  '@type': 'Article',
+  headline: title,
+  description,
+  datePublished: date.toISOString(),
+  author: { '@type': 'Organization', name: author },
+  publisher: {
+    '@type': 'Organization',
+    name: 'HelmForge',
+    url: 'https://helmforge.dev',
+    logo: 'https://helmforge.dev/helmforge-logo-horizontal.svg',
+  },
+};
+---
+
+<BaseLayout title={title} description={description}>
+  <Header />
+
+  <script type="application/ld+json" set:html={JSON.stringify(articleJsonLd)} />
+
+  <Container class="py-10 sm:py-14">
+    <div class="max-w-3xl mx-auto">
+      <!-- Back link -->
+      <a
+        href="/blog"
+        class="inline-flex items-center gap-1.5 text-sm text-text-muted hover:text-primary-light transition-colors mb-8"
+      >
+        <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 19l-7-7 7-7"></path>
+        </svg>
+        Back to blog
+      </a>
+
+      <!-- Header -->
+      <header class="mb-10">
+        <div class="flex flex-wrap items-center gap-2 mb-4">
+          {
+            tags.map((tag) => (
+              <span class="text-[10px] font-bold uppercase tracking-wider text-primary bg-primary/10 rounded-full px-2.5 py-0.5">
+                {tag}
+              </span>
+            ))
+          }
+        </div>
+        <h1 class="text-3xl sm:text-4xl lg:text-5xl font-bold tracking-tight text-text-base heading-font leading-tight">
+          {title}
+        </h1>
+        <p class="mt-4 text-lg text-text-muted leading-relaxed">{description}</p>
+        <div class="mt-6 flex items-center gap-4 text-sm text-text-muted">
+          <span>{author}</span>
+          <span class="text-border">|</span>
+          <time datetime={date.toISOString()}>{formattedDate}</time>
+          <span class="text-border">|</span>
+          <span>{readingTime} min read</span>
+        </div>
+      </header>
+
+      <!-- Content -->
+      <article class="glass-panel rounded-2xl px-5 py-8 sm:px-8 lg:px-10" data-pagefind-body>
+        <div class="prose prose-docs max-w-none">
+          <slot />
+        </div>
+      </article>
+
+      <!-- Share -->
+      <div class="mt-8 flex items-center gap-4">
+        <span class="text-sm font-semibold text-text-muted">Share:</span>
+        <a
+          href={`https://twitter.com/intent/tweet?text=${encodeURIComponent(title)}&url=${encodeURIComponent(`https://helmforge.dev/blog/${Astro.url.pathname.split('/').pop()}`)}`}
+          target="_blank"
+          rel="noopener noreferrer"
+          class="text-text-muted hover:text-primary-light transition-colors"
+          aria-label="Share on X"
+        >
+          <svg class="w-5 h-5" fill="currentColor" viewBox="0 0 24 24"
+            ><path
+              d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z"
+            ></path></svg
+          >
+        </a>
+        <a
+          href={`https://www.linkedin.com/sharing/share-offsite/?url=${encodeURIComponent(`https://helmforge.dev/blog/${Astro.url.pathname.split('/').pop()}`)}`}
+          target="_blank"
+          rel="noopener noreferrer"
+          class="text-text-muted hover:text-primary-light transition-colors"
+          aria-label="Share on LinkedIn"
+        >
+          <svg class="w-5 h-5" fill="currentColor" viewBox="0 0 24 24"
+            ><path
+              d="M20.447 20.452h-3.554v-5.569c0-1.328-.027-3.037-1.852-3.037-1.853 0-2.136 1.445-2.136 2.939v5.667H9.351V9h3.414v1.561h.046c.477-.9 1.637-1.85 3.37-1.85 3.601 0 4.267 2.37 4.267 5.455v6.286zM5.337 7.433a2.062 2.062 0 01-2.063-2.065 2.064 2.064 0 112.063 2.065zm1.782 13.019H3.555V9h3.564v11.452zM22.225 0H1.771C.792 0 0 .774 0 1.729v20.542C0 23.227.792 24 1.771 24h20.451C23.2 24 24 23.227 24 22.271V1.729C24 .774 23.2 0 22.222 0h.003z"
+            ></path></svg
+          >
+        </a>
+      </div>
+    </div>
+  </Container>
+
+  <Footer />
+</BaseLayout>

--- a/src/pages/blog/[...slug].astro
+++ b/src/pages/blog/[...slug].astro
@@ -1,0 +1,25 @@
+---
+import { getCollection, render } from 'astro:content';
+import BlogLayout from '../../layouts/BlogLayout.astro';
+
+export async function getStaticPaths() {
+  const posts = await getCollection('blog');
+  return posts.map((post) => ({
+    params: { slug: post.id },
+    props: { post },
+  }));
+}
+
+const { post } = Astro.props;
+const { Content } = await render(post);
+---
+
+<BlogLayout
+  title={post.data.title}
+  description={post.data.description}
+  date={post.data.date}
+  author={post.data.author}
+  tags={post.data.tags}
+>
+  <Content />
+</BlogLayout>

--- a/src/pages/blog/index.astro
+++ b/src/pages/blog/index.astro
@@ -1,0 +1,62 @@
+---
+import BaseLayout from '../../layouts/BaseLayout.astro';
+import Header from '../../components/Header.astro';
+import Footer from '../../components/Footer.astro';
+import Container from '../../components/Container.astro';
+import SectionHeader from '../../components/SectionHeader.astro';
+import { getCollection } from 'astro:content';
+
+const posts = (await getCollection('blog')).sort((a, b) => b.data.date.valueOf() - a.data.date.valueOf());
+---
+
+<BaseLayout title="Blog" description="News, tutorials, and insights about HelmForge charts and Kubernetes operations.">
+  <Header />
+  <main id="main-content" class="py-16 sm:py-20" data-pagefind-body>
+    <Container>
+      <SectionHeader
+        label="Blog"
+        title="News, guides, and deep dives."
+        description="Tutorials, announcements, and practical Kubernetes insights from the HelmForge team."
+      />
+
+      <div class="mt-12 grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+        {
+          posts.map((post) => (
+            <a
+              href={`/blog/${post.id}`}
+              class="group glass-panel rounded-2xl overflow-hidden transition-all hover:border-primary/40 hover:-translate-y-1 hover:shadow-xl hover:shadow-primary/10 flex flex-col"
+            >
+              <div class="p-6 flex flex-col flex-grow">
+                <div class="flex flex-wrap gap-2 mb-3">
+                  {post.data.tags.slice(0, 2).map((tag) => (
+                    <span class="text-[10px] font-bold uppercase tracking-wider text-primary bg-primary/10 rounded-full px-2 py-0.5">
+                      {tag}
+                    </span>
+                  ))}
+                </div>
+                <h2 class="text-lg font-bold text-text-base heading-font group-hover:text-primary-light transition-colors leading-snug">
+                  {post.data.title}
+                </h2>
+                <p class="mt-2 text-sm text-text-muted leading-relaxed line-clamp-3 flex-grow">
+                  {post.data.description}
+                </p>
+                <div class="mt-4 flex items-center justify-between text-xs text-text-muted">
+                  <time datetime={post.data.date.toISOString()}>
+                    {post.data.date.toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' })}
+                  </time>
+                  <span class="flex items-center gap-1 text-primary-light opacity-0 group-hover:opacity-100 transition-opacity">
+                    Read
+                    <svg class="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" />
+                    </svg>
+                  </span>
+                </div>
+              </div>
+            </a>
+          ))
+        }
+      </div>
+    </Container>
+  </main>
+  <Footer />
+</BaseLayout>

--- a/src/pages/rss.xml.ts
+++ b/src/pages/rss.xml.ts
@@ -1,17 +1,31 @@
 import rss from '@astrojs/rss';
 import type { APIContext } from 'astro';
+import { getCollection } from 'astro:content';
 import { charts } from '../data/charts';
 
-export function GET(context: APIContext) {
+export async function GET(context: APIContext) {
+  const posts = await getCollection('blog');
+
+  const blogItems = posts
+    .sort((a, b) => b.data.date.valueOf() - a.data.date.valueOf())
+    .map((post) => ({
+      title: post.data.title,
+      description: post.data.description,
+      link: `/blog/${post.id}`,
+      pubDate: post.data.date,
+    }));
+
+  const chartItems = charts.map((chart) => ({
+    title: `${chart.name} — ${chart.maturity}`,
+    description: chart.description,
+    link: `/docs/charts/${chart.slug}`,
+  }));
+
   return rss({
-    title: 'HelmForge Charts',
+    title: 'HelmForge',
     description: 'Production-ready Helm charts for Kubernetes. The open-source alternative to Bitnami.',
     site: context.site!.toString(),
-    items: charts.map((chart) => ({
-      title: `${chart.name} — ${chart.maturity}`,
-      description: chart.description,
-      link: `/docs/charts/${chart.slug}`,
-    })),
+    items: [...blogItems, ...chartItems],
     customData: '<language>en-us</language>',
   });
 }


### PR DESCRIPTION
## Summary
- Add blog infrastructure using Astro 6 content collections with glob loader
- Create blog index page with card grid and individual post layout with JSON-LD, share links, and reading time
- Add three initial posts: HelmForge introduction, Bitnami comparison, production PostgreSQL tutorial
- Update header nav, footer links, and RSS feed to include blog content
- Fix pre-existing Prettier formatting in playground and stack builder files

## Test plan
- [ ] Blog index page renders at `/blog` with card grid
- [ ] Individual blog posts render with correct layout and metadata
- [ ] RSS feed includes blog posts
- [ ] Navigation and footer links work correctly
- [ ] Build succeeds and Pagefind indexes blog content
- [ ] Lint and format checks pass