### PR TITLE
feat(site): add architecture diagrams for top charts

### DIFF
--- a/src/components/ArchitectureDiagram.astro
+++ b/src/components/ArchitectureDiagram.astro
@@ -1,0 +1,28 @@
+---
+interface Props {
+  title: string;
+  description?: string;
+}
+
+const { title, description } = Astro.props;
+---
+
+<div class="my-8">
+  <div class="glass-panel rounded-2xl p-6 overflow-hidden">
+    <div class="flex items-center gap-2 mb-4">
+      <svg class="w-5 h-5 text-primary-light shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <path
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          stroke-width="1.5"
+          d="M4 5a1 1 0 011-1h14a1 1 0 011 1v2a1 1 0 01-1 1H5a1 1 0 01-1-1V5zm0 8a1 1 0 011-1h14a1 1 0 011 1v2a1 1 0 01-1 1H5a1 1 0 01-1-1v-2zm0 8a1 1 0 011-1h14a1 1 0 011 1v2a1 1 0 01-1 1H5a1 1 0 01-1-1v-2z"
+        ></path>
+      </svg>
+      <h4 class="text-sm font-bold text-text-base">{title}</h4>
+    </div>
+    {description && <p class="text-xs text-text-muted mb-4">{description}</p>}
+    <div class="diagram-container flex justify-center overflow-x-auto">
+      <slot />
+    </div>
+  </div>
+</div>

