### PR TITLE
feat(site): enrich chart docs with tabs, callouts, and expanded values

### DIFF
--- a/src/components/Callout.astro
+++ b/src/components/Callout.astro
@@ -1,0 +1,59 @@
+---
+interface Props {
+  type?: 'info' | 'warning' | 'tip' | 'danger';
+  title?: string;
+}
+
+const { type = 'info', title } = Astro.props;
+
+const styles = {
+  info: {
+    border: 'border-blue-500/30',
+    bg: 'bg-blue-500/5',
+    icon: 'text-blue-400',
+    titleColor: 'text-blue-300',
+  },
+  warning: {
+    border: 'border-amber-500/30',
+    bg: 'bg-amber-500/5',
+    icon: 'text-amber-400',
+    titleColor: 'text-amber-300',
+  },
+  tip: {
+    border: 'border-green-500/30',
+    bg: 'bg-green-500/5',
+    icon: 'text-green-400',
+    titleColor: 'text-green-300',
+  },
+  danger: {
+    border: 'border-red-500/30',
+    bg: 'bg-red-500/5',
+    icon: 'text-red-400',
+    titleColor: 'text-red-300',
+  },
+};
+
+const s = styles[type];
+
+const icons = {
+  info: 'M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z',
+  warning:
+    'M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-2.5L13.732 4c-.77-.833-1.964-.833-2.732 0L4.082 16.5c-.77.833.192 2.5 1.732 2.5z',
+  tip: 'M9.663 17h4.673M12 3v1m6.364 1.636l-.707.707M21 12h-1M4 12H3m3.343-5.657l-.707-.707m2.828 9.9a5 5 0 117.072 0l-.548.547A3.374 3.374 0 0014 18.469V19a2 2 0 11-4 0v-.531c0-.895-.356-1.754-.988-2.386l-.548-.547z',
+  danger: 'M12 8v4m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z',
+};
+---
+
+<div class={`my-6 rounded-xl border-l-4 ${s.border} ${s.bg} p-4 sm:p-5`}>
+  <div class="flex items-start gap-3">
+    <svg class={`w-5 h-5 mt-0.5 shrink-0 ${s.icon}`} fill="none" stroke="currentColor" viewBox="0 0 24 24">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d={icons[type]}></path>
+    </svg>
+    <div class="min-w-0">
+      {title && <div class={`font-bold text-sm mb-1 ${s.titleColor}`}>{title}</div>}
+      <div class="text-sm text-text-muted leading-relaxed [&>p]:mb-2 [&>p:last-child]:mb-0">
+        <slot />
+      </div>
+    </div>
+  </div>
+</div>

--- a/src/components/DocsTabs.astro
+++ b/src/components/DocsTabs.astro
@@ -1,0 +1,72 @@
+---
+interface Tab {
+  id: string;
+  label: string;
+}
+
+interface Props {
+  tabs: Tab[];
+}
+
+const { tabs } = Astro.props;
+const groupId = `tabs-${Math.random().toString(36).slice(2, 9)}`;
+---
+
+<div class="docs-tabs my-6" data-tabs-group={groupId}>
+  <div class="flex gap-1 rounded-xl bg-bg-surface/60 border border-border p-1" role="tablist">
+    {
+      tabs.map((tab, i) => (
+        <button
+          role="tab"
+          aria-selected={i === 0 ? 'true' : 'false'}
+          aria-controls={`${groupId}-panel-${tab.id}`}
+          data-tab-id={tab.id}
+          class:list={[
+            'docs-tab rounded-lg px-4 py-2 text-sm font-semibold transition-all cursor-pointer',
+            i === 0
+              ? 'bg-primary/15 text-primary-light shadow-sm'
+              : 'text-text-muted hover:text-text-base hover:bg-text-base/5',
+          ]}
+        >
+          {tab.label}
+        </button>
+      ))
+    }
+  </div>
+
+  <div class="docs-tabs-content mt-4">
+    <slot />
+  </div>
+</div>
+
+<script>
+  document.addEventListener('DOMContentLoaded', () => {
+    document.querySelectorAll<HTMLElement>('.docs-tabs').forEach((group) => {
+      const buttons = group.querySelectorAll<HTMLButtonElement>('[role="tab"]');
+      const panels = group.querySelectorAll<HTMLElement>('[data-tab-panel]');
+
+      // Hide all panels except first
+      panels.forEach((p, i) => {
+        if (i > 0) p.classList.add('hidden');
+      });
+
+      buttons.forEach((btn) => {
+        btn.addEventListener('click', () => {
+          const tabId = btn.dataset.tabId;
+
+          buttons.forEach((b) => {
+            const isActive = b.dataset.tabId === tabId;
+            b.setAttribute('aria-selected', isActive ? 'true' : 'false');
+            b.className = isActive
+              ? 'docs-tab rounded-lg px-4 py-2 text-sm font-semibold transition-all cursor-pointer bg-primary/15 text-primary-light shadow-sm'
+              : 'docs-tab rounded-lg px-4 py-2 text-sm font-semibold transition-all cursor-pointer text-text-muted hover:text-text-base hover:bg-text-base/5';
+          });
+
+          panels.forEach((p) => {
+            p.classList.toggle('hidden', p.dataset.tabPanel !== tabId);
+          });
+        });
+      });
+    });
+  });
+</script>

