### PR TITLE
fix(site): increase header background opacity to prevent text bleed-through

### DIFF
--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -23,7 +23,7 @@ function isActive(href: string): boolean {
 ---
 
 <header
-  class="glass-panel sticky top-0 z-50 border-b border-border shadow-[0_4px_30px_rgba(0,0,0,0.05)] transition-all"
+  class="header-glass sticky top-0 z-50 border-b border-border shadow-[0_4px_30px_rgba(0,0,0,0.05)] transition-all"
 >
   <Container>
     <div class="flex h-[72px] items-center justify-between">

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -124,6 +124,14 @@ pre,
   box-shadow: var(--shadow-card);
 }
 
+.header-glass {
+  background-color: rgba(18, 18, 21, 0.92);
+  backdrop-filter: blur(24px);
+  -webkit-backdrop-filter: blur(24px);
+  border: 1px solid var(--color-border);
+  box-shadow: var(--shadow-card);
+}
+
 .glow-effect {
   position: relative;
   transition: all var(--duration-normal) cubic-bezier(0.4, 0, 0.2, 1);
@@ -422,6 +430,12 @@ html[data-theme='light'] .prose-docs tbody tr:hover {
 }
 
 html[data-theme='light'] .glass-panel {
+  box-shadow: var(--shadow-card);
+  border-color: #d4d4d8;
+}
+
+html[data-theme='light'] .header-glass {
+  background-color: rgba(255, 255, 255, 0.95);
   box-shadow: var(--shadow-card);
   border-color: #d4d4d8;
 }


### PR DESCRIPTION
## Summary
- Replace `glass-panel` class on sticky header with dedicated `header-glass` class
- Dark mode: 92% opacity (was 65%), light mode: 95% opacity (was 80%)
- Prevents page content text from bleeding through the header when scrolling
- Keeps glass-panel translucency for cards and other panels unchanged

## Test plan
- [ ] Scroll long pages and verify header text is readable without background content showing through
- [ ] Test in both dark and light themes
- [ ] Verify blur effect is still present on the header