--- a/src/components/diagrams/KeycloakDiagram.astro
+++ b/src/components/diagrams/KeycloakDiagram.astro
@@ -1,0 +1,229 @@
+---
+interface Props {
+  mode: 'basic' | 'ha';
+}
+
+const { mode } = Astro.props;
+---
+
+<svg
+  viewBox="0 0 600 240"
+  class="w-full max-w-[600px] h-auto"
+  xmlns="http://www.w3.org/2000/svg"
+  role="img"
+  aria-label={`Keycloak ${mode} architecture diagram`}
+>
+  <style>
+    .diagram-text {
+      font-family: ui-monospace, monospace;
+      font-size: 11px;
+    }
+    .diagram-label {
+      font-family: ui-sans-serif, system-ui, sans-serif;
+      font-size: 10px;
+    }
+  </style>
+
+  {
+    mode === 'basic' ? (
+      <g>
+        {/* Browser */}
+        <rect x="20" y="30" width="100" height="45" rx="8" fill="none" stroke="currentColor" stroke-width="1.5" />
+        <text x="70" y="50" text-anchor="middle" fill="currentColor" class="diagram-text">
+          Browser
+        </text>
+        <text x="70" y="63" text-anchor="middle" fill="currentColor" class="diagram-label" opacity="0.5">
+          HTTPS
+        </text>
+
+        {/* Arrow to Ingress */}
+        <line x1="120" y1="52" x2="165" y2="52" stroke="currentColor" stroke-width="1.5" />
+        <polygon points="165,47 175,52 165,57" fill="currentColor" />
+
+        {/* Ingress */}
+        <rect
+          x="175"
+          y="25"
+          width="120"
+          height="55"
+          rx="10"
+          fill="currentColor"
+          fill-opacity="0.04"
+          stroke="currentColor"
+          stroke-width="1.5"
+          stroke-dasharray="6 3"
+        />
+        <text x="235" y="47" text-anchor="middle" fill="currentColor" class="diagram-text">
+          Ingress
+        </text>
+        <text x="235" y="62" text-anchor="middle" fill="currentColor" class="diagram-label" opacity="0.5">
+          TLS termination
+        </text>
+
+        {/* Arrow to Keycloak */}
+        <line x1="295" y1="52" x2="340" y2="52" stroke="currentColor" stroke-width="1.5" />
+        <polygon points="340,47 350,52 340,57" fill="currentColor" />
+
+        {/* Keycloak */}
+        <rect
+          x="350"
+          y="20"
+          width="150"
+          height="65"
+          rx="10"
+          fill="currentColor"
+          fill-opacity="0.08"
+          stroke="currentColor"
+          stroke-width="1.5"
+        />
+        <text x="425" y="42" text-anchor="middle" fill="currentColor" class="diagram-text" font-weight="bold">
+          Keycloak
+        </text>
+        <text x="425" y="56" text-anchor="middle" fill="currentColor" class="diagram-label" opacity="0.5">
+          Deployment (1 pod)
+        </text>
+        <text x="425" y="70" text-anchor="middle" fill="currentColor" class="diagram-label" opacity="0.5">
+          :8080
+        </text>
+
+        {/* Arrow to DB */}
+        <line x1="425" y1="85" x2="425" y2="130" stroke="currentColor" stroke-width="1.5" />
+        <polygon points="420,130 425,140 430,130" fill="currentColor" />
+        <text x="448" y="112" fill="currentColor" class="diagram-label" opacity="0.5">
+          JDBC
+        </text>
+
+        {/* Database */}
+        <rect
+          x="350"
+          y="140"
+          width="150"
+          height="55"
+          rx="10"
+          fill="currentColor"
+          fill-opacity="0.05"
+          stroke="currentColor"
+          stroke-width="1.5"
+        />
+        <text x="425" y="162" text-anchor="middle" fill="currentColor" class="diagram-text">
+          PostgreSQL
+        </text>
+        <text x="425" y="178" text-anchor="middle" fill="currentColor" class="diagram-label" opacity="0.5">
+          external or bundled
+        </text>
+      </g>
+    ) : (
+      <g>
+        {/* Browser */}
+        <rect x="10" y="55" width="90" height="40" rx="8" fill="none" stroke="currentColor" stroke-width="1.5" />
+        <text x="55" y="72" text-anchor="middle" fill="currentColor" class="diagram-text">
+          Browser
+        </text>
+        <text x="55" y="85" text-anchor="middle" fill="currentColor" class="diagram-label" opacity="0.5">
+          HTTPS
+        </text>
+
+        {/* Arrow to Ingress */}
+        <line x1="100" y1="75" x2="135" y2="75" stroke="currentColor" stroke-width="1.5" />
+        <polygon points="135,70 145,75 135,80" fill="currentColor" />
+
+        {/* Ingress */}
+        <rect
+          x="145"
+          y="50"
+          width="100"
+          height="50"
+          rx="10"
+          fill="currentColor"
+          fill-opacity="0.04"
+          stroke="currentColor"
+          stroke-width="1.5"
+          stroke-dasharray="6 3"
+        />
+        <text x="195" y="72" text-anchor="middle" fill="currentColor" class="diagram-text">
+          Ingress
+        </text>
+        <text x="195" y="86" text-anchor="middle" fill="currentColor" class="diagram-label" opacity="0.5">
+          load balancer
+        </text>
+
+        {/* Arrows to KC pods */}
+        <line x1="245" y1="65" x2="310" y2="35" stroke="currentColor" stroke-width="1.5" />
+        <line x1="245" y1="85" x2="310" y2="115" stroke="currentColor" stroke-width="1.5" />
+
+        {/* KC Pod 1 */}
+        <rect
+          x="310"
+          y="10"
+          width="130"
+          height="50"
+          rx="10"
+          fill="currentColor"
+          fill-opacity="0.08"
+          stroke="currentColor"
+          stroke-width="1.5"
+        />
+        <text x="375" y="30" text-anchor="middle" fill="currentColor" class="diagram-text" font-weight="bold">
+          Keycloak
+        </text>
+        <text x="375" y="44" text-anchor="middle" fill="currentColor" class="diagram-label" opacity="0.5">
+          pod-0
+        </text>
+
+        {/* KC Pod 2 */}
+        <rect
+          x="310"
+          y="90"
+          width="130"
+          height="50"
+          rx="10"
+          fill="currentColor"
+          fill-opacity="0.08"
+          stroke="currentColor"
+          stroke-width="1.5"
+        />
+        <text x="375" y="110" text-anchor="middle" fill="currentColor" class="diagram-text" font-weight="bold">
+          Keycloak
+        </text>
+        <text x="375" y="124" text-anchor="middle" fill="currentColor" class="diagram-label" opacity="0.5">
+          pod-1
+        </text>
+
+        {/* Infinispan cache */}
+        <line x1="375" y1="60" x2="375" y2="90" stroke="currentColor" stroke-width="1" stroke-dasharray="4 3" />
+        <text x="400" y="78" fill="currentColor" class="diagram-label" opacity="0.5">
+          cache sync
+        </text>
+
+        {/* DB arrows */}
+        <line x1="440" y1="35" x2="490" y2="75" stroke="currentColor" stroke-width="1.5" />
+        <line x1="440" y1="115" x2="490" y2="80" stroke="currentColor" stroke-width="1.5" />
+
+        {/* Database */}
+        <rect
+          x="490"
+          y="55"
+          width="100"
+          height="50"
+          rx="10"
+          fill="currentColor"
+          fill-opacity="0.05"
+          stroke="currentColor"
+          stroke-width="1.5"
+        />
+        <text x="540" y="75" text-anchor="middle" fill="currentColor" class="diagram-text">
+          PostgreSQL
+        </text>
+        <text x="540" y="90" text-anchor="middle" fill="currentColor" class="diagram-label" opacity="0.5">
+          external DB
+        </text>
+
+        {/* HA label */}
+        <rect x="310" y="160" width="130" height="30" rx="6" fill="currentColor" fill-opacity="0.04" stroke="none" />
+        <text x="375" y="179" text-anchor="middle" fill="currentColor" class="diagram-label" opacity="0.6">
+          replicas: 2 (HA mode)
+        </text>
+      </g>
+    )
+  }
+</svg>

