### PR TITLE
feat(site): add faq, troubleshooting pages and fix velero icon

### DIFF
--- a/public/icons/charts/velero.svg
+++ b/public/icons/charts/velero.svg
@@ -1,1 +1,4 @@
-404: Not Found
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M12 2L3 7v6c0 5.25 3.75 10.13 9 11 5.25-.87 9-5.75 9-11V7l-9-5z"/>
+  <polyline points="8 12 11 15 16 9"/>
+</svg>

--- a/src/data/navigation.ts
+++ b/src/data/navigation.ts
@@ -12,6 +12,8 @@ export const sidebarNav: NavItem[] = [
   { label: 'Charts Overview', href: '/docs/charts' },
   { label: 'Stack Examples', href: '/docs/stack-examples' },
   { label: 'HelmForge vs Other Charts', href: '/docs/comparison' },
+  { label: 'FAQ', href: '/docs/faq' },
+  { label: 'Troubleshooting', href: '/docs/troubleshooting' },
 ];
 
 export interface ChartCategory {

--- a/src/pages/docs/faq.mdx
+++ b/src/pages/docs/faq.mdx
@@ -1,0 +1,341 @@
+---
+layout: ../../layouts/DocsLayout.astro
+title: FAQ
+description: Frequently asked questions about HelmForge charts — installation, configuration, backup, networking, and compatibility.
+---
+
+import Callout from '../../components/Callout.astro';
+
+# Frequently Asked Questions
+
+Common questions about installing, configuring, and operating HelmForge charts.
+
+---
+
+## Installation
+
+<details>
+<summary>How do I add the HelmForge Helm repository?</summary>
+
+```bash
+helm repo add helmforge https://repo.helmforge.dev
+helm repo update
+```
+
+You can also install charts directly from the OCI registry without adding a repo:
+
+```bash
+helm install my-release oci://ghcr.io/helmforgedev/helm/redis
+```
+
+</details>
+
+<details>
+<summary>Can I install charts using OCI instead of the Helm repo?</summary>
+
+Yes. All HelmForge charts are published as OCI artifacts on GitHub Container Registry:
+
+```bash
+helm install my-release oci://ghcr.io/helmforgedev/helm/<chart-name>
+```
+
+OCI artifacts are signed with Cosign keyless signing. You can verify them with:
+
+```bash
+cosign verify ghcr.io/helmforgedev/helm/<chart-name>:<version> \
+  --certificate-identity-regexp="github.com/helmforgedev" \
+  --certificate-oidc-issuer="https://token.actions.githubusercontent.com"
+```
+
+</details>
+
+<details>
+<summary>How do I upgrade a chart without downtime?</summary>
+
+For most charts, `helm upgrade` performs a rolling update by default:
+
+```bash
+helm upgrade my-release helmforge/<chart-name> -f values.yaml
+```
+
+For database charts, check the architecture-specific docs:
+
+- **Standalone**: brief downtime during pod restart is expected
+- **Replication**: the upgrade rolls replicas first, then the primary, minimizing downtime
+
+Always back up data before upgrading database charts.
+
+</details>
+
+<details>
+<summary>How do I install a specific chart version?</summary>
+
+```bash
+helm install my-release helmforge/<chart-name> --version 1.2.3
+```
+
+To list all available versions:
+
+```bash
+helm search repo helmforge/<chart-name> --versions
+```
+
+</details>
+
+---
+
+## Configuration
+
+<details>
+<summary>How do I use a different ingress controller?</summary>
+
+Set `ingress.className` in your values:
+
+```yaml
+ingress:
+  enabled: true
+  className: nginx # or traefik, haproxy, etc.
+  hosts:
+    - host: app.example.com
+      paths:
+        - path: /
+          pathType: Prefix
+```
+
+HelmForge charts default to `traefik` as the ingress class, but any controller that supports the `IngressClass` resource will work.
+
+</details>
+
+<details>
+<summary>How do I enable TLS with cert-manager?</summary>
+
+Add the cert-manager annotation and a TLS section:
+
+```yaml
+ingress:
+  enabled: true
+  className: traefik
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt-prod
+  hosts:
+    - host: app.example.com
+      paths:
+        - path: /
+          pathType: Prefix
+  tls:
+    - secretName: app-tls
+      hosts:
+        - app.example.com
+```
+
+</details>
+
+<details>
+<summary>How do I set resource requests and limits?</summary>
+
+Most charts support a `resources` block:
+
+```yaml
+resources:
+  requests:
+    cpu: 100m
+    memory: 128Mi
+  limits:
+    cpu: 500m
+    memory: 512Mi
+```
+
+Check the chart's `values.yaml` for the exact path — some charts have per-component resources (e.g., `primary.resources`, `secondary.resources`).
+
+</details>
+
+<details>
+<summary>How do I use an existing Secret instead of chart-generated credentials?</summary>
+
+Most charts support `existingSecret`:
+
+```yaml
+auth:
+  existingSecret: my-precreated-secret
+```
+
+The secret must contain the expected keys. Check the chart's README for the required key names.
+
+</details>
+
+---
+
+## Backup
+
+<details>
+<summary>How do I configure S3 backup with MinIO?</summary>
+
+Database charts that support backup accept S3-compatible endpoints:
+
+```yaml
+backup:
+  enabled: true
+  schedule: '0 2 * * *'
+  s3:
+    endpoint: http://minio.minio.svc.cluster.local:9000
+    bucket: backups
+    accessKey: minioadmin
+    secretKey: minioadmin
+    region: us-east-1
+```
+
+For production, store credentials in a Kubernetes Secret and reference it via `backup.existingSecret`.
+
+</details>
+
+<details>
+<summary>Which charts support automated backups?</summary>
+
+Charts with built-in S3 backup CronJobs:
+
+- **PostgreSQL** — `pg_dump` to S3
+- **MySQL** — `mysqldump` to S3
+- **MongoDB** — `mongodump` to S3
+- **MariaDB** — `mariadb-dump` to S3
+
+All backup jobs support S3-compatible endpoints (AWS S3, MinIO, DigitalOcean Spaces, etc.).
+
+</details>
+
+<details>
+<summary>How do I restore from a backup?</summary>
+
+Backup restoration is application-specific. General steps:
+
+1. Download the backup from S3
+2. Create a new release or scale down the existing one
+3. Restore using the application's native tool (`psql`, `mysql`, `mongorestore`)
+4. Verify data integrity
+5. Scale back up
+
+Check the chart's docs for detailed restore procedures.
+
+</details>
+
+---
+
+## Networking
+
+<details>
+<summary>How do I expose a service without an ingress controller?</summary>
+
+Use a `NodePort` or `LoadBalancer` service type:
+
+```yaml
+service:
+  type: LoadBalancer
+  port: 80
+```
+
+Or use port-forwarding for development:
+
+```bash
+kubectl port-forward svc/my-release-<chart> 8080:80
+```
+
+</details>
+
+<details>
+<summary>How do I use Pi-hole with Cloudflared for DNS-over-HTTPS?</summary>
+
+Deploy both charts and point Pi-hole's upstream DNS to Cloudflared:
+
+```yaml
+# Pi-hole values
+pihole:
+  dns:
+    upstream:
+      - 'cloudflared.default.svc.cluster.local#5053'
+```
+
+See the [Network Stack](/stack) preset in the Stack Builder for a one-click setup.
+
+</details>
+
+---
+
+## Compatibility
+
+<details>
+<summary>What Kubernetes versions are supported?</summary>
+
+HelmForge charts are tested on Kubernetes 1.28+. Most charts work on 1.26+ but we recommend staying on a supported Kubernetes version.
+
+</details>
+
+<details>
+<summary>Can I use HelmForge charts with ArgoCD or Flux?</summary>
+
+Yes. For **ArgoCD**, create an Application resource:
+
+```yaml
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: my-redis
+  namespace: argocd
+spec:
+  destination:
+    namespace: default
+    server: https://kubernetes.default.svc
+  source:
+    repoURL: https://repo.helmforge.dev
+    chart: redis
+    targetRevision: '*'
+    helm:
+      values: |
+        architecture: standalone
+  project: default
+```
+
+For **Flux**, create a HelmRelease:
+
+```yaml
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: my-redis
+  namespace: default
+spec:
+  chart:
+    spec:
+      chart: redis
+      sourceRef:
+        kind: HelmRepository
+        name: helmforge
+      version: '*'
+  values:
+    architecture: standalone
+```
+
+The [Stack Builder](/stack) can generate both ArgoCD and Helmfile manifests.
+
+</details>
+
+<details>
+<summary>Do HelmForge charts use official images?</summary>
+
+Yes. HelmForge charts use official upstream images whenever available. When an official image does not exist, the chart documents this clearly and specifies a trusted community image.
+
+All image tags are pinned to specific versions — never `latest` or floating tags.
+
+</details>
+
+<details>
+<summary>Are charts signed?</summary>
+
+Yes. All OCI artifacts are signed with [Sigstore Cosign](https://www.sigstore.dev/) keyless signing in the CI/CD pipeline. You can verify signatures using the `cosign verify` command shown in the installation section above.
+
+</details>
+
+<details>
+<summary>What license are the charts under?</summary>
+
+All HelmForge charts are released under the **MIT License**. You can use them freely in personal and commercial projects.
+
+</details>

--- a/src/pages/docs/troubleshooting.mdx
+++ b/src/pages/docs/troubleshooting.mdx
@@ -1,0 +1,231 @@
+---
+layout: ../../layouts/DocsLayout.astro
+title: Troubleshooting
+description: Diagnose and fix common issues with HelmForge charts — CrashLoopBackOff, pending PVCs, connection errors, and more.
+---
+
+import Callout from '../../components/Callout.astro';
+
+# Troubleshooting
+
+Symptom-based guide to diagnosing and resolving common issues with HelmForge charts.
+
+---
+
+## Pod stays in CrashLoopBackOff
+
+**Symptoms:** Pod restarts repeatedly, `kubectl get pods` shows `CrashLoopBackOff` status.
+
+**Diagnosis:**
+
+```bash
+# Check pod logs
+kubectl logs <pod-name> --previous
+
+# Check pod events
+kubectl describe pod <pod-name>
+```
+
+**Common causes:**
+
+| Cause                                 | Fix                                                           |
+| ------------------------------------- | ------------------------------------------------------------- |
+| Missing or wrong database credentials | Check `auth.existingSecret` references and secret key names   |
+| Insufficient memory (OOMKilled)       | Increase `resources.limits.memory`                            |
+| Wrong image tag or missing image      | Verify `image.tag` matches a valid published version          |
+| Config file syntax error              | Check mounted ConfigMaps for YAML/JSON syntax                 |
+| Dependency not ready                  | Ensure dependent services (database, Redis) are running first |
+
+<Callout type="tip">
+  If the pod log shows `exec format error`, you may be running an AMD64 image on an ARM node (or vice versa). Check the
+  image supports your node architecture.
+</Callout>
+
+---
+
+## PVC stuck in Pending
+
+**Symptoms:** `kubectl get pvc` shows `Pending` status, pods cannot start.
+
+**Diagnosis:**
+
+```bash
+kubectl describe pvc <pvc-name>
+kubectl get storageclass
+```
+
+**Common causes:**
+
+| Cause                        | Fix                                                                                                                               |
+| ---------------------------- | --------------------------------------------------------------------------------------------------------------------------------- |
+| No default StorageClass      | Set a default: `kubectl patch sc <name> -p '{"metadata":{"annotations":{"storageclass.kubernetes.io/is-default-class":"true"}}}'` |
+| StorageClass doesn't exist   | Create the StorageClass or change `persistence.storageClass` in values                                                            |
+| Insufficient cluster storage | Free disk space or add nodes                                                                                                      |
+| WaitForFirstConsumer binding | The PVC binds when a pod is scheduled — check pod scheduling issues                                                               |
+
+---
+
+## Database connection refused
+
+**Symptoms:** Application pods log `connection refused` or `could not connect to server` when trying to reach a database.
+
+**Diagnosis:**
+
+```bash
+# Check if the database pod is running
+kubectl get pods -l app.kubernetes.io/name=<chart-name>
+
+# Check the service exists
+kubectl get svc -l app.kubernetes.io/name=<chart-name>
+
+# Test connectivity from within the cluster
+kubectl run debug --rm -it --image=busybox -- sh
+# then: nc -zv <service-name> <port>
+```
+
+**Common causes:**
+
+| Cause                           | Fix                                                                          |
+| ------------------------------- | ---------------------------------------------------------------------------- |
+| Database pod not ready          | Wait for readiness probe to pass, check logs for startup errors              |
+| Wrong service name              | Use the full service name: `<release>-<chart>.<namespace>.svc.cluster.local` |
+| Wrong port                      | Check `service.port` in the chart's values                                   |
+| Network policy blocking traffic | Check NetworkPolicies in the namespace                                       |
+| Auth mismatch                   | Verify the application uses the same credentials as the database chart       |
+
+---
+
+## Ingress returns 404 or 503
+
+**Symptoms:** Ingress resource exists but the application returns 404 or 503 errors.
+
+**Diagnosis:**
+
+```bash
+# Check ingress resource
+kubectl describe ingress <ingress-name>
+
+# Check ingress controller logs
+kubectl logs -n <ingress-namespace> -l app.kubernetes.io/name=<controller>
+
+# Verify backend service
+kubectl get endpoints <service-name>
+```
+
+**Common causes:**
+
+| Cause                           | Fix                                                                     |
+| ------------------------------- | ----------------------------------------------------------------------- |
+| Wrong `ingressClassName`        | Match the class to your installed controller (`traefik`, `nginx`, etc.) |
+| No ingress controller installed | Install one: `helm install traefik traefik/traefik`                     |
+| Service has no endpoints        | Check if pods are running and passing readiness probes                  |
+| Path mismatch                   | Verify `pathType` (`Prefix` vs `Exact`) matches your app's routing      |
+| TLS secret missing              | Create the TLS secret or configure cert-manager                         |
+
+---
+
+## Backup CronJob never runs
+
+**Symptoms:** Backup is enabled but no backup jobs appear.
+
+**Diagnosis:**
+
+```bash
+# Check CronJob exists
+kubectl get cronjob -l app.kubernetes.io/name=<chart-name>
+
+# Check CronJob schedule
+kubectl describe cronjob <cronjob-name>
+
+# Check for failed jobs
+kubectl get jobs -l app.kubernetes.io/name=<chart-name>
+```
+
+**Common causes:**
+
+| Cause                              | Fix                                                           |
+| ---------------------------------- | ------------------------------------------------------------- |
+| `backup.enabled` not set to `true` | Set `backup.enabled: true` in values                          |
+| Invalid cron schedule              | Validate schedule syntax (5 fields, no seconds)               |
+| S3 credentials wrong               | Test S3 connectivity manually with `aws s3 ls --endpoint-url` |
+| Job deadline exceeded              | Increase `backup.activeDeadlineSeconds`                       |
+| Suspended CronJob                  | Check `spec.suspend` field — set to `false`                   |
+
+<Callout type="warning">
+  Backup jobs use the same ServiceAccount as the main pod. If you have restrictive PodSecurityPolicies or
+  PodSecurityStandards, ensure the backup container is allowed to run.
+</Callout>
+
+---
+
+## Helm upgrade fails with conflict
+
+**Symptoms:** `helm upgrade` fails with `cannot patch` or `field is immutable` errors.
+
+**Common causes:**
+
+| Cause                                                              | Fix                                                               |
+| ------------------------------------------------------------------ | ----------------------------------------------------------------- |
+| Immutable field changed (e.g., StatefulSet `volumeClaimTemplates`) | Delete the StatefulSet with `--cascade=orphan` and re-run upgrade |
+| Resource owned by another release                                  | Check `meta.helm.sh/release-name` annotation                      |
+| CRD version conflict                                               | Manually update CRDs before upgrading                             |
+
+```bash
+# For immutable StatefulSet fields:
+kubectl delete statefulset <name> --cascade=orphan
+helm upgrade my-release helmforge/<chart-name> -f values.yaml
+```
+
+<Callout type="danger">
+  Using `--cascade=orphan` keeps the pods running while deleting the StatefulSet controller. The upgrade will recreate
+  the StatefulSet and adopt the existing pods.
+</Callout>
+
+---
+
+## Helm install times out
+
+**Symptoms:** `helm install --wait` times out before pods are ready.
+
+**Diagnosis:**
+
+```bash
+kubectl get pods -l app.kubernetes.io/instance=<release>
+kubectl describe pod <pod-name>
+kubectl get events --sort-by=.metadata.creationTimestamp
+```
+
+**Common causes:**
+
+| Cause                        | Fix                                                            |
+| ---------------------------- | -------------------------------------------------------------- |
+| Image pull error             | Check image name, tag, and pull secrets                        |
+| Resource quota exceeded      | Check namespace ResourceQuotas                                 |
+| Node scheduling issues       | Check node taints, tolerations, and available resources        |
+| Slow startup (large DB init) | Increase `--timeout` flag: `helm install --wait --timeout 10m` |
+
+---
+
+## General debugging commands
+
+```bash
+# Overview of release status
+helm status <release-name>
+
+# See what values are in use
+helm get values <release-name>
+
+# See rendered templates
+helm template <release-name> helmforge/<chart-name> -f values.yaml
+
+# Diff before upgrading (requires helm-diff plugin)
+helm diff upgrade <release-name> helmforge/<chart-name> -f values.yaml
+
+# Check all resources for a release
+kubectl get all -l app.kubernetes.io/instance=<release-name>
+```
+
+<Callout type="tip">
+  Still stuck? Open an issue on [GitHub](https://github.com/helmforgedev/charts/issues) with your chart version,
+  Kubernetes version, and the output of `kubectl describe pod` and `helm get values`.
+</Callout>


### PR DESCRIPTION
## Summary
- Fixed corrupted `velero.svg` icon (contained "404: Not Found" text)
- Added `/docs/faq` page with 15+ questions across 5 categories (Installation, Configuration, Backup, Networking, Compatibility)
- Added `/docs/troubleshooting` page with symptom-based diagnosis for 7 common issues (CrashLoopBackOff, pending PVCs, connection errors, ingress 404/503, backup failures, upgrade conflicts, install timeouts)
- Added FAQ and Troubleshooting to docs sidebar navigation

## Phase 5 of V3 backlog + Velero icon fix

## Test plan
- [ ] Velero icon renders on homepage catalog
- [ ] `/docs/faq` renders with collapsible details sections
- [ ] `/docs/troubleshooting` renders with Callout components
- [ ] FAQ and Troubleshooting appear in docs sidebar
- [ ] Pagefind indexes both new pages