--- a/src/pages/docs/charts/keycloak.mdx
+++ b/src/pages/docs/charts/keycloak.mdx
@@ -4,6 +4,9 @@ title: Keycloak Chart
 description: HelmForge Keycloak chart — Keycloak identity and access management for Kubernetes.
 ---
 
+import DocsTabs from '../../../components/DocsTabs.astro';
+import Callout from '../../../components/Callout.astro';
+
 # Keycloak
 
 Production-ready Keycloak deployment for identity and access management, supporting SSO, OAuth 2.0, OIDC, and SAML.
@@ -34,10 +37,19 @@ helm install my-keycloak helmforge/keycloak
 helm install my-keycloak oci://ghcr.io/helmforgedev/helm/keycloak
 ```
 
-## Basic Example
+## Deployment Examples
+
+<DocsTabs tabs={[
+  { id: 'basic', label: 'Basic' },
+  { id: 'external-db', label: 'External Database' },
+  { id: 'ha', label: 'High Availability' },
+  { id: 'ingress', label: 'With Ingress + TLS' },
+]}>
+
+<div data-tab-panel="basic">
 
 ```yaml
-# values.yaml
+# values.yaml — Embedded H2 database (dev only)
 auth:
   adminUser: admin
   adminPassword: 'my-secret-password'
@@ -50,15 +62,19 @@ ingress:
       paths:
         - path: /
           pathType: Prefix
-  tls:
-    - secretName: keycloak-tls
-      hosts:
-        - auth.example.com
 ```
 
-## External Database Example
+<Callout type="warning" title="H2 is for development only">
+  The embedded H2 database does not support clustering and will lose data if the pod restarts without persistence.
+  Always use an external database for production.
+</Callout>
+
+</div>
+
+<div data-tab-panel="external-db">
 
 ```yaml
+# values.yaml
 auth:
   adminUser: admin
   adminPassword: 'my-secret-password'