--- a/src/components/diagrams/MysqlDiagram.astro
+++ b/src/components/diagrams/MysqlDiagram.astro
@@ -1,0 +1,166 @@
+---
+interface Props {
+  mode: 'standalone' | 'replication';
+}
+
+const { mode } = Astro.props;
+---
+
+<svg
+  viewBox="0 0 600 220"
+  class="w-full max-w-[600px] h-auto"
+  xmlns="http://www.w3.org/2000/svg"
+  role="img"
+  aria-label={`MySQL ${mode} architecture diagram`}
+>
+  <style>
+    .diagram-text {
+      font-family: ui-monospace, monospace;
+      font-size: 11px;
+    }
+    .diagram-label {
+      font-family: ui-sans-serif, system-ui, sans-serif;
+      font-size: 10px;
+    }
+  </style>
+
+  {
+    mode === 'standalone' ? (
+      <g>
+        <rect x="30" y="70" width="120" height="50" rx="8" fill="none" stroke="currentColor" stroke-width="1.5" />
+        <text x="90" y="92" text-anchor="middle" fill="currentColor" class="diagram-text">
+          Application
+        </text>
+        <text x="90" y="106" text-anchor="middle" fill="currentColor" class="diagram-label" opacity="0.5">
+          client
+        </text>
+
+        <line x1="150" y1="95" x2="230" y2="95" stroke="currentColor" stroke-width="1.5" />
+        <polygon points="230,90 240,95 230,100" fill="currentColor" />
+        <text x="190" y="88" text-anchor="middle" fill="currentColor" class="diagram-label" opacity="0.5">
+          TCP:3306
+        </text>
+
+        <rect
+          x="240"
+          y="60"
+          width="140"
+          height="70"
+          rx="10"
+          fill="currentColor"
+          fill-opacity="0.05"
+          stroke="currentColor"
+          stroke-width="1.5"
+        />
+        <text x="310" y="88" text-anchor="middle" fill="currentColor" class="diagram-text" font-weight="bold">
+          MySQL
+        </text>
+        <text x="310" y="102" text-anchor="middle" fill="currentColor" class="diagram-label" opacity="0.5">
+          StatefulSet (1 pod)
+        </text>
+        <text x="310" y="116" text-anchor="middle" fill="currentColor" class="diagram-label" opacity="0.5">
+          source
+        </text>
+
+        <line x1="310" y1="130" x2="310" y2="165" stroke="currentColor" stroke-width="1.5" stroke-dasharray="4 3" />
+        <rect x="260" y="165" width="100" height="35" rx="6" fill="none" stroke="currentColor" stroke-width="1.5" />
+        <text x="310" y="187" text-anchor="middle" fill="currentColor" class="diagram-label">
+          PVC (data)
+        </text>
+
+        <line x1="380" y1="95" x2="430" y2="95" stroke="currentColor" stroke-width="1.5" stroke-dasharray="4 3" />
+        <rect x="430" y="70" width="130" height="50" rx="8" fill="none" stroke="currentColor" stroke-width="1.5" />
+        <text x="495" y="92" text-anchor="middle" fill="currentColor" class="diagram-text">
+          Backup CronJob
+        </text>
+        <text x="495" y="106" text-anchor="middle" fill="currentColor" class="diagram-label" opacity="0.5">
+          mysqldump → S3
+        </text>
+      </g>
+    ) : (
+      <g>
+        {/* Client */}
+        <rect x="10" y="50" width="100" height="45" rx="8" fill="none" stroke="currentColor" stroke-width="1.5" />
+        <text x="60" y="70" text-anchor="middle" fill="currentColor" class="diagram-text">
+          Application
+        </text>
+        <text x="60" y="83" text-anchor="middle" fill="currentColor" class="diagram-label" opacity="0.5">
+          read/write
+        </text>
+
+        <line x1="110" y1="72" x2="175" y2="72" stroke="currentColor" stroke-width="1.5" />
+        <polygon points="175,67 185,72 175,77" fill="currentColor" />
+
+        {/* Source */}
+        <rect
+          x="185"
+          y="40"
+          width="150"
+          height="65"
+          rx="10"
+          fill="currentColor"
+          fill-opacity="0.08"
+          stroke="currentColor"
+          stroke-width="1.5"
+        />
+        <text x="260" y="62" text-anchor="middle" fill="currentColor" class="diagram-text" font-weight="bold">
+          Source
+        </text>
+        <text x="260" y="76" text-anchor="middle" fill="currentColor" class="diagram-label" opacity="0.5">
+          read + write
+        </text>
+        <text x="260" y="90" text-anchor="middle" fill="currentColor" class="diagram-label" opacity="0.5">
+          pod-0
+        </text>
+
+        {/* Replication arrow */}
+        <line x1="335" y1="72" x2="395" y2="72" stroke="currentColor" stroke-width="1.5" stroke-dasharray="6 3" />
+        <text x="365" y="65" text-anchor="middle" fill="currentColor" class="diagram-label" opacity="0.5">
+          binlog
+        </text>
+
+        {/* Replica */}
+        <rect
+          x="395"
+          y="40"
+          width="150"
+          height="65"
+          rx="10"
+          fill="currentColor"
+          fill-opacity="0.04"
+          stroke="currentColor"
+          stroke-width="1.5"
+        />
+        <text x="470" y="62" text-anchor="middle" fill="currentColor" class="diagram-text">
+          Replica
+        </text>
+        <text x="470" y="76" text-anchor="middle" fill="currentColor" class="diagram-label" opacity="0.5">
+          read-only
+        </text>
+        <text x="470" y="90" text-anchor="middle" fill="currentColor" class="diagram-label" opacity="0.5">
+          pod-1
+        </text>
+
+        {/* PVCs */}
+        <line x1="260" y1="105" x2="260" y2="135" stroke="currentColor" stroke-width="1.5" stroke-dasharray="4 3" />
+        <rect x="210" y="135" width="100" height="32" rx="6" fill="none" stroke="currentColor" stroke-width="1.5" />
+        <text x="260" y="155" text-anchor="middle" fill="currentColor" class="diagram-label">
+          PVC (data)
+        </text>
+
+        <line x1="470" y1="105" x2="470" y2="135" stroke="currentColor" stroke-width="1.5" stroke-dasharray="4 3" />
+        <rect x="420" y="135" width="100" height="32" rx="6" fill="none" stroke="currentColor" stroke-width="1.5" />
+        <text x="470" y="155" text-anchor="middle" fill="currentColor" class="diagram-label">
+          PVC (data)
+        </text>
+
+        {/* Backup */}
+        <rect x="210" y="185" width="130" height="32" rx="6" fill="none" stroke="currentColor" stroke-width="1.5" />
+        <text x="275" y="205" text-anchor="middle" fill="currentColor" class="diagram-label">
+          Backup CronJob → S3
+        </text>
+        <line x1="260" y1="167" x2="260" y2="185" stroke="currentColor" stroke-width="1" stroke-dasharray="4 3" />
+      </g>
+    )
+  }
+</svg>

