### PR TITLE
ci: add dependabot configuration for npm and github actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,42 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 10
+    labels:
+      - "dependencies"
+    commit-message:
+      prefix: "chore(deps)"
+    groups:
+      astro:
+        patterns:
+          - "astro"
+          - "@astrojs/*"
+      tailwind:
+        patterns:
+          - "tailwindcss"
+          - "@tailwindcss/*"
+      eslint:
+        patterns:
+          - "eslint"
+          - "eslint-*"
+          - "@eslint/*"
+          - "typescript-eslint"
+      playwright:
+        patterns:
+          - "@playwright/*"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "ci"
+    commit-message:
+      prefix: "ci(deps)"


### PR DESCRIPTION
## Summary
- Add `.github/dependabot.yml` with weekly dependency update checks
- Configure grouped PRs for astro, tailwind, eslint, and playwright ecosystems
- Monitor GitHub Actions versions for security patches
- Use conventional commit prefixes (`chore(deps)` for npm, `ci(deps)` for actions)

## Test plan
- [ ] Dependabot picks up the config and starts scanning on next schedule
- [ ] PR labels and commit message prefixes are applied correctly