@@ -81,18 +97,127 @@ ingress:
           pathType: Prefix
 ```
 
+</div>
+
+<div data-tab-panel="ha">
+
+```yaml
+# values.yaml — Multi-replica with external PostgreSQL
+replicaCount: 3
+
+auth:
+  adminUser: admin
+  adminPassword: 'my-secret-password'
+
+database:
+  vendor: postgres
+  hostname: postgresql.database.svc
+  port: 5432
+  database: keycloak
+  username: keycloak
+  password: 'db-password'
+
+resources:
+  requests:
+    memory: 512Mi
+    cpu: 500m
+  limits:
+    memory: 1Gi
+
+ingress:
+  enabled: true
+  ingressClassName: traefik
+  hosts:
+    - host: auth.example.com
+      paths:
+        - path: /
+          pathType: Prefix
+```
+
+</div>
+
+<div data-tab-panel="ingress">
+
+```yaml
+# values.yaml — Full ingress with TLS and cert-manager
+auth:
+  adminUser: admin
+  adminPassword: 'my-secret-password'
+
+database:
+  vendor: postgres
+  hostname: postgresql.database.svc
+  port: 5432
+  database: keycloak
+  username: keycloak
+  password: 'db-password'
+
+ingress:
+  enabled: true
+  ingressClassName: traefik
+  hosts:
+    - host: auth.example.com
+      paths:
+        - path: /
+          pathType: Prefix
+  tls:
+    - secretName: keycloak-tls
+      hosts:
+        - auth.example.com
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt-prod
+```
+
+</div>
+
+</DocsTabs>
+
 ## Key Values
 
-| Key                        | Default   | Description                                |
-| -------------------------- | --------- | ------------------------------------------ |
-| `auth.adminUser`           | `admin`   | Keycloak admin username                    |
-| `auth.adminPassword`       | `""`      | Keycloak admin password                    |
-| `database.vendor`          | `h2`      | Database vendor: `h2`, `postgres`, `mysql` |
-| `database.hostname`        | `""`      | External database hostname                 |
-| `ingress.enabled`          | `false`   | Enable ingress                             |
-| `ingress.ingressClassName` | `traefik` | Ingress class                              |
-| `replicaCount`             | `1`       | Number of Keycloak replicas                |
-| `metrics.enabled`          | `false`   | Enable Prometheus metrics                  |
+| Key                              | Type    | Default    | Description                                |
+| -------------------------------- | ------- | ---------- | ------------------------------------------ |
+| `auth.adminUser`                 | string  | `admin`    | Keycloak admin username                    |
+| `auth.adminPassword`             | string  | `""`       | Keycloak admin password                    |
+| `database.vendor`                | string  | `h2`       | Database vendor: `h2`, `postgres`, `mysql` |
+| `database.hostname`              | string  | `""`       | External database hostname                 |
+| `database.port`                  | integer | `5432`     | External database port                     |
+| `database.database`              | string  | `keycloak` | Database name                              |
+| `database.username`              | string  | `""`       | Database username                          |
+| `database.password`              | string  | `""`       | Database password                          |
+| `replicaCount`                   | integer | `1`        | Number of Keycloak replicas                |
+| `ingress.enabled`                | boolean | `false`    | Enable ingress                             |
+| `ingress.ingressClassName`       | string  | `traefik`  | Ingress class name                         |
+| `ingress.hosts`                  | array   | `[]`       | Ingress host rules                         |
+| `ingress.tls`                    | array   | `[]`       | TLS configuration                          |
+| `resources.requests.memory`      | string  | `256Mi`    | Memory request                             |
+| `resources.requests.cpu`         | string  | `250m`     | CPU request                                |
+| `metrics.enabled`                | boolean | `false`    | Enable Prometheus metrics                  |
+| `metrics.serviceMonitor.enabled` | boolean | `false`    | Create ServiceMonitor resource             |
+| `realmImport`                    | object  | `{}`       | Realm configuration to import on startup   |
+
+## Upgrade Notes
+
+<Callout type="warning" title="Database migrations">
+  Keycloak runs database migrations automatically on startup. When upgrading to a new Keycloak version, ensure only one
+  replica starts first (scale to 1, upgrade, then scale back). Running migrations from multiple replicas simultaneously
+  can cause conflicts.
+</Callout>
+
+- Admin password changes in values only take effect on fresh installations
+- Realm import runs on every startup by default — use `realmImport.skipExisting: true` to avoid overwriting
+- Ingress annotations changes require a pod restart if the ingress controller caches configuration
+
+## Common Issues
+
+<Callout type="danger" title="Admin console returns 403 or redirect loop">
+  This usually means the proxy headers are not configured correctly. Ensure your ingress controller forwards
+  `X-Forwarded-For`, `X-Forwarded-Proto`, and `X-Forwarded-Host` headers. For Traefik, this is enabled by default.
+</Callout>
+
+<Callout type="tip" title="Slow startup with large realms">
+  Keycloak with many realms, clients, or users takes longer to start. Increase the `startupProbe.failureThreshold` and
+  `startupProbe.periodSeconds` values to prevent Kubernetes from killing the pod before it finishes initialization.
+</Callout>
 
 ## More Information
 

--- a/src/pages/docs/charts/mongodb.mdx
+++ b/src/pages/docs/charts/mongodb.mdx
@@ -4,6 +4,9 @@ title: MongoDB Chart
 description: HelmForge MongoDB chart — MongoDB with standalone and replica set configurations for Kubernetes.
 ---
 
+import DocsTabs from '../../../components/DocsTabs.astro';
+import Callout from '../../../components/Callout.astro';
+
 # MongoDB
 
 Production-ready MongoDB deployment with support for standalone and replica set configurations.
@@ -33,7 +36,15 @@ helm install my-mongo helmforge/mongodb
 helm install my-mongo oci://ghcr.io/helmforgedev/helm/mongodb
 ```
 
-## Standalone Example
+## Deployment Examples
+
+<DocsTabs tabs={[
+  { id: 'standalone', label: 'Standalone' },
+  { id: 'replicaset', label: 'Replica Set' },
+  { id: 'arbiter', label: 'With Arbiter' },
+]}>
+
+<div data-tab-panel="standalone">
 
 ```yaml
 # values.yaml
@@ -54,9 +65,12 @@ metrics:
     enabled: true
 ```
 
-## Replica Set Example
+</div>
+
+<div data-tab-panel="replicaset">
 
 ```yaml
+# values.yaml
 architecture: replicaset
 
 auth:
@@ -69,23 +83,79 @@ replicaCount: 3
 
 persistence:
   size: 20Gi
+```
+
+</div>
+
+<div data-tab-panel="arbiter">
+
+```yaml
+# values.yaml
+architecture: replicaset
+
+auth:
+  rootPassword: 'my-secret-password'
+  database: myapp
+
+replicaCount: 2
+
+persistence:
+  size: 20Gi
 
 arbiter:
   enabled: true
 ```
 