--- a/src/components/diagrams/PostgresqlDiagram.astro
+++ b/src/components/diagrams/PostgresqlDiagram.astro
@@ -1,0 +1,210 @@
+---
+interface Props {
+  mode: 'standalone' | 'replication';
+}
+
+const { mode } = Astro.props;
+---
+
+<svg
+  viewBox="0 0 600 260"
+  class="w-full max-w-[600px] h-auto"
+  xmlns="http://www.w3.org/2000/svg"
+  role="img"
+  aria-label={`PostgreSQL ${mode} architecture diagram`}
+>
+  <style>
+    .diagram-text {
+      font-family: ui-monospace, monospace;
+      font-size: 11px;
+    }
+    .diagram-label {
+      font-family: ui-sans-serif, system-ui, sans-serif;
+      font-size: 10px;
+    }
+  </style>
+
+  {
+    mode === 'standalone' ? (
+      <g>
+        {/* Client */}
+        <rect x="30" y="90" width="120" height="50" rx="8" fill="none" stroke="currentColor" stroke-width="1.5" />
+        <text x="90" y="112" text-anchor="middle" fill="currentColor" class="diagram-text">
+          Application
+        </text>
+        <text x="90" y="126" text-anchor="middle" fill="currentColor" class="diagram-label" opacity="0.5">
+          client
+        </text>
+
+        {/* Arrow */}
+        <line x1="150" y1="115" x2="230" y2="115" stroke="currentColor" stroke-width="1.5" />
+        <polygon points="230,110 240,115 230,120" fill="currentColor" />
+        <text x="190" y="108" text-anchor="middle" fill="currentColor" class="diagram-label" opacity="0.5">
+          TCP:5432
+        </text>
+
+        {/* Service */}
+        <rect
+          x="240"
+          y="80"
+          width="140"
+          height="70"
+          rx="10"
+          fill="currentColor"
+          fill-opacity="0.05"
+          stroke="currentColor"
+          stroke-width="1.5"
+        />
+        <text x="310" y="105" text-anchor="middle" fill="currentColor" class="diagram-text" font-weight="bold">
+          PostgreSQL
+        </text>
+        <text x="310" y="120" text-anchor="middle" fill="currentColor" class="diagram-label" opacity="0.5">
+          StatefulSet (1 pod)
+        </text>
+        <text x="310" y="135" text-anchor="middle" fill="currentColor" class="diagram-label" opacity="0.5">
+          primary
+        </text>
+
+        {/* PVC */}
+        <line x1="310" y1="150" x2="310" y2="185" stroke="currentColor" stroke-width="1.5" stroke-dasharray="4 3" />
+        <rect x="260" y="185" width="100" height="40" rx="6" fill="none" stroke="currentColor" stroke-width="1.5" />
+        <text x="310" y="208" text-anchor="middle" fill="currentColor" class="diagram-label">
+          PVC (data)
+        </text>
+
+        {/* Backup CronJob */}
+        <line x1="380" y1="115" x2="430" y2="115" stroke="currentColor" stroke-width="1.5" stroke-dasharray="4 3" />
+        <rect x="430" y="90" width="130" height="50" rx="8" fill="none" stroke="currentColor" stroke-width="1.5" />
+        <text x="495" y="112" text-anchor="middle" fill="currentColor" class="diagram-text">
+          Backup CronJob
+        </text>
+        <text x="495" y="126" text-anchor="middle" fill="currentColor" class="diagram-label" opacity="0.5">
+          pg_dump → S3
+        </text>
+      </g>
+    ) : (
+      <g>
+        {/* Client */}
+        <rect x="10" y="30" width="100" height="45" rx="8" fill="none" stroke="currentColor" stroke-width="1.5" />
+        <text x="60" y="50" text-anchor="middle" fill="currentColor" class="diagram-text">
+          Application
+        </text>
+        <text x="60" y="63" text-anchor="middle" fill="currentColor" class="diagram-label" opacity="0.5">
+          read/write
+        </text>
+
+        {/* Arrow to Primary */}
+        <line x1="110" y1="52" x2="175" y2="52" stroke="currentColor" stroke-width="1.5" />
+        <polygon points="175,47 185,52 175,57" fill="currentColor" />
+
+        {/* Primary */}
+        <rect
+          x="185"
+          y="20"
+          width="150"
+          height="65"
+          rx="10"
+          fill="currentColor"
+          fill-opacity="0.08"
+          stroke="currentColor"
+          stroke-width="1.5"
+        />
+        <text x="260" y="42" text-anchor="middle" fill="currentColor" class="diagram-text" font-weight="bold">
+          Primary
+        </text>
+        <text x="260" y="56" text-anchor="middle" fill="currentColor" class="diagram-label" opacity="0.5">
+          read + write
+        </text>
+        <text x="260" y="70" text-anchor="middle" fill="currentColor" class="diagram-label" opacity="0.5">
+          StatefulSet pod-0
+        </text>
+
+        {/* Primary PVC */}
+        <line x1="260" y1="85" x2="260" y2="110" stroke="currentColor" stroke-width="1.5" stroke-dasharray="4 3" />
+        <rect x="210" y="110" width="100" height="32" rx="6" fill="none" stroke="currentColor" stroke-width="1.5" />
+        <text x="260" y="130" text-anchor="middle" fill="currentColor" class="diagram-label">
+          PVC (data)
+        </text>
+
+        {/* Streaming arrows */}
+        <line x1="335" y1="52" x2="395" y2="52" stroke="currentColor" stroke-width="1.5" stroke-dasharray="6 3" />
+        <text x="365" y="45" text-anchor="middle" fill="currentColor" class="diagram-label" opacity="0.5">
+          WAL
+        </text>
+
+        {/* Replica 1 */}
+        <rect
+          x="395"
+          y="20"
+          width="150"
+          height="65"
+          rx="10"
+          fill="currentColor"
+          fill-opacity="0.04"
+          stroke="currentColor"
+          stroke-width="1.5"
+        />
+        <text x="470" y="42" text-anchor="middle" fill="currentColor" class="diagram-text">
+          Replica
+        </text>
+        <text x="470" y="56" text-anchor="middle" fill="currentColor" class="diagram-label" opacity="0.5">
+          read-only
+        </text>
+        <text x="470" y="70" text-anchor="middle" fill="currentColor" class="diagram-label" opacity="0.5">
+          StatefulSet pod-1
+        </text>
+
+        {/* Replica PVC */}
+        <line x1="470" y1="85" x2="470" y2="110" stroke="currentColor" stroke-width="1.5" stroke-dasharray="4 3" />
+        <rect x="420" y="110" width="100" height="32" rx="6" fill="none" stroke="currentColor" stroke-width="1.5" />
+        <text x="470" y="130" text-anchor="middle" fill="currentColor" class="diagram-label">
+          PVC (data)
+        </text>
+
+        {/* Read-only client */}
+        <rect x="10" y="160" width="100" height="45" rx="8" fill="none" stroke="currentColor" stroke-width="1.5" />
+        <text x="60" y="180" text-anchor="middle" fill="currentColor" class="diagram-text">
+          Read Client
+        </text>
+        <text x="60" y="193" text-anchor="middle" fill="currentColor" class="diagram-label" opacity="0.5">
+          read-only
+        </text>
+
+        {/* Arrow to read svc */}
+        <line x1="110" y1="182" x2="175" y2="182" stroke="currentColor" stroke-width="1.5" />
+        <polygon points="175,177 185,182 175,187" fill="currentColor" />
+
+        {/* Read Service */}
+        <rect
+          x="185"
+          y="160"
+          width="150"
+          height="45"
+          rx="10"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="1.5"
+          stroke-dasharray="4 3"
+        />
+        <text x="260" y="180" text-anchor="middle" fill="currentColor" class="diagram-text">
+          svc-read
+        </text>
+        <text x="260" y="193" text-anchor="middle" fill="currentColor" class="diagram-label" opacity="0.5">
+          load-balanced
+        </text>
+
+        {/* Arrow from read svc to replica */}
+        <line x1="335" y1="182" x2="460" y2="85" stroke="currentColor" stroke-width="1" stroke-dasharray="4 3" />
+
+        {/* Backup */}
+        <rect x="395" y="160" width="150" height="45" rx="8" fill="none" stroke="currentColor" stroke-width="1.5" />
+        <text x="470" y="180" text-anchor="middle" fill="currentColor" class="diagram-text">
+          Backup CronJob
+        </text>
+        <text x="470" y="193" text-anchor="middle" fill="currentColor" class="diagram-label" opacity="0.5">
+          pg_dump → S3
+        </text>
+      </g>
+    )
+  }
+</svg>

