### PR TITLE
feat(site): add accessibility tests and fix wcag 2.1 aa contrast issues

### DIFF
--- a/e2e/accessibility.spec.ts
+++ b/e2e/accessibility.spec.ts
@@ -1,0 +1,66 @@
+import { test, expect } from '@playwright/test';
+import AxeBuilder from '@axe-core/playwright';
+
+const pagesToTest = [
+  { name: 'Homepage', path: '/' },
+  { name: 'Docs', path: '/docs' },
+  { name: 'Playground', path: '/playground' },
+  { name: 'Blog', path: '/blog' },
+  { name: 'Changelog', path: '/changelog' },
+];
+
+test.describe('Accessibility', () => {
+  for (const page of pagesToTest) {
+    test(`${page.name} has no critical a11y violations`, async ({ page: p }) => {
+      await p.goto(page.path);
+      await p.waitForLoadState('domcontentloaded');
+
+      const results = await new AxeBuilder({ page: p })
+        .withTags(['wcag2a', 'wcag2aa', 'wcag21a', 'wcag21aa'])
+        .exclude('.pagefind-ui') // exclude third-party search UI
+        .analyze();
+
+      const critical = results.violations.filter((v) => v.impact === 'critical' || v.impact === 'serious');
+
+      if (critical.length > 0) {
+        const summary = critical
+          .map((v) => `[${v.impact}] ${v.id}: ${v.description} (${v.nodes.length} nodes)`)
+          .join('\n');
+        expect(critical, `Accessibility violations on ${page.name}:\n${summary}`).toHaveLength(0);
+      }
+    });
+  }
+
+  test('skip-to-content link is functional', async ({ page }) => {
+    await page.goto('/');
+    await page.keyboard.press('Tab');
+
+    const skipLink = page.locator('a[href="#main-content"]');
+    await expect(skipLink).toBeFocused();
+    await expect(skipLink).toBeVisible();
+  });
+
+  test('keyboard navigation through header nav', async ({ page }) => {
+    await page.goto('/');
+
+    // Tab past skip link to first nav item
+    await page.keyboard.press('Tab');
+    await page.keyboard.press('Tab'); // logo link
+    await page.keyboard.press('Tab'); // first nav item
+
+    const activeElement = page.locator(':focus');
+    await expect(activeElement).toBeVisible();
+  });
+
+  test('all images have alt text', async ({ page }) => {
+    await page.goto('/');
+    const images = page.locator('img:not([alt])');
+    expect(await images.count()).toBe(0);
+  });
+
+  test('heading hierarchy is correct on homepage', async ({ page }) => {
+    await page.goto('/');
+    const h1Count = await page.locator('h1').count();
+    expect(h1Count).toBe(1);
+  });
+});

