### PR TITLE
fix(site): update blog dates and add test phase to backlog

### DIFF
--- a/SITE-BACKLOG-V3.md
+++ b/SITE-BACKLOG-V3.md
@@ -6,16 +6,17 @@
 
 | Phase | Title | Status | PR |
 |-------|-------|--------|-----|
-| 1 | Blog & News Section | `pending` | — |
-| 2 | Chart Documentation Enrichment | `pending` | — |
-| 3 | Accessibility & a11y Tests | `pending` | — |
+| 1 | Blog & News Section | `done` | #70 |
+| 2 | Chart Documentation Enrichment | `done` | #78 |
+| 3 | Accessibility & a11y Tests | `done` | #79 |
 | 4 | Roadmap & Community Pages | `pending` | — |
 | 5 | FAQ & Troubleshooting | `pending` | — |
 | 6 | Architecture Diagrams | `pending` | — |
 | 7 | Performance & Web Vitals | `pending` | — |
 | 8 | SEO & Social Enhancements | `pending` | — |
 | 9 | Advanced Playground Features | `pending` | — |
-| 10 | i18n PT-BR | `pending` | — |
+| 10 | ~~i18n PT-BR~~ | `skipped` | — |
+| 11 | Test Coverage & Quality | `pending` | — |
 
 ---
 
@@ -206,22 +207,31 @@
 
 ---
 
-## Phase 10 — i18n PT-BR
+## Phase 10 — ~~i18n PT-BR~~ (SKIPPED)
 
-**Goal:** Add Portuguese (Brazil) translation as first non-English language.
+Skipped per maintainer decision.
+
+---
+
+## Phase 11 — Test Coverage & Quality
+
+**Goal:** Expand E2E and unit test coverage to catch regressions on all new features, code style, broken assets, and interactive components.
 
 **Tasks:**
-- Configure Astro i18n with `defaultLocale: 'en'` and `locales: ['en', 'pt-br']`
-- Create translation JSON files for UI strings (header, footer, buttons, labels)
-- Translate main pages: home, docs index, getting-started, comparison, FAQ
-- Translate top 10 chart docs (postgresql, mysql, redis, mongodb, keycloak, etc.)
-- Add language switcher to header (globe icon dropdown)
-- Add `hreflang` alternate links in `<head>`
-- Update sitemap to include localized URLs
-- Keep English as canonical, PT-BR as alternate
-- Add PT-BR to Pagefind search index
+- Add E2E tests for blog pages (index, individual post, reading time, share links)
+- Add E2E tests for broken images/icons across all pages (assert no 404 on `<img>` src)
+- Add E2E tests for Stack Builder (chart selection, preset stacks, output generation, format toggle)
+- Add E2E tests for Playground (chart selector, config panel, command output, copy button)
+- Add E2E tests for DocsTabs component (tab switching, content visibility, aria states)
+- Add E2E tests for Callout component rendering on doc pages
+- Add E2E tests for install section (tab switching, chart selector, copy button)
+- Add code style/lint validation test (ensure Prettier and ESLint pass on all files)
+- Add visual regression baseline snapshots for key pages (homepage, docs, blog)
+- Verify all chart icons load correctly (no corrupted SVGs, no 404s)
+- Verify search (Pagefind) indexes blog and doc pages correctly
+- Add dark/light theme toggle test (ensure no broken styles on switch)
 
-**Priority:** Low — the user (maintainer) is PT-BR native; adds accessibility for LATAM community.
+**Priority:** High — ensures all new V3 features are regression-proof.
 
 ---
 
@@ -231,11 +241,12 @@
 |----------|--------|-----------|
 | **High** | 1, 2, 3 | SEO, user experience, compliance |
 | **Medium** | 4, 5, 6, 7, 8 | Trust, discoverability, comprehension |
-| **Low** | 9, 10 | Engagement, internationalization |
+| **Low** | 9 | Engagement |
+| **High** | 11 | Regression-proof all V3 features |
 
 ## Notes
 
-- Execute phases sequentially (1 → 10)
+- Execute phases sequentially (1 → 11, phase 10 skipped)
 - Each phase = 1 branch + 1 PR to `main`
 - Branch naming: `feat/<description>` or `docs/<description>`
 - All phases must pass CI (lint, format, build, bundle budget, links, E2E)

--- a/src/content/blog/helmforge-vs-bitnami.mdx
+++ b/src/content/blog/helmforge-vs-bitnami.mdx
@@ -1,7 +1,7 @@
 ---
 title: 'HelmForge vs Bitnami: A Practical Comparison'
 description: 'An honest look at how HelmForge charts compare to Bitnami — images, licensing, backup, and operational trade-offs.'
-date: 2025-02-10
+date: 2026-04-01
 author: 'HelmForge Team'
 tags: ['comparison', 'bitnami', 'kubernetes']
 ---

--- a/src/content/blog/introducing-helmforge.mdx
+++ b/src/content/blog/introducing-helmforge.mdx
@@ -1,7 +1,7 @@
 ---
 title: 'Introducing HelmForge: Why We Built It'
 description: 'The story behind HelmForge — production-ready Helm charts built with security, backups, and operational excellence as first-class features.'
-date: 2025-01-15
+date: 2026-04-01
 author: 'HelmForge Team'
 tags: ['announcement', 'open-source', 'kubernetes']
 ---

--- a/src/content/blog/production-postgresql-kubernetes.mdx
+++ b/src/content/blog/production-postgresql-kubernetes.mdx
@@ -1,7 +1,7 @@
 ---
 title: 'Deploy Production-Ready PostgreSQL on Kubernetes'
 description: 'Step-by-step guide to deploying PostgreSQL with replication, automated backups, and monitoring using the HelmForge chart.'
-date: 2025-03-05
+date: 2026-04-02
 author: 'HelmForge Team'
 tags: ['tutorial', 'postgresql', 'database', 'kubernetes']
 ---


### PR DESCRIPTION
## Summary
- Updated all blog post dates to start from 2026-04-01 (previously had 2025 dates)
- Added Phase 11 (Test Coverage & Quality) to V3 backlog as final phase
- Marked phases 1-3 as done, phase 10 (i18n) as skipped

## Test plan
- [ ] Blog posts show correct dates on `/blog`
- [ ] Build succeeds