--- a/src/components/diagrams/RedisDiagram.astro
+++ b/src/components/diagrams/RedisDiagram.astro
@@ -1,0 +1,182 @@
+---
+interface Props {
+  mode: 'standalone' | 'sentinel';
+}
+
+const { mode } = Astro.props;
+---
+
+<svg
+  viewBox="0 0 600 240"
+  class="w-full max-w-[600px] h-auto"
+  xmlns="http://www.w3.org/2000/svg"
+  role="img"
+  aria-label={`Redis ${mode} architecture diagram`}
+>
+  <style>
+    .diagram-text {
+      font-family: ui-monospace, monospace;
+      font-size: 11px;
+    }
+    .diagram-label {
+      font-family: ui-sans-serif, system-ui, sans-serif;
+      font-size: 10px;
+    }
+  </style>
+
+  {
+    mode === 'standalone' ? (
+      <g>
+        {/* Client */}
+        <rect x="30" y="80" width="120" height="50" rx="8" fill="none" stroke="currentColor" stroke-width="1.5" />
+        <text x="90" y="102" text-anchor="middle" fill="currentColor" class="diagram-text">
+          Application
+        </text>
+        <text x="90" y="116" text-anchor="middle" fill="currentColor" class="diagram-label" opacity="0.5">
+          client
+        </text>
+
+        {/* Arrow */}
+        <line x1="150" y1="105" x2="230" y2="105" stroke="currentColor" stroke-width="1.5" />
+        <polygon points="230,100 240,105 230,110" fill="currentColor" />
+        <text x="190" y="98" text-anchor="middle" fill="currentColor" class="diagram-label" opacity="0.5">
+          TCP:6379
+        </text>
+
+        {/* Redis */}
+        <rect
+          x="240"
+          y="70"
+          width="140"
+          height="70"
+          rx="10"
+          fill="currentColor"
+          fill-opacity="0.05"
+          stroke="currentColor"
+          stroke-width="1.5"
+        />
+        <text x="310" y="98" text-anchor="middle" fill="currentColor" class="diagram-text" font-weight="bold">
+          Redis
+        </text>
+        <text x="310" y="112" text-anchor="middle" fill="currentColor" class="diagram-label" opacity="0.5">
+          StatefulSet (1 pod)
+        </text>
+        <text x="310" y="126" text-anchor="middle" fill="currentColor" class="diagram-label" opacity="0.5">
+          in-memory + AOF
+        </text>
+
+        {/* PVC */}
+        <line x1="310" y1="140" x2="310" y2="175" stroke="currentColor" stroke-width="1.5" stroke-dasharray="4 3" />
+        <rect x="260" y="175" width="100" height="35" rx="6" fill="none" stroke="currentColor" stroke-width="1.5" />
+        <text x="310" y="197" text-anchor="middle" fill="currentColor" class="diagram-label">
+          PVC (data)
+        </text>
+      </g>
+    ) : (
+      <g>
+        {/* Client */}
+        <rect x="10" y="10" width="100" height="45" rx="8" fill="none" stroke="currentColor" stroke-width="1.5" />
+        <text x="60" y="30" text-anchor="middle" fill="currentColor" class="diagram-text">
+          Application
+        </text>
+        <text x="60" y="43" text-anchor="middle" fill="currentColor" class="diagram-label" opacity="0.5">
+          client
+        </text>
+
+        {/* Arrow to Sentinel */}
+        <line x1="110" y1="32" x2="165" y2="32" stroke="currentColor" stroke-width="1.5" />
+        <polygon points="165,27 175,32 165,37" fill="currentColor" />
+        <text x="137" y="25" text-anchor="middle" fill="currentColor" class="diagram-label" opacity="0.5">
+          query
+        </text>
+
+        {/* Sentinel cluster */}
+        <rect
+          x="175"
+          y="5"
+          width="240"
+          height="55"
+          rx="10"
+          fill="currentColor"
+          fill-opacity="0.04"
+          stroke="currentColor"
+          stroke-width="1.5"
+          stroke-dasharray="6 3"
+        />
+        <text x="295" y="25" text-anchor="middle" fill="currentColor" class="diagram-text">
+          Sentinel (3 pods)
+        </text>
+        <text x="295" y="40" text-anchor="middle" fill="currentColor" class="diagram-label" opacity="0.5">
+          monitors + failover
+        </text>
+
+        {/* Arrow from Sentinel to Master */}
+        <line x1="295" y1="60" x2="200" y2="105" stroke="currentColor" stroke-width="1" stroke-dasharray="4 3" />
+        <line x1="295" y1="60" x2="440" y2="105" stroke="currentColor" stroke-width="1" stroke-dasharray="4 3" />
+
+        {/* Master */}
+        <rect
+          x="120"
+          y="90"
+          width="160"
+          height="60"
+          rx="10"
+          fill="currentColor"
+          fill-opacity="0.08"
+          stroke="currentColor"
+          stroke-width="1.5"
+        />
+        <text x="200" y="112" text-anchor="middle" fill="currentColor" class="diagram-text" font-weight="bold">
+          Master
+        </text>
+        <text x="200" y="126" text-anchor="middle" fill="currentColor" class="diagram-label" opacity="0.5">
+          read + write
+        </text>
+        <text x="200" y="140" text-anchor="middle" fill="currentColor" class="diagram-label" opacity="0.5">
+          pod-0
+        </text>
+
+        {/* Replication arrow */}
+        <line x1="280" y1="120" x2="355" y2="120" stroke="currentColor" stroke-width="1.5" stroke-dasharray="6 3" />
+        <text x="318" y="113" text-anchor="middle" fill="currentColor" class="diagram-label" opacity="0.5">
+          repl
+        </text>
+
+        {/* Replica */}
+        <rect
+          x="355"
+          y="90"
+          width="160"
+          height="60"
+          rx="10"
+          fill="currentColor"
+          fill-opacity="0.04"
+          stroke="currentColor"
+          stroke-width="1.5"
+        />
+        <text x="435" y="112" text-anchor="middle" fill="currentColor" class="diagram-text">
+          Replica
+        </text>
+        <text x="435" y="126" text-anchor="middle" fill="currentColor" class="diagram-label" opacity="0.5">
+          read-only
+        </text>
+        <text x="435" y="140" text-anchor="middle" fill="currentColor" class="diagram-label" opacity="0.5">
+          pod-1
+        </text>
+
+        {/* PVCs */}
+        <line x1="200" y1="150" x2="200" y2="180" stroke="currentColor" stroke-width="1.5" stroke-dasharray="4 3" />
+        <rect x="150" y="180" width="100" height="32" rx="6" fill="none" stroke="currentColor" stroke-width="1.5" />
+        <text x="200" y="200" text-anchor="middle" fill="currentColor" class="diagram-label">
+          PVC
+        </text>
+
+        <line x1="435" y1="150" x2="435" y2="180" stroke="currentColor" stroke-width="1.5" stroke-dasharray="4 3" />
+        <rect x="385" y="180" width="100" height="32" rx="6" fill="none" stroke="currentColor" stroke-width="1.5" />
+        <text x="435" y="200" text-anchor="middle" fill="currentColor" class="diagram-label">
+          PVC
+        </text>
+      </g>
+    )
+  }
+</svg>