+<Callout type="info" title="When to use an arbiter">
+  An arbiter participates in elections but holds no data. Use it when you have an even number of data-bearing members to
+  ensure a majority for elections. With 3 data members, an arbiter is not needed.
+</Callout>
+
+</div>
+
+</DocsTabs>
+
 ## Key Values
 
-| Key                 | Default      | Description                   |
-| ------------------- | ------------ | ----------------------------- |
-| `architecture`      | `standalone` | `standalone` or `replicaset`  |
-| `auth.rootPassword` | `""`         | MongoDB root password         |
-| `auth.database`     | `""`         | Default database to create    |
-| `auth.username`     | `""`         | Default user to create        |
-| `replicaCount`      | `1`          | Number of replica set members |
-| `persistence.size`  | `8Gi`        | PVC size                      |
-| `arbiter.enabled`   | `false`      | Enable arbiter node           |
-| `metrics.enabled`   | `false`      | Enable Prometheus exporter    |
+| Key                              | Type    | Default      | Description                                           |
+| -------------------------------- | ------- | ------------ | ----------------------------------------------------- |
+| `architecture`                   | string  | `standalone` | Deployment architecture: `standalone` or `replicaset` |
+| `auth.rootPassword`              | string  | `""`         | MongoDB root password                                 |
+| `auth.database`                  | string  | `""`         | Default database to create                            |
+| `auth.username`                  | string  | `""`         | Default user to create                                |
+| `auth.password`                  | string  | `""`         | Password for default user                             |
+| `replicaCount`                   | integer | `1`          | Number of replica set members                         |
+| `persistence.size`               | string  | `8Gi`        | PVC size                                              |
+| `persistence.storageClass`       | string  | `""`         | Storage class for PVC                                 |
+| `resources.requests.memory`      | string  | `256Mi`      | Memory request                                        |
+| `resources.requests.cpu`         | string  | `250m`       | CPU request                                           |
+| `arbiter.enabled`                | boolean | `false`      | Enable arbiter node                                   |
+| `metrics.enabled`                | boolean | `false`      | Enable Prometheus exporter                            |
+| `metrics.serviceMonitor.enabled` | boolean | `false`      | Create ServiceMonitor resource                        |
+| `networkPolicy.enabled`          | boolean | `false`      | Enable network policies                               |
+
+## Upgrade Notes
+
+<Callout type="warning" title="Replica set reconfiguration">
+  Changing `replicaCount` triggers a replica set reconfiguration. MongoDB handles this gracefully, but scaling down
+  removes members — ensure no data is exclusively on the removed members.
+</Callout>
+
+- Upgrading from standalone to replicaset requires re-initialization (dump and restore)
+- Auth credentials are set during first initialization and cannot be changed via values on upgrade
+- WiredTiger cache size defaults to 50% of available memory — set `resources.limits.memory` accordingly
+
+## Common Issues
+
+<Callout type="danger" title="Replica set members stuck in RECOVERING">
+  This usually means initial sync is still in progress for large datasets. Check sync progress with `rs.status()` inside
+  the mongo shell. If it persists, check disk IOPS and network bandwidth.
+</Callout>
+
+<Callout type="tip" title="Connection string for replica sets">
+  Use the full replica set connection string with all members listed, or use the headless service DNS:
+  `mongodb://user:pass@my-mongo-mongodb-headless.namespace.svc:27017/mydb?replicaSet=rs0`
+</Callout>
 
 ## More Information
 

--- a/src/pages/docs/charts/mysql.mdx
+++ b/src/pages/docs/charts/mysql.mdx
@@ -4,6 +4,9 @@ title: MySQL Chart
 description: HelmForge MySQL chart — MySQL with standalone and source-replica replication architectures for Kubernetes.
 ---
 
+import DocsTabs from '../../../components/DocsTabs.astro';
+import Callout from '../../../components/Callout.astro';
+
 # MySQL
 
 Production-ready MySQL deployment with support for standalone and source-replica replication architectures.
@@ -12,7 +15,7 @@ Production-ready MySQL deployment with support for standalone and source-replica
 
 - **Standalone and replication** — Single instance or source-replica topology
 - **Automatic initialization** — Init scripts and custom configuration
-- **Backup support** — Configurable backup CronJobs
+- **Backup support** — Configurable backup CronJobs to S3-compatible storage
 - **Metrics** — Prometheus exporter with ServiceMonitor
 - **Security** — Non-root containers, network policies, TLS support
 - **Persistent storage** — Configurable PVCs with storage class selection
@@ -33,7 +36,16 @@ helm install my-mysql helmforge/mysql
 helm install my-mysql oci://ghcr.io/helmforgedev/helm/mysql
 ```
 
-## Standalone Example
+## Deployment Examples
+
+<DocsTabs tabs={[
+  { id: 'standalone', label: 'Standalone' },
+  { id: 'replication', label: 'Replication' },
+  { id: 'backup', label: 'With Backup' },
+  { id: 'ingress', label: 'With Ingress' },
+]}>
+
+<div data-tab-panel="standalone">
 
 ```yaml
 # values.yaml