--- a/e2e/hero.spec.ts
+++ b/e2e/hero.spec.ts
@@ -1,7 +1,6 @@
 import { test, expect } from '@playwright/test';
 
 test.describe('Hero Section and SEO validations', () => {
-
   test('should render the terminal animation without errors', async ({ page }) => {
     await page.goto('/');
 
@@ -15,9 +14,7 @@ test.describe('Hero Section and SEO validations', () => {
     await expect(terminal).toBeVisible();
 
     // Verify terminal eventually renders the helm repo add output
-    await expect(
-      page.locator('#terminal-lines >> text=helmforge').first()
-    ).toBeVisible({ timeout: 15000 });
+    await expect(page.locator('#terminal-lines >> text=helmforge').first()).toBeVisible({ timeout: 15000 });
   });
 
   test('should inject the aggressive SEO and JSON-LD schemas', async ({ page }) => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "tailwindcss": "^4.2.2"
       },
       "devDependencies": {
+        "@axe-core/playwright": "^4.11.1",
         "@eslint/js": "^10.0.1",
         "@playwright/test": "^1.59.1",
         "eslint": "^10.1.0",
@@ -152,6 +153,19 @@
       },
       "engines": {
         "node": "18.20.8 || ^20.3.0 || >=22.0.0"
+      }
+    },
+    "node_modules/@axe-core/playwright": {
+      "version": "4.11.1",
+      "resolved": "https://registry.npmjs.org/@axe-core/playwright/-/playwright-4.11.1.tgz",
+      "integrity": "sha512-mKEfoUIB1MkVTht0BGZFXtSAEKXMJoDkyV5YZ9jbBmZCcWDz71tegNsdTkIN8zc/yMi5Gm2kx7Z5YQ9PfWNAWw==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "axe-core": "~4.11.1"
+      },
+      "peerDependencies": {
+        "playwright-core": ">= 1.0.0"
       }
     },
     "node_modules/@babel/helper-string-parser": {
@@ -3254,6 +3268,16 @@
       },
       "peerDependencies": {
         "@astrojs/compiler": ">=0.27.0"
+      }
+    },
+    "node_modules/axe-core": {
+      "version": "4.11.2",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.11.2.tgz",
+      "integrity": "sha512-byD6KPdvo72y/wj2T/4zGEvvlis+PsZsn/yPS3pEO+sFpcrqRpX/TJCxvVaEsNeMrfQbCr7w163YqoD9IYwHXw==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/axobject-query": {
@@ -6791,6 +6815,7 @@
       "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "playwright-core": "cli.js"
       },

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "tailwindcss": "^4.2.2"
   },
   "devDependencies": {
+    "@axe-core/playwright": "^4.11.1",
     "@eslint/js": "^10.0.1",
     "@playwright/test": "^1.59.1",
     "eslint": "^10.1.0",

--- a/src/components/EcosystemLogos.astro
+++ b/src/components/EcosystemLogos.astro
@@ -34,9 +34,7 @@ const logos = [
     <p class="text-center text-xs font-bold uppercase tracking-[0.2em] text-text-muted mb-8">
       Works with the tools you already use
     </p>
-    <div
-      class="flex flex-wrap items-center justify-center gap-8 sm:gap-12 opacity-50 hover:opacity-70 transition-opacity"
-    >
+    <div class="flex flex-wrap items-center justify-center gap-8 sm:gap-12">
       {
         logos.map((logo) => (
           <div class="flex items-center gap-2 text-text-muted" title={logo.name}>

--- a/src/components/Features.astro
+++ b/src/components/Features.astro
@@ -77,7 +77,7 @@ const features = [
             {feature.snippet && (
               <div class="rounded-lg bg-[#0d1117] border border-white/5 p-3 font-mono text-[11px] leading-relaxed text-zinc-400 overflow-x-auto">
                 {feature.snippet.split('\n').map((line) => (
-                  <div class:list={[line.startsWith('#') ? 'text-zinc-600' : '']}>{line}</div>
+                  <div class:list={[line.startsWith('#') ? 'text-zinc-400' : '']}>{line}</div>
                 ))}
               </div>
             )}

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -73,7 +73,7 @@ const year = new Date().getFullYear();
       </div>
     </div>
 
-    <div class="mt-8 border-t border-border pt-6 text-center text-sm text-text-muted/60">
+    <div class="mt-8 border-t border-border pt-6 text-center text-sm text-text-muted">
       <p>&copy; {year} HelmForge.</p>
     </div>
   </Container>

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -65,7 +65,7 @@ function isActive(href: string): boolean {
         >
           <Search class="w-4 h-4" />
           <span
-            class="text-xs text-text-muted/60 hidden lg:inline-flex items-center gap-0.5 border border-border rounded-md px-1.5 py-0.5 font-mono"
+            class="text-xs text-text-muted hidden lg:inline-flex items-center gap-0.5 border border-border rounded-md px-1.5 py-0.5 font-mono"
           >
             <span class="text-[10px]" id="search-mod-key">Ctrl</span>K
           </span>

--- a/src/components/InstallSection.astro
+++ b/src/components/InstallSection.astro
@@ -75,7 +75,7 @@ const stableCharts = charts.filter((c) => c.maturity === 'stable').map((c) => c.
               <div class="w-2.5 h-2.5 rounded-full bg-[#ffbd2e]"></div>
               <div class="w-2.5 h-2.5 rounded-full bg-[#27c93f]"></div>
             </div>
-            <span class="mx-auto text-[10px] text-zinc-500 font-mono">zsh</span>
+            <span class="mx-auto text-[10px] text-zinc-400 font-mono">zsh</span>
           </div>
           <div class="relative group">
             <CopyButton
@@ -84,25 +84,25 @@ const stableCharts = charts.filter((c) => c.maturity === 'stable').map((c) => c.
             />
             <div class="px-5 py-5 space-y-1.5 font-mono text-[13px] text-zinc-300 leading-relaxed overflow-x-auto">
               <div class="install-line transition-colors hover:bg-white/[0.02] -mx-5 px-5 py-0.5 rounded">
-                <span class="text-emerald-400 select-none">user@k8s</span><span class="text-zinc-500 select-none"
+                <span class="text-emerald-400 select-none">user@k8s</span><span class="text-zinc-400 select-none"
                   >:</span
-                ><span class="text-blue-400 select-none">~</span><span class="text-zinc-500 select-none"> $</span>
+                ><span class="text-blue-400 select-none">~</span><span class="text-zinc-400 select-none"> $</span>
                 <span class="ml-2">helm repo add helmforge https://repo.helmforge.dev</span>
               </div>
-              <div class="text-zinc-500 text-xs pl-0">"helmforge" has been added to your repositories</div>
+              <div class="text-zinc-400 text-xs pl-0">"helmforge" has been added to your repositories</div>
               <div class="install-line transition-colors hover:bg-white/[0.02] -mx-5 px-5 py-0.5 rounded">
-                <span class="text-emerald-400 select-none">user@k8s</span><span class="text-zinc-500 select-none"
+                <span class="text-emerald-400 select-none">user@k8s</span><span class="text-zinc-400 select-none"
                   >:</span
-                ><span class="text-blue-400 select-none">~</span><span class="text-zinc-500 select-none"> $</span>
+                ><span class="text-blue-400 select-none">~</span><span class="text-zinc-400 select-none"> $</span>
                 <span class="ml-2">helm repo update</span>
               </div>
-              <div class="text-zinc-500 text-xs pl-0">
+              <div class="text-zinc-400 text-xs pl-0">
                 ...Successfully got an update from the "helmforge" chart repository
               </div>
               <div class="install-line transition-colors hover:bg-white/[0.02] -mx-5 px-5 py-0.5 rounded pt-2">
-                <span class="text-emerald-400 select-none">user@k8s</span><span class="text-zinc-500 select-none"
+                <span class="text-emerald-400 select-none">user@k8s</span><span class="text-zinc-400 select-none"
                   >:</span
-                ><span class="text-blue-400 select-none">~</span><span class="text-zinc-500 select-none"> $</span>
+                ><span class="text-blue-400 select-none">~</span><span class="text-zinc-400 select-none"> $</span>
                 <span class="ml-2"
                   >helm install my-release helmforge/<span id="install-chart-name" class="text-amber-300">redis</span
                   ></span
@@ -123,7 +123,7 @@ const stableCharts = charts.filter((c) => c.maturity === 'stable').map((c) => c.
               <div class="w-2.5 h-2.5 rounded-full bg-[#ffbd2e]"></div>
               <div class="w-2.5 h-2.5 rounded-full bg-[#27c93f]"></div>
             </div>
-            <span class="mx-auto text-[10px] text-zinc-500 font-mono">zsh</span>
+            <span class="mx-auto text-[10px] text-zinc-400 font-mono">zsh</span>
           </div>
           <div class="relative group">
             <CopyButton
@@ -132,9 +132,9 @@ const stableCharts = charts.filter((c) => c.maturity === 'stable').map((c) => c.
             />
             <div class="px-5 py-5 font-mono text-[13px] text-zinc-300 leading-relaxed overflow-x-auto">
               <div class="install-line transition-colors hover:bg-white/[0.02] -mx-5 px-5 py-0.5 rounded">
-                <span class="text-emerald-400 select-none">user@k8s</span><span class="text-zinc-500 select-none"
+                <span class="text-emerald-400 select-none">user@k8s</span><span class="text-zinc-400 select-none"
                   >:</span
-                ><span class="text-blue-400 select-none">~</span><span class="text-zinc-500 select-none"> $</span>
+                ><span class="text-blue-400 select-none">~</span><span class="text-zinc-400 select-none"> $</span>
                 <span class="ml-2"
                   >helm install my-release oci://ghcr.io/helmforgedev/helm/<span
                     id="install-chart-name-oci"

--- a/src/layouts/DocsLayout.astro
+++ b/src/layouts/DocsLayout.astro
@@ -177,7 +177,7 @@ function isActive(href: string): boolean {
             {
               chartCategories.map((cat) => (
                 <div class="mb-3">
-                  <div class="px-3 py-1 text-[10px] font-semibold uppercase tracking-[0.14em] text-text-muted/60">
+                  <div class="px-3 py-1 text-[10px] font-semibold uppercase tracking-[0.14em] text-text-muted">
                     {cat.label}
                   </div>
                   <ul class="space-y-0.5">

--- a/src/pages/playground.astro
+++ b/src/pages/playground.astro
@@ -168,7 +168,7 @@ const configsJson = JSON.stringify(chartConfigs);
                   d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"></path>
               </svg>
               <p class="text-sm font-medium">Select a chart to configure</p>
-              <p class="text-xs mt-1 opacity-60">Values will appear here with controls to customize them</p>
+              <p class="text-xs mt-1">Values will appear here with controls to customize them</p>
             </div>
             <div id="playground-fields" class="hidden">
               <div class="flex items-center justify-between mb-5">
@@ -197,11 +197,11 @@ const configsJson = JSON.stringify(chartConfigs);
                 <div class="w-2.5 h-2.5 rounded-full bg-[#ffbd2e]"></div>
                 <div class="w-2.5 h-2.5 rounded-full bg-[#27c93f]"></div>
               </div>
-              <span class="mx-auto text-[10px] text-zinc-500 font-mono">terminal</span>
+              <span class="mx-auto text-[10px] text-zinc-400 font-mono">terminal</span>
             </div>
             <pre
               id="playground-output"
-              class="p-5 font-mono text-sm text-zinc-300 leading-relaxed overflow-x-auto min-h-[120px]"><code id="playground-code" class="block"><span class="text-zinc-500"># Select a chart and configure values</span></code></pre>
+              class="p-5 font-mono text-sm text-zinc-300 leading-relaxed overflow-x-auto min-h-[120px]"><code id="playground-code" class="block"><span class="text-zinc-400"># Select a chart and configure values</span></code></pre>
           </div>
         </div>
       </div>

--- a/src/pages/stack.astro
+++ b/src/pages/stack.astro
@@ -108,12 +108,12 @@ const stableCharts = charts.filter((c) => c.maturity === 'stable');
                 <div class="w-2.5 h-2.5 rounded-full bg-[#ffbd2e]"></div>
                 <div class="w-2.5 h-2.5 rounded-full bg-[#27c93f]"></div>
               </div>
-              <span id="stack-filename" class="mx-auto text-[10px] text-zinc-500 font-mono">stack-builder.sh</span>
+              <span id="stack-filename" class="mx-auto text-[10px] text-zinc-400 font-mono">stack-builder.sh</span>
             </div>
             <pre
               id="stack-output"
-              class="p-5 font-mono text-sm text-zinc-300 leading-relaxed overflow-x-auto min-h-[320px]"><code id="stack-code" class="block"><span class="text-zinc-500"># Select charts on the left to generate your install script</span>
-<span class="text-zinc-500"># Commands will appear here automatically</span></code></pre>
+              class="p-5 font-mono text-sm text-zinc-300 leading-relaxed overflow-x-auto min-h-[320px]"><code id="stack-code" class="block"><span class="text-zinc-400"># Select charts on the left to generate your install script</span>
+<span class="text-zinc-400"># Commands will appear here automatically</span></code></pre>
           </div>
 
           <div id="stack-empty-hint" class="mt-4 text-sm text-text-muted">

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -504,6 +504,25 @@ html[data-theme='light'] .chart-card:hover {
   border-color: rgba(109, 40, 217, 0.3);
 }
 
+/* Light mode: badge contrast fixes */
+html[data-theme='light'] .text-green-400 {
+  color: #15803d;
+}
+html[data-theme='light'] .text-amber-400 {
+  color: #b45309;
+}
+html[data-theme='light'] .text-red-400 {
+  color: #b91c1c;
+}
+html[data-theme='light'] .text-sky-400 {
+  color: #0369a1;
+}
+
+/* Light mode: active nav link contrast */
+html[data-theme='light'] .text-primary-light {
+  color: #5b21b6;
+}
+
 /* Light mode: stat cards (glass-panel counters) */
 html[data-theme='light'] .glass-panel p.text-3xl {
   color: var(--color-text-base);


### PR DESCRIPTION
## Summary
- Add `@axe-core/playwright` for automated accessibility testing
- Add 9 a11y E2E tests: axe scans on 5 pages, skip-to-content, keyboard nav, alt text, heading hierarchy
- Fix WCAG 2.1 AA color contrast issues across the site:
  - Remove opacity on footer copyright and search shortcut text
  - Darken badge text colors (green, amber, red, sky) in light mode
  - Darken active nav link color in light mode
  - Increase ecosystem logos section opacity for readable text
  - Use zinc-400 for comment text in dark-bg code blocks
  - Remove placeholder text opacity in playground

## Test plan
- [ ] All 21 E2E tests pass (9 a11y + 7 nav + 3 search + 2 hero)
- [ ] Axe scans detect no critical/serious violations on any page
- [ ] Light and dark modes both maintain AA contrast ratios
- [ ] Visual design preserved (changes are subtle contrast improvements)