--- a/src/pages/docs/charts/keycloak.mdx
+++ b/src/pages/docs/charts/keycloak.mdx
@@ -6,6 +6,8 @@ description: HelmForge Keycloak chart — Keycloak identity and access managemen
 
 import DocsTabs from '../../../components/DocsTabs.astro';
 import Callout from '../../../components/Callout.astro';
+import ArchitectureDiagram from '../../../components/ArchitectureDiagram.astro';
+import KeycloakDiagram from '../../../components/diagrams/KeycloakDiagram.astro';
 
 # Keycloak
 
@@ -20,6 +22,19 @@ Production-ready Keycloak deployment for identity and access management, support
 - **Metrics** — Prometheus metrics with ServiceMonitor
 - **Security** — Non-root containers, network policies, pod security
 - **Realm import** — Automatic realm configuration on startup
+
+## Architecture
+
+<ArchitectureDiagram title="Basic" description="Single Keycloak instance behind an ingress with PostgreSQL backend.">
+  <KeycloakDiagram mode="basic" />
+</ArchitectureDiagram>
+
+<ArchitectureDiagram
+  title="High Availability"
+  description="Multiple Keycloak replicas with cache synchronization and external database."
+>
+  <KeycloakDiagram mode="ha" />
+</ArchitectureDiagram>
 
 ## Installation
 