@@ -55,9 +67,12 @@ metrics:
     enabled: true
 ```
 
-## Replication Example
+</div>
+
+<div data-tab-panel="replication">
 
 ```yaml
+# values.yaml
 architecture: replication
 
 auth:
@@ -77,18 +92,115 @@ secondary:
     size: 20Gi
 ```
 
+</div>
+
+<div data-tab-panel="backup">
+
+```yaml
+# values.yaml
+architecture: standalone
+
+auth:
+  rootPassword: 'my-secret-password'
+  database: myapp
+
+primary:
+  persistence:
+    size: 20Gi
+
+backup:
+  enabled: true
+  schedule: '0 3 * * *'
+  s3:
+    endpoint: https://s3.amazonaws.com
+    bucket: my-mysql-backups
+    accessKey: AKIAIOSFODNN7EXAMPLE
+    secretKey: wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
+  retention:
+    days: 30
+```
+
+</div>
+
+<div data-tab-panel="ingress">
+
+```yaml
+# values.yaml — Use with phpMyAdmin or a web-based management tool
+architecture: standalone
+
+auth:
+  rootPassword: 'my-secret-password'
+  database: myapp
+
+primary:
+  persistence:
+    size: 20Gi
+
+ingress:
+  enabled: true
+  ingressClassName: traefik
+  hosts:
+    - host: phpmyadmin.example.com
+      paths:
+        - path: /
+          pathType: Prefix
+  tls:
+    - secretName: phpmyadmin-tls
+      hosts:
+        - phpmyadmin.example.com
+  # annotations:
+  #   cert-manager.io/cluster-issuer: letsencrypt-prod
+```
+
+</div>
+
+</DocsTabs>
+
 ## Key Values
 
-| Key                        | Default      | Description                   |
-| -------------------------- | ------------ | ----------------------------- |
-| `architecture`             | `standalone` | `standalone` or `replication` |
-| `auth.rootPassword`        | `""`         | MySQL root password           |
-| `auth.database`            | `""`         | Default database to create    |
-| `auth.username`            | `""`         | Default user to create        |
-| `auth.password`            | `""`         | Password for default user     |
-| `primary.persistence.size` | `8Gi`        | Primary PVC size              |
-| `secondary.replicaCount`   | `1`          | Number of read replicas       |
-| `metrics.enabled`          | `false`      | Enable Prometheus exporter    |
+| Key                                 | Type    | Default      | Description                                            |
+| ----------------------------------- | ------- | ------------ | ------------------------------------------------------ |
+| `architecture`                      | string  | `standalone` | Deployment architecture: `standalone` or `replication` |
+| `auth.rootPassword`                 | string  | `""`         | MySQL root password                                    |
+| `auth.database`                     | string  | `""`         | Default database to create                             |
+| `auth.username`                     | string  | `""`         | Default user to create                                 |
+| `auth.password`                     | string  | `""`         | Password for default user                              |
+| `auth.replicationPassword`          | string  | `""`         | Password for replication user                          |
+| `primary.persistence.size`          | string  | `8Gi`        | Primary PVC size                                       |
+| `primary.persistence.storageClass`  | string  | `""`         | Storage class for primary PVC                          |
+| `primary.resources.requests.memory` | string  | `256Mi`      | Memory request for primary                             |
+| `primary.resources.requests.cpu`    | string  | `250m`       | CPU request for primary                                |
+| `secondary.replicaCount`            | integer | `1`          | Number of read replicas                                |
+| `secondary.persistence.size`        | string  | `8Gi`        | Secondary PVC size                                     |
+| `backup.enabled`                    | boolean | `false`      | Enable S3 backup CronJob                               |
+| `backup.schedule`                   | string  | `0 3 * * *`  | Cron schedule for backups                              |
+| `metrics.enabled`                   | boolean | `false`      | Enable Prometheus exporter                             |
+| `metrics.serviceMonitor.enabled`    | boolean | `false`      | Create ServiceMonitor resource                         |
+| `networkPolicy.enabled`             | boolean | `false`      | Enable network policies                                |
+| `tls.enabled`                       | boolean | `false`      | Enable TLS encryption                                  |
+
+## Upgrade Notes
+
+<Callout type="warning" title="Password persistence">
+  MySQL stores the root password during initial setup. On upgrade, ensure `auth.rootPassword` matches the original value
+  or the pod will fail to start with an authentication error.
+</Callout>
+
+- When enabling replication on an existing standalone instance, a full re-initialization is required
+- Backup CronJob changes take effect on the next scheduled run
+- Secondary replicas are read-only; write attempts return an error
+
+## Common Issues
+
+<Callout type="danger" title="Pod stuck in CrashLoopBackOff after upgrade">
+  If the root password in values doesn't match the existing data directory, MySQL refuses to start.
+  Check logs with `kubectl logs <pod>` and verify the password matches.
+</Callout>
+
+<Callout type="tip" title="Replication lag monitoring">
+  Enable metrics and monitor `mysql_slave_status_seconds_behind_master`. Values consistently above 0 indicate the
+  replica cannot keep up — consider increasing replica resources or reducing write load.
+</Callout>
 
 ## More Information
 

--- a/src/pages/docs/charts/postgresql.mdx
+++ b/src/pages/docs/charts/postgresql.mdx
@@ -4,6 +4,9 @@ title: PostgreSQL Chart
 description: HelmForge PostgreSQL chart — PostgreSQL with standalone and streaming replication for Kubernetes.
 ---
 
+import DocsTabs from '../../../components/DocsTabs.astro';
+import Callout from '../../../components/Callout.astro';
+
 # PostgreSQL
 
 Production-ready PostgreSQL deployment with support for standalone and streaming replication architectures.
@@ -12,7 +15,7 @@ Production-ready PostgreSQL deployment with support for standalone and streaming
 
 - **Standalone and replication** — Single instance or primary with streaming replicas
 - **Automatic initialization** — Init scripts, extensions, and custom configuration
-- **Backup support** — Configurable backup strategies
+- **S3 backup** — Scheduled backups to S3-compatible storage via CronJob
 - **Metrics** — Prometheus exporter with ServiceMonitor
 - **Security** — Non-root containers, network policies, TLS support
 - **Persistent storage** — Configurable PVCs with storage class selection
@@ -33,7 +36,16 @@ helm install my-pg helmforge/postgresql
 helm install my-pg oci://ghcr.io/helmforgedev/helm/postgresql
 ```
 
