### PR TITLE
feat(site): add roadmap and community pages

### DIFF
--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -47,6 +47,12 @@ const year = new Date().getFullYear();
         <div class="mb-3 text-[11px] font-bold uppercase tracking-[0.18em] text-text-base">Community</div>
         <ul class="space-y-2 text-sm">
           <li>
+            <a href="/community" class="text-text-muted transition-colors hover:text-text-base">Community</a>
+          </li>
+          <li>
+            <a href="/roadmap" class="text-text-muted transition-colors hover:text-text-base">Roadmap</a>
+          </li>
+          <li>
             <a
               href="https://github.com/helmforgedev/charts"
               target="_blank"

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -14,6 +14,7 @@ const navItems = [
   { label: 'Blog', href: '/blog' },
   { label: 'Request', href: '/request' },
   { label: 'Changelog', href: '/changelog' },
+  { label: 'Roadmap', href: '/roadmap' },
 ];
 
 function isActive(href: string): boolean {

--- a/src/pages/community.astro
+++ b/src/pages/community.astro
@@ -1,0 +1,266 @@
+---
+import BaseLayout from '../layouts/BaseLayout.astro';
+import Header from '../components/Header.astro';
+import Footer from '../components/Footer.astro';
+import Container from '../components/Container.astro';
+import SectionHeader from '../components/SectionHeader.astro';
+
+interface Contributor {
+  login: string;
+  avatar_url: string;
+  html_url: string;
+  contributions: number;
+}
+
+let contributors: Contributor[] = [];
+try {
+  const res = await fetch('https://api.github.com/repos/helmforgedev/charts/contributors?per_page=30', {
+    headers: { Accept: 'application/vnd.github+json' },
+  });
+  if (res.ok) {
+    contributors = (await res.json()).filter((c: Contributor) => !c.login.includes('[bot]'));
+  }
+} catch {
+  // Build continues with empty contributors
+}
+
+const ways = [
+  {
+    icon: 'chart',
+    title: 'Submit a Chart',
+    description: 'Build and contribute a new Helm chart for an application you use in production.',
+    link: 'https://github.com/helmforgedev/charts/blob/main/CONTRIBUTING.md',
+    linkText: 'Read CONTRIBUTING.md',
+  },
+  {
+    icon: 'bug',
+    title: 'Report Issues',
+    description: 'Found a bug or unexpected behavior? Open an issue with reproduction steps.',
+    link: 'https://github.com/helmforgedev/charts/issues/new',
+    linkText: 'Open an issue',
+  },
+  {
+    icon: 'request',
+    title: 'Request a Chart',
+    description: 'Need a chart for an application? Submit a request and the community will evaluate it.',
+    link: '/request',
+    linkText: 'Request form',
+  },
+  {
+    icon: 'docs',
+    title: 'Improve Docs',
+    description: 'Fix typos, add examples, improve explanations. Documentation PRs are always welcome.',
+    link: 'https://github.com/helmforgedev/site',
+    linkText: 'Site repository',
+  },
+  {
+    icon: 'test',
+    title: 'Test & Review',
+    description: 'Try charts on your cluster and report results. Review open pull requests.',
+    link: 'https://github.com/helmforgedev/charts/pulls',
+    linkText: 'Open PRs',
+  },
+  {
+    icon: 'star',
+    title: 'Spread the Word',
+    description: 'Star the repo, share on social media, or write about your experience with HelmForge.',
+    link: 'https://github.com/helmforgedev/charts',
+    linkText: 'Star on GitHub',
+  },
+];
+
+const iconPaths: Record<string, string> = {
+  chart:
+    'M4 6a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2H6a2 2 0 01-2-2V6zm10 0a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2h-2a2 2 0 01-2-2V6zM4 16a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2H6a2 2 0 01-2-2v-2zm10 0a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2h-2a2 2 0 01-2-2v-2z',
+  bug: 'M12 8v4m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z',
+  request: 'M12 4v16m8-8H4',
+  docs: 'M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z',
+  test: 'M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2m-6 9l2 2 4-4',
+  star: 'M11.049 2.927c.3-.921 1.603-.921 1.902 0l1.519 4.674a1 1 0 00.95.69h4.915c.969 0 1.371 1.24.588 1.81l-3.976 2.888a1 1 0 00-.363 1.118l1.518 4.674c.3.922-.755 1.688-1.538 1.118l-3.976-2.888a1 1 0 00-1.176 0l-3.976 2.888c-.783.57-1.838-.197-1.538-1.118l1.518-4.674a1 1 0 00-.363-1.118l-3.976-2.888c-.784-.57-.38-1.81.588-1.81h4.914a1 1 0 00.951-.69l1.519-4.674z',
+};
+
+const governance = [
+  { label: 'License', value: 'MIT', description: 'All charts are open-source under the MIT license.' },
+  {
+    label: 'Versioning',
+    value: 'SemVer',
+    description: 'Automated semantic versioning from Conventional Commits.',
+  },
+  {
+    label: 'Signing',
+    value: 'Cosign',
+    description: 'All OCI artifacts are signed with Sigstore keyless signing.',
+  },
+  {
+    label: 'Maturity',
+    value: 'alpha → beta → stable',
+    description: 'Charts progress through maturity levels with clear criteria.',
+  },
+];
+---
+
+<BaseLayout
+  title="Community"
+  description="Join the HelmForge community. Contribute charts, report issues, and help shape the future of Kubernetes deployments."
+>
+  <Header />
+  <main id="main-content" class="py-16 sm:py-20" data-pagefind-body>
+    <Container>
+      <SectionHeader
+        label="Community"
+        title="Built in the open, shaped by the community."
+        description="HelmForge is open-source and community-driven. Every contribution makes the project better for everyone."
+      />
+
+      <!-- How to Contribute -->
+      <div class="mt-12">
+        <h3 class="text-lg font-bold text-text-base heading-font mb-6">How to contribute</h3>
+        <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+          {
+            ways.map((way) => (
+              <div class="glass-panel rounded-2xl p-5 flex flex-col">
+                <div class="flex items-center gap-3 mb-3">
+                  <div class="flex h-9 w-9 items-center justify-center rounded-xl bg-primary/10 text-primary shrink-0">
+                    <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d={iconPaths[way.icon]} />
+                    </svg>
+                  </div>
+                  <h4 class="text-sm font-bold text-text-base">{way.title}</h4>
+                </div>
+                <p class="text-xs text-text-muted leading-relaxed flex-1">{way.description}</p>
+                <a
+                  href={way.link}
+                  target={way.link.startsWith('/') ? undefined : '_blank'}
+                  rel={way.link.startsWith('/') ? undefined : 'noopener noreferrer'}
+                  class="mt-3 inline-flex items-center gap-1.5 text-xs font-semibold text-primary-light hover:underline"
+                >
+                  {way.linkText}
+                  <svg class="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path
+                      stroke-linecap="round"
+                      stroke-linejoin="round"
+                      stroke-width="2"
+                      d="M13 7l5 5m0 0l-5 5m5-5H6"
+                    />
+                  </svg>
+                </a>
+              </div>
+            ))
+          }
+        </div>
+      </div>
+
+      <!-- Contributors -->
+      {
+        contributors.length > 0 && (
+          <div class="mt-16">
+            <h3 class="text-lg font-bold text-text-base heading-font mb-6">Contributors</h3>
+            <div class="glass-panel rounded-2xl p-6">
+              <div class="flex flex-wrap gap-3">
+                {contributors.map((c) => (
+                  <a
+                    href={c.html_url}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    class="group flex items-center gap-2.5 rounded-xl border border-border bg-bg-surface/40 px-3 py-2 transition-all hover:border-primary/40 hover:bg-bg-surface/80"
+                    title={`${c.login} — ${c.contributions} contributions`}
+                  >
+                    <img
+                      src={c.avatar_url}
+                      alt={c.login}
+                      class="w-7 h-7 rounded-full"
+                      loading="lazy"
+                      width="28"
+                      height="28"
+                    />
+                    <span class="text-sm font-medium text-text-base group-hover:text-primary-light">{c.login}</span>
+                    <span class="text-xs text-text-muted font-mono">{c.contributions}</span>
+                  </a>
+                ))}
+              </div>
+            </div>
+          </div>
+        )
+      }
+
+      <!-- Governance -->
+      <div class="mt-16">
+        <h3 class="text-lg font-bold text-text-base heading-font mb-6">Project governance</h3>
+        <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
+          {
+            governance.map((g) => (
+              <div class="glass-panel rounded-2xl p-5">
+                <div class="flex items-center gap-2 mb-2">
+                  <span class="text-xs font-bold uppercase tracking-[0.16em] text-text-muted">{g.label}</span>
+                  <span class="text-xs font-mono text-primary-light bg-primary/10 px-2 py-0.5 rounded-full">
+                    {g.value}
+                  </span>
+                </div>
+                <p class="text-sm text-text-muted leading-relaxed">{g.description}</p>
+              </div>
+            ))
+          }
+        </div>
+      </div>
+
+      <!-- Chart Request Process -->
+      <div class="mt-16">
+        <h3 class="text-lg font-bold text-text-base heading-font mb-6">Chart request process</h3>
+        <div class="glass-panel rounded-2xl p-6">
+          <div class="flex flex-col sm:flex-row gap-4">
+            {
+              [
+                {
+                  step: '1',
+                  title: 'Submit',
+                  description: 'Open a chart request via the request form or GitHub issue.',
+                },
+                {
+                  step: '2',
+                  title: 'Evaluate',
+                  description: 'Maintainers assess demand, complexity, and upstream support.',
+                },
+                {
+                  step: '3',
+                  title: 'Build',
+                  description: 'Chart is scaffolded, tested on k3d, and reviewed.',
+                },
+                {
+                  step: '4',
+                  title: 'Release',
+                  description: 'Chart is published to OCI and Helm repo with signed artifacts.',
+                },
+              ].map((s) => (
+                <div class="flex-1 text-center">
+                  <div class="inline-flex h-10 w-10 items-center justify-center rounded-full bg-primary text-white text-sm font-bold mb-2">
+                    {s.step}
+                  </div>
+                  <div class="text-sm font-bold text-text-base">{s.title}</div>
+                  <p class="mt-1 text-xs text-text-muted">{s.description}</p>
+                </div>
+              ))
+            }
+          </div>
+        </div>
+      </div>
+
+      <!-- CTA -->
+      <div class="mt-16 text-center">
+        <a
+          href="https://github.com/helmforgedev/charts"
+          target="_blank"
+          rel="noopener noreferrer"
+          class="inline-flex items-center gap-2 rounded-full bg-primary px-6 py-3 text-sm font-semibold text-white transition-all hover:bg-primary-dark hover:shadow-lg hover:shadow-primary/20"
+        >
+          <svg class="w-5 h-5" fill="currentColor" viewBox="0 0 24 24">
+            <path
+              d="M12 0C5.37 0 0 5.37 0 12c0 5.31 3.435 9.795 8.205 11.385.6.105.825-.255.825-.57 0-.285-.015-1.23-.015-2.235-3.015.555-3.795-.735-4.035-1.41-.135-.345-.72-1.41-1.23-1.695-.42-.225-1.02-.78-.015-.795.945-.015 1.62.87 1.845 1.23 1.08 1.815 2.805 1.305 3.495.99.105-.78.42-1.305.765-1.605-2.67-.3-5.46-1.335-5.46-5.925 0-1.305.465-2.385 1.23-3.225-.12-.3-.54-1.53.12-3.18 0 0 1.005-.315 3.3 1.23.96-.27 1.98-.405 3-.405s2.04.135 3 .405c2.295-1.56 3.3-1.23 3.3-1.23.66 1.65.24 2.88.12 3.18.765.84 1.23 1.905 1.23 3.225 0 4.605-2.805 5.625-5.475 5.925.435.375.81 1.095.81 2.22 0 1.605-.015 2.895-.015 3.3 0 .315.225.69.825.57A12.02 12.02 0 0024 12c0-6.63-5.37-12-12-12z"
+            ></path>
+          </svg>
+          Star on GitHub
+        </a>
+      </div>
+    </Container>
+  </main>
+  <Footer />
+</BaseLayout>

--- a/src/pages/roadmap.astro
+++ b/src/pages/roadmap.astro
@@ -1,0 +1,282 @@
+---
+import BaseLayout from '../layouts/BaseLayout.astro';
+import Header from '../components/Header.astro';
+import Footer from '../components/Footer.astro';
+import Container from '../components/Container.astro';
+import SectionHeader from '../components/SectionHeader.astro';
+
+interface Milestone {
+  title: string;
+  description: string;
+  html_url: string;
+  state: 'open' | 'closed';
+  open_issues: number;
+  closed_issues: number;
+  due_on: string | null;
+  created_at: string;
+}
+
+let milestones: Milestone[] = [];
+try {
+  const res = await fetch(
+    'https://api.github.com/repos/helmforgedev/charts/milestones?state=all&sort=due_on&direction=asc&per_page=30',
+    { headers: { Accept: 'application/vnd.github+json' } },
+  );
+  if (res.ok) {
+    milestones = await res.json();
+  }
+} catch {
+  // Build continues with empty milestones
+}
+
+const openMilestones = milestones.filter((m) => m.state === 'open');
+const closedMilestones = milestones.filter((m) => m.state === 'closed');
+
+function formatDate(iso: string | null) {
+  if (!iso) return 'No deadline';
+  return new Date(iso).toLocaleDateString('en-US', {
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric',
+  });
+}
+
+function progress(m: Milestone) {
+  const total = m.open_issues + m.closed_issues;
+  return total === 0 ? 0 : Math.round((m.closed_issues / total) * 100);
+}
+
+// Static roadmap items when no milestones exist
+const staticRoadmap = [
+  {
+    phase: 'Foundation',
+    status: 'done' as const,
+    items: [
+      'Core database charts (PostgreSQL, MySQL, Redis, MongoDB)',
+      'S3-compatible backup CronJobs',
+      'Cosign-signed OCI artifacts',
+      'Automated semantic versioning & release notes',
+      'ArtifactHub integration',
+    ],
+  },
+  {
+    phase: 'Growth',
+    status: 'active' as const,
+    items: [
+      'Application charts (n8n, Keycloak, Gitea, WordPress, etc.)',
+      'Networking charts (Pi-hole, Cloudflared, Uptime Kuma)',
+      'AI/ML charts (Flowise, Open WebUI)',
+      'Chart maturity promotion pipeline',
+      'Website with docs, playground, and stack builder',
+    ],
+  },
+  {
+    phase: 'Enterprise',
+    status: 'planned' as const,
+    items: [
+      'HA and multi-region deployment patterns',
+      'Monitoring and alerting integrations',
+      'Operator-based lifecycle management',
+      'Terraform and Pulumi modules',
+      'Compliance and policy templates (OPA, Kyverno)',
+    ],
+  },
+  {
+    phase: 'Ecosystem',
+    status: 'planned' as const,
+    items: [
+      'GitOps-native install (ArgoCD, Flux catalogs)',
+      'Chart dependency graph and compatibility matrix',
+      'Community chart contribution pipeline',
+      'Cloud marketplace listings (AWS, Azure, GCP)',
+      'Interactive tutorials and learning paths',
+    ],
+  },
+];
+
+const statusColors = {
+  done: { bg: 'bg-emerald-500/10', text: 'text-emerald-400', border: 'border-emerald-500/30', label: 'Completed' },
+  active: { bg: 'bg-primary/10', text: 'text-primary-light', border: 'border-primary/30', label: 'In Progress' },
+  planned: { bg: 'bg-zinc-500/10', text: 'text-zinc-400', border: 'border-zinc-500/30', label: 'Planned' },
+};
+---
+
+<BaseLayout
+  title="Roadmap"
+  description="See what's coming next for HelmForge. Track milestones, upcoming charts, and planned features."
+>
+  <Header />
+  <main id="main-content" class="py-16 sm:py-20" data-pagefind-body>
+    <Container>
+      <SectionHeader
+        label="Roadmap"
+        title="Where HelmForge is heading."
+        description="Our roadmap is public. Track progress, see what's next, and help shape the direction."
+      />
+
+      <!-- GitHub Milestones (if available) -->
+      {
+        milestones.length > 0 && (
+          <div class="mt-12">
+            <h3 class="text-lg font-bold text-text-base heading-font mb-6">GitHub Milestones</h3>
+
+            {openMilestones.length > 0 && (
+              <div class="space-y-4 mb-8">
+                <h4 class="text-sm font-bold uppercase tracking-[0.16em] text-text-muted">Active</h4>
+                {openMilestones.map((m) => (
+                  <a
+                    href={m.html_url}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    class="block glass-panel rounded-2xl p-5 transition-all hover:border-primary/40 hover:-translate-y-0.5"
+                  >
+                    <div class="flex items-start justify-between gap-4">
+                      <div class="min-w-0 flex-1">
+                        <div class="text-base font-bold text-text-base">{m.title}</div>
+                        {m.description && <p class="mt-1 text-sm text-text-muted line-clamp-2">{m.description}</p>}
+                      </div>
+                      <span class="shrink-0 text-xs text-text-muted">{formatDate(m.due_on)}</span>
+                    </div>
+                    <div class="mt-3">
+                      <div class="flex items-center justify-between text-xs text-text-muted mb-1.5">
+                        <span>
+                          {m.closed_issues}/{m.open_issues + m.closed_issues} issues
+                        </span>
+                        <span>{progress(m)}%</span>
+                      </div>
+                      <div class="h-1.5 rounded-full bg-border overflow-hidden">
+                        <div class="h-full rounded-full bg-primary transition-all" style={`width: ${progress(m)}%`} />
+                      </div>
+                    </div>
+                  </a>
+                ))}
+              </div>
+            )}
+
+            {closedMilestones.length > 0 && (
+              <div class="space-y-3">
+                <h4 class="text-sm font-bold uppercase tracking-[0.16em] text-text-muted">Completed</h4>
+                {closedMilestones.map((m) => (
+                  <a
+                    href={m.html_url}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    class="flex items-center gap-3 glass-panel rounded-xl px-5 py-3 transition-all hover:border-primary/40 opacity-70 hover:opacity-100"
+                  >
+                    <svg
+                      class="w-4 h-4 text-emerald-400 shrink-0"
+                      fill="none"
+                      stroke="currentColor"
+                      viewBox="0 0 24 24"
+                    >
+                      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7" />
+                    </svg>
+                    <span class="text-sm font-semibold text-text-base">{m.title}</span>
+                    <span class="text-xs text-text-muted ml-auto">{formatDate(m.due_on)}</span>
+                  </a>
+                ))}
+              </div>
+            )}
+          </div>
+        )
+      }
+
+      <!-- Static Roadmap Timeline -->
+      <div class="mt-12">
+        {milestones.length > 0 && <h3 class="text-lg font-bold text-text-base heading-font mb-6">Long-term Vision</h3>}
+
+        <div class="relative">
+          <!-- Timeline line -->
+          <div class="absolute left-[19px] top-8 bottom-8 w-px bg-border hidden sm:block"></div>
+
+          <div class="space-y-6">
+            {
+              staticRoadmap.map((phase) => {
+                const s = statusColors[phase.status];
+                return (
+                  <div class="relative flex gap-5">
+                    <div class="hidden sm:flex shrink-0 w-10 justify-center pt-5">
+                      <div class={`w-3.5 h-3.5 rounded-full border-2 ${s.border} ${s.bg}`} />
+                    </div>
+                    <div class="flex-1 glass-panel rounded-2xl p-6">
+                      <div class="flex items-center gap-3 mb-3">
+                        <h3 class="text-lg font-bold text-text-base heading-font">{phase.phase}</h3>
+                        <span class={`text-xs font-semibold px-2.5 py-0.5 rounded-full ${s.bg} ${s.text}`}>
+                          {s.label}
+                        </span>
+                      </div>
+                      <ul class="space-y-2">
+                        {phase.items.map((item) => (
+                          <li class="flex items-start gap-2.5 text-sm text-text-muted">
+                            {phase.status === 'done' ? (
+                              <svg
+                                class="w-4 h-4 text-emerald-400 shrink-0 mt-0.5"
+                                fill="none"
+                                stroke="currentColor"
+                                viewBox="0 0 24 24"
+                              >
+                                <path
+                                  stroke-linecap="round"
+                                  stroke-linejoin="round"
+                                  stroke-width="2"
+                                  d="M5 13l4 4L19 7"
+                                />
+                              </svg>
+                            ) : (
+                              <svg
+                                class={`w-4 h-4 shrink-0 mt-0.5 ${phase.status === 'active' ? 'text-primary-light' : 'text-zinc-500'}`}
+                                fill="none"
+                                stroke="currentColor"
+                                viewBox="0 0 24 24"
+                              >
+                                <circle cx="12" cy="12" r="3" />
+                              </svg>
+                            )}
+                            <span>{item}</span>
+                          </li>
+                        ))}
+                      </ul>
+                    </div>
+                  </div>
+                );
+              })
+            }
+          </div>
+        </div>
+      </div>
+
+      <!-- CTA -->
+      <div class="mt-16 glass-panel rounded-2xl p-8 text-center">
+        <h3 class="text-lg font-bold text-text-base heading-font">Have a suggestion?</h3>
+        <p class="mt-2 text-sm text-text-muted max-w-lg mx-auto">
+          The roadmap is shaped by the community. Open an issue to request a chart, suggest a feature, or propose a
+          change.
+        </p>
+        <div class="mt-5 flex flex-wrap justify-center gap-3">
+          <a
+            href="/request"
+            class="inline-flex items-center gap-2 rounded-full bg-primary px-5 py-2.5 text-sm font-semibold text-white transition-all hover:bg-primary-dark hover:shadow-lg hover:shadow-primary/20"
+          >
+            Request a Chart
+          </a>
+          <a
+            href="https://github.com/helmforgedev/charts/issues"
+            target="_blank"
+            rel="noopener noreferrer"
+            class="inline-flex items-center gap-2 rounded-full border border-border px-5 py-2.5 text-sm font-semibold text-text-base transition-all hover:border-primary/40 hover:bg-bg-surface"
+          >
+            Open an Issue
+            <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="2"
+                d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14"></path>
+            </svg>
+          </a>
+        </div>
+      </div>
+    </Container>
+  </main>
+  <Footer />
+</BaseLayout>


### PR DESCRIPTION
## Summary
- Added `/roadmap` page with GitHub milestones integration (progress bars, due dates) and a static long-term vision timeline (Foundation → Growth → Enterprise → Ecosystem)
- Added `/community` page with 6 contribution pathways, GitHub contributors showcase, project governance details, and chart request process flow
- Added Roadmap to header navigation
- Added Community and Roadmap to footer navigation

## Phase 4 of V3 backlog

## Test plan
- [ ] `/roadmap` page renders with static timeline
- [ ] `/community` page renders with contribution cards and governance
- [ ] Header shows Roadmap link
- [ ] Footer shows Community and Roadmap links
- [ ] Mobile navigation includes Roadmap
- [ ] Build succeeds with 57+ HTML pages