--- a/src/pages/docs/charts/mysql.mdx
+++ b/src/pages/docs/charts/mysql.mdx
@@ -6,6 +6,8 @@ description: HelmForge MySQL chart — MySQL with standalone and source-replica 
 
 import DocsTabs from '../../../components/DocsTabs.astro';
 import Callout from '../../../components/Callout.astro';
+import ArchitectureDiagram from '../../../components/ArchitectureDiagram.astro';
+import MysqlDiagram from '../../../components/diagrams/MysqlDiagram.astro';
 
 # MySQL
 
@@ -19,6 +21,22 @@ Production-ready MySQL deployment with support for standalone and source-replica
 - **Metrics** — Prometheus exporter with ServiceMonitor
 - **Security** — Non-root containers, network policies, TLS support
 - **Persistent storage** — Configurable PVCs with storage class selection
+
+## Architecture
+
+<ArchitectureDiagram
+  title="Standalone"
+  description="Single MySQL instance with persistent storage and optional S3 backup."
+>
+  <MysqlDiagram mode="standalone" />
+</ArchitectureDiagram>
+
+<ArchitectureDiagram
+  title="Source-Replica"
+  description="Source (read-write) with binary log replication to read-only replicas."
+>
+  <MysqlDiagram mode="replication" />
+</ArchitectureDiagram>
 
 ## Installation
 