-## Standalone Example
+## Deployment Examples
+
+<DocsTabs tabs={[
+  { id: 'standalone', label: 'Standalone' },
+  { id: 'replication', label: 'Replication' },
+  { id: 'backup', label: 'With Backup' },
+  { id: 'ingress', label: 'With Ingress' },
+]}>
+
+<div data-tab-panel="standalone">
 
 ```yaml
 # values.yaml
@@ -55,9 +67,12 @@ metrics:
     enabled: true
 ```
 
-## Replication Example
+</div>
+
+<div data-tab-panel="replication">
 
 ```yaml
+# values.yaml
 architecture: replication
 
 auth:
@@ -77,17 +92,131 @@ readReplicas:
     size: 20Gi
 ```
 
+</div>
+
+<div data-tab-panel="backup">
+
+```yaml
+# values.yaml
+architecture: standalone
+
+auth:
+  postgresPassword: 'my-secret-password'
+  database: myapp
+
+primary:
+  persistence:
+    size: 20Gi
+
+backup:
+  enabled: true
+  schedule: '0 2 * * *'
+  s3:
+    endpoint: https://s3.amazonaws.com
+    bucket: my-pg-backups
+    accessKey: AKIAIOSFODNN7EXAMPLE
+    secretKey: wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
+  retention:
+    days: 30
+```
+
+</div>
+
+<div data-tab-panel="ingress">
+
+```yaml
+# values.yaml — Use with pgAdmin or a TCP ingress controller
+architecture: standalone
+
+auth:
+  postgresPassword: 'my-secret-password'
+  database: myapp
+
+primary:
+  persistence:
+    size: 20Gi
+
+# For pgAdmin or web-based management tools
+ingress:
+  enabled: true
+  ingressClassName: traefik
+  hosts:
+    - host: pgadmin.example.com
+      paths:
+        - path: /
+          pathType: Prefix
+  tls:
+    - secretName: pgadmin-tls
+      hosts:
+        - pgadmin.example.com
+  # annotations:
+  #   cert-manager.io/cluster-issuer: letsencrypt-prod
+```
+
+</div>
+
+</DocsTabs>
+
 ## Key Values
 
-| Key                         | Default      | Description                   |
-| --------------------------- | ------------ | ----------------------------- |
-| `architecture`              | `standalone` | `standalone` or `replication` |
-| `auth.postgresPassword`     | `""`         | PostgreSQL superuser password |
-| `auth.database`             | `""`         | Default database to create    |
-| `auth.username`             | `""`         | Default user to create        |
-| `primary.persistence.size`  | `8Gi`        | Primary PVC size              |
-| `readReplicas.replicaCount` | `1`          | Number of read replicas       |
-| `metrics.enabled`           | `false`      | Enable Prometheus exporter    |
+| Key                                 | Type    | Default      | Description                                            |
+| ----------------------------------- | ------- | ------------ | ------------------------------------------------------ |
+| `architecture`                      | string  | `standalone` | Deployment architecture: `standalone` or `replication` |
+| `auth.postgresPassword`             | string  | `""`         | PostgreSQL superuser password                          |
+| `auth.database`                     | string  | `""`         | Default database to create                             |
+| `auth.username`                     | string  | `""`         | Default user to create                                 |
+| `auth.password`                     | string  | `""`         | Password for default user                              |
+| `auth.replicationPassword`          | string  | `""`         | Password for replication user (replication mode)       |
+| `primary.persistence.size`          | string  | `8Gi`        | Primary PVC size                                       |
+| `primary.persistence.storageClass`  | string  | `""`         | Storage class for primary PVC                          |
+| `primary.resources.requests.memory` | string  | `256Mi`      | Memory request for primary                             |
+| `primary.resources.requests.cpu`    | string  | `250m`       | CPU request for primary                                |
+| `readReplicas.replicaCount`         | integer | `1`          | Number of read replicas                                |
+| `readReplicas.persistence.size`     | string  | `8Gi`        | Read replica PVC size                                  |
+| `backup.enabled`                    | boolean | `false`      | Enable S3 backup CronJob                               |
+| `backup.schedule`                   | string  | `0 2 * * *`  | Cron schedule for backups                              |
+| `backup.s3.endpoint`                | string  | `""`         | S3-compatible endpoint URL                             |
+| `backup.s3.bucket`                  | string  | `""`         | S3 bucket name                                         |
+| `metrics.enabled`                   | boolean | `false`      | Enable Prometheus exporter                             |
+| `metrics.serviceMonitor.enabled`    | boolean | `false`      | Create ServiceMonitor resource                         |
+| `networkPolicy.enabled`             | boolean | `false`      | Enable network policies                                |
+| `tls.enabled`                       | boolean | `false`      | Enable TLS encryption                                  |
+
+## Upgrade Notes
+
+<Callout type="warning" title="Upgrading from 0.x to 1.x">
+  If upgrading across major versions, check the
+  <a
+    href="https://github.com/helmforgedev/charts/tree/main/charts/postgresql"
+    target="_blank"
+    rel="noopener noreferrer"
+  >
+    changelog
+  </a>
+  for breaking changes in values structure. Always back up your data before upgrading.
+</Callout>
+
+- When switching from `standalone` to `replication`, set `auth.replicationPassword` before upgrading
+- PVC resize requires the storage class to support volume expansion (`allowVolumeExpansion: true`)
+- Metrics sidecar changes may cause a pod restart during upgrade
+
+## Common Issues
+
+<Callout type="danger" title="Pod stuck in CrashLoopBackOff">
+  Usually caused by incorrect `auth.postgresPassword` on upgrade. PostgreSQL does not re-initialize
+  auth when the data directory already exists. Check logs with `kubectl logs <pod>` and verify the
+  password matches the existing data.
+</Callout>
+
+<Callout type="tip" title="Slow replication sync">
+  For large databases, initial replica sync can take time. Increase `readReplicas.resources` and ensure the storage
+  class provides adequate IOPS. Monitor replication lag with the Prometheus exporter (`pg_replication_lag` metric).
+</Callout>
+
+<Callout type="info" title="Using with connection poolers">
+  For high-connection workloads, deploy PgBouncer alongside PostgreSQL. Point your application to PgBouncer and
+  configure it to connect to the PostgreSQL service.
+</Callout>
 
 ## More Information
 

--- a/src/pages/docs/charts/redis.mdx
+++ b/src/pages/docs/charts/redis.mdx
@@ -4,6 +4,9 @@ title: Redis Chart
 description: HelmForge Redis chart — Redis with standalone and Sentinel high-availability for Kubernetes.
 ---
 
+import DocsTabs from '../../../components/DocsTabs.astro';
+import Callout from '../../../components/Callout.astro';
+
 # Redis
 
 Production-ready Redis deployment with support for standalone and Sentinel high-availability architectures.
@@ -32,7 +35,15 @@ helm install my-redis helmforge/redis
 helm install my-redis oci://ghcr.io/helmforgedev/helm/redis
 ```
 
-## Standalone Example
+## Deployment Examples
+
+<DocsTabs tabs={[
+  { id: 'standalone', label: 'Standalone' },
+  { id: 'sentinel', label: 'Sentinel HA' },
+  { id: 'cache', label: 'Cache Only' },
+]}>
+
+<div data-tab-panel="standalone">
 
 ```yaml
 # values.yaml
@@ -51,9 +62,12 @@ metrics:
     enabled: true
 ```
 
-## Sentinel Example
+</div>
+
+<div data-tab-panel="sentinel">
 
 ```yaml