--- a/src/pages/docs/charts/postgresql.mdx
+++ b/src/pages/docs/charts/postgresql.mdx
@@ -6,6 +6,8 @@ description: HelmForge PostgreSQL chart — PostgreSQL with standalone and strea
 
 import DocsTabs from '../../../components/DocsTabs.astro';
 import Callout from '../../../components/Callout.astro';
+import ArchitectureDiagram from '../../../components/ArchitectureDiagram.astro';
+import PostgresqlDiagram from '../../../components/diagrams/PostgresqlDiagram.astro';
 
 # PostgreSQL
 
@@ -19,6 +21,22 @@ Production-ready PostgreSQL deployment with support for standalone and streaming
 - **Metrics** — Prometheus exporter with ServiceMonitor
 - **Security** — Non-root containers, network policies, TLS support
 - **Persistent storage** — Configurable PVCs with storage class selection
+
+## Architecture
+
+<ArchitectureDiagram
+  title="Standalone"
+  description="Single PostgreSQL instance with persistent storage and optional S3 backup."
+>
+  <PostgresqlDiagram mode="standalone" />
+</ArchitectureDiagram>
+
+<ArchitectureDiagram
+  title="Replication"
+  description="Primary with streaming replicas, read-only service, and backup CronJob."
+>
+  <PostgresqlDiagram mode="replication" />
+</ArchitectureDiagram>
 
 ## Installation
 

--- a/src/pages/docs/charts/redis.mdx
+++ b/src/pages/docs/charts/redis.mdx
@@ -6,6 +6,8 @@ description: HelmForge Redis chart — Redis with standalone and Sentinel high-a
 
 import DocsTabs from '../../../components/DocsTabs.astro';
 import Callout from '../../../components/Callout.astro';
+import ArchitectureDiagram from '../../../components/ArchitectureDiagram.astro';
+import RedisDiagram from '../../../components/diagrams/RedisDiagram.astro';
 
 # Redis
 
@@ -18,6 +20,19 @@ Production-ready Redis deployment with support for standalone and Sentinel high-
 - **Metrics** — Prometheus exporter with ServiceMonitor
 - **Security** — Password authentication, non-root containers, network policies
 - **Configurable** — Custom Redis configuration parameters
+
+## Architecture
+
+<ArchitectureDiagram title="Standalone" description="Single Redis instance with persistent storage (RDB/AOF).">
+  <RedisDiagram mode="standalone" />
+</ArchitectureDiagram>
+
+<ArchitectureDiagram
+  title="Sentinel"
+  description="Redis master with replicas, monitored by Sentinel for automatic failover."
+>
+  <RedisDiagram mode="sentinel" />
+</ArchitectureDiagram>
 
 ## Installation
 


### PR DESCRIPTION
## Summary
- Created `ArchitectureDiagram.astro` wrapper component with glass-panel styling
- Added SVG architecture diagrams for 4 charts:
  - **PostgreSQL**: standalone + streaming replication
  - **Redis**: standalone + Sentinel HA
  - **MySQL**: standalone + source-replica
  - **Keycloak**: basic + high availability
- All diagrams use `currentColor` for automatic dark/light theme support
- Diagrams are responsive (scale to container width)
- Added "Architecture" section to each chart's doc page

## Phase 6 of V3 backlog

## Test plan
- [ ] Diagrams render on PostgreSQL, Redis, MySQL, Keycloak doc pages
- [ ] Diagrams adapt to dark and light themes
- [ ] Diagrams scale responsively on mobile
- [ ] Build succeeds