+# values.yaml
 architecture: sentinel
 
 auth:
@@ -72,17 +86,72 @@ sentinel:
   enabled: true
 ```
 
+</div>
+
+<div data-tab-panel="cache">
+
+```yaml
+# values.yaml — Ephemeral cache with no persistence
+architecture: standalone
+
+auth:
+  password: 'my-secret-password'
+
+master:
+  persistence:
+    enabled: false
+  configuration: |
+    maxmemory 512mb
+    maxmemory-policy allkeys-lru
+```
+
+</div>
+
+</DocsTabs>
+
 ## Key Values
 
-| Key                       | Default      | Description                        |
-| ------------------------- | ------------ | ---------------------------------- |
-| `architecture`            | `standalone` | `standalone` or `sentinel`         |
-| `auth.enabled`            | `true`       | Enable password authentication     |
-| `auth.password`           | `""`         | Redis password                     |
-| `master.persistence.size` | `8Gi`        | Master PVC size                    |
-| `replica.replicaCount`    | `3`          | Number of replicas (Sentinel mode) |
-| `sentinel.enabled`        | `false`      | Enable Sentinel                    |
-| `metrics.enabled`         | `false`      | Enable Prometheus exporter         |
+| Key                                | Type    | Default      | Description                                         |
+| ---------------------------------- | ------- | ------------ | --------------------------------------------------- |
+| `architecture`                     | string  | `standalone` | Deployment architecture: `standalone` or `sentinel` |
+| `auth.enabled`                     | boolean | `true`       | Enable password authentication                      |
+| `auth.password`                    | string  | `""`         | Redis password                                      |
+| `master.persistence.enabled`       | boolean | `true`       | Enable persistence for master                       |
+| `master.persistence.size`          | string  | `8Gi`        | Master PVC size                                     |
+| `master.persistence.storageClass`  | string  | `""`         | Storage class for master PVC                        |
+| `master.resources.requests.memory` | string  | `128Mi`      | Memory request for master                           |
+| `master.resources.requests.cpu`    | string  | `100m`       | CPU request for master                              |
+| `master.configuration`             | string  | `""`         | Custom Redis configuration                          |
+| `replica.replicaCount`             | integer | `3`          | Number of replicas (Sentinel mode)                  |
+| `replica.persistence.size`         | string  | `8Gi`        | Replica PVC size                                    |
+| `sentinel.enabled`                 | boolean | `false`      | Enable Sentinel                                     |
+| `metrics.enabled`                  | boolean | `false`      | Enable Prometheus exporter                          |
+| `metrics.serviceMonitor.enabled`   | boolean | `false`      | Create ServiceMonitor resource                      |
+| `networkPolicy.enabled`            | boolean | `false`      | Enable network policies                             |
+
+## Upgrade Notes
+
+<Callout type="warning" title="Sentinel failover during upgrades">
+  In Sentinel mode, rolling upgrades may trigger a failover. This is expected behavior — Sentinel promotes a replica
+  when the master pod restarts. Applications using Sentinel-aware clients handle this transparently.
+</Callout>
+
+- Switching from `standalone` to `sentinel` requires a fresh deployment (data migration needed)
+- Persistence changes only affect new pods; existing PVCs retain their size
+- Custom `master.configuration` overrides are appended to the default config
+
+## Common Issues
+
+<Callout type="danger" title="OOMKilled pods">
+  Redis stores data in memory. If your dataset exceeds the pod's memory limit, Kubernetes kills the pod. Set
+  `master.resources.limits.memory` higher than your expected dataset size, and configure `maxmemory` in Redis to leave
+  headroom for overhead.
+</Callout>
+
+<Callout type="tip" title="Connection refused after failover">
+  If your application connects directly to the master pod IP instead of using the Sentinel service, connections break
+  after failover. Use a Sentinel-aware client library or connect via the `-headless` service.
+</Callout>
 
 ## More Information
 


### PR DESCRIPTION
## Summary
- Add `DocsTabs` component for switching between deployment examples (standalone, replication, backup, ingress)
- Add `Callout` component for tips, warnings, common issues, and danger alerts
- Enrich top 5 chart docs (PostgreSQL, MySQL, Redis, MongoDB, Keycloak) with:
  - Tabbed deployment scenario examples
  - Expanded key values table with types column
  - Upgrade notes section
  - Common issues with troubleshooting callouts
  - Additional deployment patterns (backup, ingress+TLS, cache-only, HA)

## Test plan
- [ ] DocsTabs switches correctly between deployment examples
- [ ] Callout components render with correct styles and icons
- [ ] All 5 enriched chart docs build and render correctly
- [ ] Tabs work with keyboard navigation
- [ ] Build and lint pass