### PR TITLE
feat(site): advanced playground with scenarios, shareable urls, and scroll fix

### DIFF
--- a/src/pages/playground.astro
+++ b/src/pages/playground.astro
@@ -8,7 +8,7 @@ import { charts, chartIcon } from '../data/charts';
 
 const stableCharts = charts.filter((c) => c.maturity === 'stable');
 
-// Define common configurable values for chart categories
+// Chart-specific configurations with ingress, resources, backup, and auth settings
 const chartConfigs: Record<
   string,
   {
@@ -18,6 +18,7 @@ const chartConfigs: Record<
     default: string;
     options?: string[];
     description: string;
+    group?: string;
   }[]
 > = {
   postgresql: [
@@ -28,15 +29,87 @@ const chartConfigs: Record<
       default: 'standalone',
       options: ['standalone', 'replication'],
       description: 'Deployment architecture',
+      group: 'General',
     },
-    { label: 'Storage Size', key: 'persistence.size', type: 'text', default: '8Gi', description: 'PVC storage size' },
-    { label: 'Replica Count', key: 'replicaCount', type: 'number', default: '1', description: 'Number of replicas' },
+    {
+      label: 'Replica Count',
+      key: 'replicaCount',
+      type: 'number',
+      default: '1',
+      description: 'Number of replicas',
+      group: 'General',
+    },
+    {
+      label: 'Storage Size',
+      key: 'persistence.size',
+      type: 'text',
+      default: '8Gi',
+      description: 'PVC storage size',
+      group: 'Storage',
+    },
+    {
+      label: 'CPU Request',
+      key: 'resources.requests.cpu',
+      type: 'text',
+      default: '250m',
+      description: 'CPU resource request',
+      group: 'Resources',
+    },
+    {
+      label: 'Memory Request',
+      key: 'resources.requests.memory',
+      type: 'text',
+      default: '256Mi',
+      description: 'Memory resource request',
+      group: 'Resources',
+    },
+    {
+      label: 'CPU Limit',
+      key: 'resources.limits.cpu',
+      type: 'text',
+      default: '1000m',
+      description: 'CPU resource limit',
+      group: 'Resources',
+    },
+    {
+      label: 'Memory Limit',
+      key: 'resources.limits.memory',
+      type: 'text',
+      default: '512Mi',
+      description: 'Memory resource limit',
+      group: 'Resources',
+    },
     {
       label: 'S3 Backup',
       key: 'backup.enabled',
       type: 'toggle',
       default: 'false',
       description: 'Enable S3 backup CronJob',
+      group: 'Backup',
+    },
+    {
+      label: 'Backup Schedule',
+      key: 'backup.schedule',
+      type: 'text',
+      default: '0 2 * * *',
+      description: 'Cron schedule for backups',
+      group: 'Backup',
+    },
+    {
+      label: 'S3 Endpoint',
+      key: 'backup.s3.endpoint',
+      type: 'text',
+      default: 's3.amazonaws.com',
+      description: 'S3-compatible endpoint',
+      group: 'Backup',
+    },
+    {
+      label: 'S3 Bucket',
+      key: 'backup.s3.bucket',
+      type: 'text',
+      default: 'my-backups',
+      description: 'S3 bucket name',
+      group: 'Backup',
     },
   ],
   mysql: [
@@ -47,15 +120,55 @@ const chartConfigs: Record<
       default: 'standalone',
       options: ['standalone', 'replication'],
       description: 'Deployment architecture',
+      group: 'General',
     },
-    { label: 'Storage Size', key: 'persistence.size', type: 'text', default: '8Gi', description: 'PVC storage size' },
-    { label: 'Replica Count', key: 'replicaCount', type: 'number', default: '1', description: 'Number of replicas' },
+    {
+      label: 'Replica Count',
+      key: 'replicaCount',
+      type: 'number',
+      default: '1',
+      description: 'Number of replicas',
+      group: 'General',
+    },
+    {
+      label: 'Storage Size',
+      key: 'persistence.size',
+      type: 'text',
+      default: '8Gi',
+      description: 'PVC storage size',
+      group: 'Storage',
+    },
+    {
+      label: 'CPU Request',
+      key: 'resources.requests.cpu',
+      type: 'text',
+      default: '250m',
+      description: 'CPU resource request',
+      group: 'Resources',
+    },
+    {
+      label: 'Memory Request',
+      key: 'resources.requests.memory',
+      type: 'text',
+      default: '256Mi',
+      description: 'Memory resource request',
+      group: 'Resources',
+    },
     {
       label: 'S3 Backup',
       key: 'backup.enabled',
       type: 'toggle',
       default: 'false',
       description: 'Enable S3 backup CronJob',
+      group: 'Backup',
+    },
+    {
+      label: 'Backup Schedule',
+      key: 'backup.schedule',
+      type: 'text',
+      default: '0 2 * * *',
+      description: 'Cron schedule for backups',
+      group: 'Backup',
     },
   ],
   redis: [
@@ -66,9 +179,40 @@ const chartConfigs: Record<
       default: 'standalone',
       options: ['standalone', 'sentinel'],
       description: 'Deployment architecture',
+      group: 'General',
     },
-    { label: 'Storage Size', key: 'persistence.size', type: 'text', default: '2Gi', description: 'PVC storage size' },
-    { label: 'Replica Count', key: 'replicaCount', type: 'number', default: '1', description: 'Number of replicas' },
+    {
+      label: 'Replica Count',
+      key: 'replicaCount',
+      type: 'number',
+      default: '1',
+      description: 'Number of replicas',
+      group: 'General',
+    },
+    {
+      label: 'Storage Size',
+      key: 'persistence.size',
+      type: 'text',
+      default: '2Gi',
+      description: 'PVC storage size',
+      group: 'Storage',
+    },
+    {
+      label: 'CPU Request',
+      key: 'resources.requests.cpu',
+      type: 'text',
+      default: '100m',
+      description: 'CPU resource request',
+      group: 'Resources',
+    },
+    {
+      label: 'Memory Request',
+      key: 'resources.requests.memory',
+      type: 'text',
+      default: '128Mi',
+      description: 'Memory resource request',
+      group: 'Resources',
+    },
   ],
   mongodb: [
     {
@@ -78,32 +222,451 @@ const chartConfigs: Record<
       default: 'standalone',
       options: ['standalone', 'replicaset'],
       description: 'Deployment architecture',
+      group: 'General',
     },
-    { label: 'Storage Size', key: 'persistence.size', type: 'text', default: '8Gi', description: 'PVC storage size' },
-    { label: 'Replica Count', key: 'replicaCount', type: 'number', default: '1', description: 'Number of replicas' },
+    {
+      label: 'Replica Count',
+      key: 'replicaCount',
+      type: 'number',
+      default: '1',
+      description: 'Number of replicas',
+      group: 'General',
+    },
+    {
+      label: 'Storage Size',
+      key: 'persistence.size',
+      type: 'text',
+      default: '8Gi',
+      description: 'PVC storage size',
+      group: 'Storage',
+    },
+    {
+      label: 'CPU Request',
+      key: 'resources.requests.cpu',
+      type: 'text',
+      default: '250m',
+      description: 'CPU resource request',
+      group: 'Resources',
+    },
+    {
+      label: 'Memory Request',
+      key: 'resources.requests.memory',
+      type: 'text',
+      default: '256Mi',
+      description: 'Memory resource request',
+      group: 'Resources',
+    },
     {
       label: 'S3 Backup',
       key: 'backup.enabled',
       type: 'toggle',
       default: 'false',
       description: 'Enable S3 backup CronJob',
+      group: 'Backup',
     },
   ],
-  _default: [
-    { label: 'Replica Count', key: 'replicaCount', type: 'number', default: '1', description: 'Number of replicas' },
-    { label: 'Storage Size', key: 'persistence.size', type: 'text', default: '8Gi', description: 'PVC storage size' },
+  keycloak: [
+    {
+      label: 'Replica Count',
+      key: 'replicaCount',
+      type: 'number',
+      default: '1',
+      description: 'Number of replicas',
+      group: 'General',
+    },
     {
       label: 'Ingress',
       key: 'ingress.enabled',
       type: 'toggle',
       default: 'false',
       description: 'Enable Ingress resource',
+      group: 'Ingress',
+    },
+    {
+      label: 'Hostname',
+      key: 'ingress.hostname',
+      type: 'text',
+      default: 'keycloak.example.com',
+      description: 'Ingress hostname',
+      group: 'Ingress',
+    },
+    {
+      label: 'Ingress Class',
+      key: 'ingress.ingressClassName',
+      type: 'select',
+      default: 'traefik',
+      options: ['traefik', 'nginx'],
+      description: 'Ingress controller class',
+      group: 'Ingress',
+    },
+    {
+      label: 'TLS',
+      key: 'ingress.tls',
+      type: 'toggle',
+      default: 'false',
+      description: 'Enable TLS on Ingress',
+      group: 'Ingress',
+    },
+    {
+      label: 'Admin Password',
+      key: 'auth.adminPassword',
+      type: 'text',
+      default: '',
+      description: 'Initial admin password (auto-generated if empty)',
+      group: 'Auth',
+    },
+    {
+      label: 'CPU Request',
+      key: 'resources.requests.cpu',
+      type: 'text',
+      default: '500m',
+      description: 'CPU resource request',
+      group: 'Resources',
+    },
+    {
+      label: 'Memory Request',
+      key: 'resources.requests.memory',
+      type: 'text',
+      default: '512Mi',
+      description: 'Memory resource request',
+      group: 'Resources',
+    },
+  ],
+  n8n: [
+    {
+      label: 'Replica Count',
+      key: 'replicaCount',
+      type: 'number',
+      default: '1',
+      description: 'Number of replicas',
+      group: 'General',
+    },
+    {
+      label: 'Ingress',
+      key: 'ingress.enabled',
+      type: 'toggle',
+      default: 'false',
+      description: 'Enable Ingress resource',
+      group: 'Ingress',
+    },
+    {
+      label: 'Hostname',
+      key: 'ingress.hostname',
+      type: 'text',
+      default: 'n8n.example.com',
+      description: 'Ingress hostname',
+      group: 'Ingress',
+    },
+    {
+      label: 'Ingress Class',
+      key: 'ingress.ingressClassName',
+      type: 'select',
+      default: 'traefik',
+      options: ['traefik', 'nginx'],
+      description: 'Ingress controller class',
+      group: 'Ingress',
+    },
+    {
+      label: 'Storage Size',
+      key: 'persistence.size',
+      type: 'text',
+      default: '5Gi',
+      description: 'PVC storage size',
+      group: 'Storage',
+    },
+    {
+      label: 'S3 Backup',
+      key: 'backup.enabled',
+      type: 'toggle',
+      default: 'false',
+      description: 'Enable S3 backup CronJob',
+      group: 'Backup',
+    },
+  ],
+  wordpress: [
+    {
+      label: 'Ingress',
+      key: 'ingress.enabled',
+      type: 'toggle',
+      default: 'false',
+      description: 'Enable Ingress resource',
+      group: 'Ingress',
+    },
+    {
+      label: 'Hostname',
+      key: 'ingress.hostname',
+      type: 'text',
+      default: 'blog.example.com',
+      description: 'Ingress hostname',
+      group: 'Ingress',
+    },
+    {
+      label: 'Ingress Class',
+      key: 'ingress.ingressClassName',
+      type: 'select',
+      default: 'traefik',
+      options: ['traefik', 'nginx'],
+      description: 'Ingress controller class',
+      group: 'Ingress',
+    },
+    {
+      label: 'TLS',
+      key: 'ingress.tls',
+      type: 'toggle',
+      default: 'false',
+      description: 'Enable TLS on Ingress',
+      group: 'Ingress',
+    },
+    {
+      label: 'Storage Size',
+      key: 'persistence.size',
+      type: 'text',
+      default: '10Gi',
+      description: 'PVC storage size',
+      group: 'Storage',
+    },
+    {
+      label: 'S3 Backup',
+      key: 'backup.enabled',
+      type: 'toggle',
+      default: 'false',
+      description: 'Enable S3 backup CronJob',
+      group: 'Backup',
+    },
+  ],
+  gitea: [
+    {
+      label: 'Ingress',
+      key: 'ingress.enabled',
+      type: 'toggle',
+      default: 'false',
+      description: 'Enable Ingress resource',
+      group: 'Ingress',
+    },
+    {
+      label: 'Hostname',
+      key: 'ingress.hostname',
+      type: 'text',
+      default: 'git.example.com',
+      description: 'Ingress hostname',
+      group: 'Ingress',
+    },
+    {
+      label: 'Ingress Class',
+      key: 'ingress.ingressClassName',
+      type: 'select',
+      default: 'traefik',
+      options: ['traefik', 'nginx'],
+      description: 'Ingress controller class',
+      group: 'Ingress',
+    },
+    {
+      label: 'Storage Size',
+      key: 'persistence.size',
+      type: 'text',
+      default: '10Gi',
+      description: 'PVC storage size',
+      group: 'Storage',
+    },
+    {
+      label: 'S3 Backup',
+      key: 'backup.enabled',
+      type: 'toggle',
+      default: 'false',
+      description: 'Enable S3 backup CronJob',
+      group: 'Backup',
+    },
+  ],
+  _default: [
+    {
+      label: 'Replica Count',
+      key: 'replicaCount',
+      type: 'number',
+      default: '1',
+      description: 'Number of replicas',
+      group: 'General',
+    },
+    {
+      label: 'Storage Size',
+      key: 'persistence.size',
+      type: 'text',
+      default: '8Gi',
+      description: 'PVC storage size',
+      group: 'Storage',
+    },
+    {
+      label: 'Ingress',
+      key: 'ingress.enabled',
+      type: 'toggle',
+      default: 'false',
+      description: 'Enable Ingress resource',
+      group: 'Ingress',
+    },
+    {
+      label: 'Hostname',
+      key: 'ingress.hostname',
+      type: 'text',
+      default: 'app.example.com',
+      description: 'Ingress hostname',
+      group: 'Ingress',
+    },
+    {
+      label: 'Ingress Class',
+      key: 'ingress.ingressClassName',
+      type: 'select',
+      default: 'traefik',
+      options: ['traefik', 'nginx'],
+      description: 'Ingress controller class',
+      group: 'Ingress',
+    },
+    {
+      label: 'CPU Request',
+      key: 'resources.requests.cpu',
+      type: 'text',
+      default: '100m',
+      description: 'CPU resource request',
+      group: 'Resources',
+    },
+    {
+      label: 'Memory Request',
+      key: 'resources.requests.memory',
+      type: 'text',
+      default: '128Mi',
+      description: 'Memory resource request',
+      group: 'Resources',
     },
   ],
 };
 
-// Serialize configs for the client
+// Pre-built scenarios per chart
+const scenarios: Record<string, { label: string; description: string; values: Record<string, string> }[]> = {
+  postgresql: [
+    {
+      label: 'Development',
+      description: 'Minimal resources for local dev',
+      values: {
+        architecture: 'standalone',
+        replicaCount: '1',
+        'persistence.size': '2Gi',
+        'resources.requests.cpu': '100m',
+        'resources.requests.memory': '128Mi',
+        'resources.limits.cpu': '500m',
+        'resources.limits.memory': '256Mi',
+        'backup.enabled': 'false',
+      },
+    },
+    {
+      label: 'Staging',
+      description: 'Production-like with smaller resources',
+      values: {
+        architecture: 'replication',
+        replicaCount: '2',
+        'persistence.size': '10Gi',
+        'resources.requests.cpu': '250m',
+        'resources.requests.memory': '256Mi',
+        'resources.limits.cpu': '1000m',
+        'resources.limits.memory': '512Mi',
+        'backup.enabled': 'true',
+        'backup.schedule': '0 3 * * *',
+      },
+    },
+    {
+      label: 'Production',
+      description: 'HA with replication and backups',
+      values: {
+        architecture: 'replication',
+        replicaCount: '3',
+        'persistence.size': '50Gi',
+        'resources.requests.cpu': '1000m',
+        'resources.requests.memory': '1Gi',
+        'resources.limits.cpu': '2000m',
+        'resources.limits.memory': '2Gi',
+        'backup.enabled': 'true',
+        'backup.schedule': '0 */6 * * *',
+        'backup.s3.endpoint': 's3.amazonaws.com',
+        'backup.s3.bucket': 'prod-pg-backups',
+      },
+    },
+  ],
+  mysql: [
+    {
+      label: 'Development',
+      description: 'Minimal for local dev',
+      values: {
+        architecture: 'standalone',
+        replicaCount: '1',
+        'persistence.size': '2Gi',
+        'resources.requests.cpu': '100m',
+        'resources.requests.memory': '128Mi',
+        'backup.enabled': 'false',
+      },
+    },
+    {
+      label: 'Production',
+      description: 'Replication with backups',
+      values: {
+        architecture: 'replication',
+        replicaCount: '2',
+        'persistence.size': '50Gi',
+        'resources.requests.cpu': '500m',
+        'resources.requests.memory': '512Mi',
+        'backup.enabled': 'true',
+        'backup.schedule': '0 2 * * *',
+      },
+    },
+  ],
+  redis: [
+    {
+      label: 'Development',
+      description: 'Standalone for caching',
+      values: {
+        architecture: 'standalone',
+        replicaCount: '1',
+        'persistence.size': '1Gi',
+        'resources.requests.cpu': '50m',
+        'resources.requests.memory': '64Mi',
+      },
+    },
+    {
+      label: 'Production',
+      description: 'Sentinel HA with replicas',
+      values: {
+        architecture: 'sentinel',
+        replicaCount: '3',
+        'persistence.size': '5Gi',
+        'resources.requests.cpu': '250m',
+        'resources.requests.memory': '256Mi',
+      },
+    },
+  ],
+  keycloak: [
+    {
+      label: 'Development',
+      description: 'Single instance, no ingress',
+      values: {
+        replicaCount: '1',
+        'ingress.enabled': 'false',
+        'resources.requests.cpu': '250m',
+        'resources.requests.memory': '256Mi',
+      },
+    },
+    {
+      label: 'Production',
+      description: 'HA with Ingress and TLS',
+      values: {
+        replicaCount: '2',
+        'ingress.enabled': 'true',
+        'ingress.hostname': 'auth.example.com',
+        'ingress.tls': 'true',
+        'resources.requests.cpu': '1000m',
+        'resources.requests.memory': '1Gi',
+      },
+    },
+  ],
+};
+
 const configsJson = JSON.stringify(chartConfigs);
+const scenariosJson = JSON.stringify(scenarios);
 ---
 
 <BaseLayout
@@ -123,7 +686,15 @@ const configsJson = JSON.stringify(chartConfigs);
         <!-- Chart Selector -->
         <div class="lg:col-span-2">
           <h3 class="text-sm font-bold uppercase tracking-[0.16em] text-text-muted mb-4">Select a chart</h3>
-          <div class="space-y-2 max-h-[560px] overflow-y-auto pr-1">
+          <div class="relative mb-4">
+            <input
+              type="search"
+              id="playground-search"
+              class="block w-full pl-4 pr-4 py-2.5 border border-border rounded-xl bg-bg-surface/80 text-text-base placeholder-text-muted focus:outline-none focus:ring-2 focus:ring-primary-light focus:border-transparent text-sm"
+              placeholder="Filter charts..."
+            />
+          </div>
+          <div id="playground-chart-list" class="space-y-2 max-h-[500px] overflow-y-auto pr-1">
             {
               stableCharts.map((chart) => (
                 <button
@@ -171,24 +742,59 @@ const configsJson = JSON.stringify(chartConfigs);
               <p class="text-xs mt-1">Values will appear here with controls to customize them</p>
             </div>
             <div id="playground-fields" class="hidden">
-              <div class="flex items-center justify-between mb-5">
+              <div class="flex items-center justify-between mb-3">
                 <h3 id="playground-chart-title" class="text-lg font-bold text-text-base heading-font"></h3>
                 <a id="playground-docs-link" href="#" class="text-xs text-primary-light hover:underline">View docs</a>
               </div>
-              <div id="playground-controls" class="space-y-4"></div>
+
+              <!-- Scenario buttons -->
+              <div id="playground-scenarios" class="hidden mb-5">
+                <div class="flex items-center gap-2 mb-2">
+                  <span class="text-xs font-bold uppercase tracking-[0.12em] text-text-muted">Presets</span>
+                </div>
+                <div id="playground-scenario-btns" class="flex flex-wrap gap-2"></div>
+              </div>
+
+              <div id="playground-controls" class="space-y-5"></div>
             </div>
           </div>
 
-          <!-- Command Output -->
+          <!-- Output Format Toggle -->
           <div class="flex items-center justify-between mb-3">
-            <h3 class="text-sm font-bold uppercase tracking-[0.16em] text-text-muted">Install command</h3>
-            <button
-              id="playground-copy"
-              class="text-xs font-medium text-primary-light hover:text-primary transition-colors disabled:opacity-40"
-              disabled
-            >
-              Copy to clipboard
-            </button>
+            <div class="flex items-center gap-3">
+              <h3 class="text-sm font-bold uppercase tracking-[0.16em] text-text-muted">Output</h3>
+              <div class="flex gap-1 p-0.5 rounded-lg bg-bg-surface/80 border border-border">
+                <button
+                  class="playground-output-btn px-2.5 py-1 rounded-md text-xs font-semibold transition-all bg-primary text-white"
+                  data-output="helm"
+                >
+                  Helm
+                </button>
+                <button
+                  class="playground-output-btn px-2.5 py-1 rounded-md text-xs font-semibold transition-all text-text-muted hover:text-text-base"
+                  data-output="values"
+                >
+                  values.yaml
+                </button>
+              </div>
+            </div>
+            <div class="flex items-center gap-2">
+              <button
+                id="playground-share"
+                class="text-xs font-medium text-text-muted hover:text-primary-light transition-colors disabled:opacity-40"
+                disabled
+                title="Copy shareable link"
+              >
+                Share
+              </button>
+              <button
+                id="playground-copy"
+                class="text-xs font-medium text-primary-light hover:text-primary transition-colors disabled:opacity-40"
+                disabled
+              >
+                Copy to clipboard
+              </button>
+            </div>
           </div>
           <div class="rounded-2xl border border-border bg-[#1e1e2e] overflow-hidden">
             <div class="flex items-center px-4 py-2.5 border-b border-white/5 bg-white/5">
@@ -197,11 +803,53 @@ const configsJson = JSON.stringify(chartConfigs);
                 <div class="w-2.5 h-2.5 rounded-full bg-[#ffbd2e]"></div>
                 <div class="w-2.5 h-2.5 rounded-full bg-[#27c93f]"></div>
               </div>
-              <span class="mx-auto text-[10px] text-zinc-400 font-mono">terminal</span>
+              <span id="playground-filename" class="mx-auto text-[10px] text-zinc-400 font-mono">terminal</span>
             </div>
             <pre
               id="playground-output"
               class="p-5 font-mono text-sm text-zinc-300 leading-relaxed overflow-x-auto min-h-[120px]"><code id="playground-code" class="block"><span class="text-zinc-400"># Select a chart and configure values</span></code></pre>
+          </div>
+
+          <!-- Deploy documentation popup -->
+          <div id="playground-deploy-hint" class="hidden mt-4 glass-panel rounded-xl p-4">
+            <div class="flex items-start gap-3">
+              <svg class="w-5 h-5 text-primary-light shrink-0 mt-0.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  stroke-width="2"
+                  d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"></path>
+              </svg>
+              <div class="text-xs text-text-muted leading-relaxed">
+                <p class="font-semibold text-text-base mb-1">Deploy to your cluster</p>
+                <ol class="list-decimal list-inside space-y-1">
+                  <li>Add the HelmForge repo: <code class="text-primary-light">helm repo add helmforge https://repo.helmforge.dev</code></li>
+                  <li>Copy the command above and run it in your terminal</li>
+                  <li>
+                    Verify:
+                    <code class="text-primary-light">kubectl get pods -n helmforge</code>
+                  </li>
+                </ol>
+                <p class="mt-2">
+                  For production use, save the <strong>values.yaml</strong> output to a file and install with
+                  <code class="text-primary-light">helm install -f values.yaml</code>.
+                </p>
+              </div>
+            </div>
+          </div>
+
+          <!-- Changed values summary -->
+          <div id="playground-diff" class="hidden mt-4">
+            <div class="flex items-center gap-2 mb-2">
+              <span class="text-xs font-bold uppercase tracking-[0.12em] text-text-muted">Changes from defaults</span>
+              <span
+                id="playground-diff-count"
+                class="text-[10px] font-bold bg-primary/10 text-primary-light rounded-full px-2 py-0.5"
+              >
+                0
+              </span>
+            </div>
+            <div id="playground-diff-list" class="flex flex-wrap gap-2"></div>
           </div>
         </div>
       </div>
@@ -210,8 +858,9 @@ const configsJson = JSON.stringify(chartConfigs);
   <Footer />
 </BaseLayout>
 
-<script define:vars={{ configsJson }}>
+<script define:vars={{ configsJson, scenariosJson }}>
   window.__playgroundConfigs = JSON.parse(configsJson);
+  window.__playgroundScenarios = JSON.parse(scenariosJson);
 </script>
 <script>
   import '../scripts/playground';

--- a/src/pages/playground.astro
+++ b/src/pages/playground.astro
@@ -813,7 +813,12 @@ const scenariosJson = JSON.stringify(scenarios);
           <!-- Deploy documentation popup -->
           <div id="playground-deploy-hint" class="hidden mt-4 glass-panel rounded-xl p-4">
             <div class="flex items-start gap-3">
-              <svg class="w-5 h-5 text-primary-light shrink-0 mt-0.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <svg
+                class="w-5 h-5 text-primary-light shrink-0 mt-0.5"
+                fill="none"
+                stroke="currentColor"
+                viewBox="0 0 24 24"
+              >
                 <path
                   stroke-linecap="round"
                   stroke-linejoin="round"
@@ -823,7 +828,11 @@ const scenariosJson = JSON.stringify(scenarios);
               <div class="text-xs text-text-muted leading-relaxed">
                 <p class="font-semibold text-text-base mb-1">Deploy to your cluster</p>
                 <ol class="list-decimal list-inside space-y-1">
-                  <li>Add the HelmForge repo: <code class="text-primary-light">helm repo add helmforge https://repo.helmforge.dev</code></li>
+                  <li>
+                    Add the HelmForge repo: <code class="text-primary-light"
+                      >helm repo add helmforge https://repo.helmforge.dev</code
+                    >
+                  </li>
                   <li>Copy the command above and run it in your terminal</li>
                   <li>
                     Verify:

--- a/src/pages/stack.astro
+++ b/src/pages/stack.astro
@@ -43,7 +43,7 @@ const stableCharts = charts.filter((c) => c.maturity === 'stable');
             {
               stableCharts.map((chart) => (
                 <label
-                  class="stack-chart-item flex items-center gap-3 rounded-xl border border-border bg-bg-surface/40 px-4 py-3 cursor-pointer transition-all hover:border-primary/40 hover:bg-bg-surface/80 has-[:checked]:border-primary/60 has-[:checked]:bg-primary/5"
+                  class="stack-chart-item relative flex items-center gap-3 rounded-xl border border-border bg-bg-surface/40 px-4 py-3 cursor-pointer transition-all hover:border-primary/40 hover:bg-bg-surface/80 has-[:checked]:border-primary/60 has-[:checked]:bg-primary/5"
                   data-name={chart.slug}
                 >
                   <input

--- a/src/scripts/playground.ts
+++ b/src/scripts/playground.ts
@@ -5,11 +5,21 @@ interface FieldConfig {
   default: string;
   options?: string[];
   description: string;
+  group?: string;
+}
+
+interface Scenario {
+  label: string;
+  description: string;
+  values: Record<string, string>;
 }
 
 const configs: Record<string, FieldConfig[]> = (window as any).__playgroundConfigs ?? {};
+const scenarios: Record<string, Scenario[]> = (window as any).__playgroundScenarios ?? {};
 
 const chartBtns = document.querySelectorAll<HTMLButtonElement>('.playground-chart-btn');
+const chartItems = document.querySelectorAll<HTMLElement>('.playground-chart-btn');
+const searchInput = document.getElementById('playground-search') as HTMLInputElement | null;
 const emptyEl = document.getElementById('playground-empty');
 const fieldsEl = document.getElementById('playground-fields');
 const controlsEl = document.getElementById('playground-controls');
@@ -17,16 +27,44 @@ const titleEl = document.getElementById('playground-chart-title');
 const docsLink = document.getElementById('playground-docs-link') as HTMLAnchorElement | null;
 const codeEl = document.getElementById('playground-code');
 const copyBtn = document.getElementById('playground-copy') as HTMLButtonElement | null;
+const shareBtn = document.getElementById('playground-share') as HTMLButtonElement | null;
+const scenariosEl = document.getElementById('playground-scenarios');
+const scenarioBtnsEl = document.getElementById('playground-scenario-btns');
+const outputBtns = document.querySelectorAll<HTMLButtonElement>('.playground-output-btn');
+const filenameEl = document.getElementById('playground-filename');
+const deployHint = document.getElementById('playground-deploy-hint');
+const diffEl = document.getElementById('playground-diff');
+const diffCountEl = document.getElementById('playground-diff-count');
+const diffListEl = document.getElementById('playground-diff-list');
 
+type OutputMode = 'helm' | 'values';
+let outputMode: OutputMode = 'helm';
 let selectedSlug = '';
+let selectedName = '';
 let currentValues: Record<string, string> = {};
 
 function getFields(slug: string): FieldConfig[] {
   return configs[slug] ?? configs['_default'] ?? [];
 }
 
+function getScenarios(slug: string): Scenario[] {
+  return scenarios[slug] ?? [];
+}
+
+// Group fields by their group property
+function groupFields(fields: FieldConfig[]): Map<string, FieldConfig[]> {
+  const groups = new Map<string, FieldConfig[]>();
+  for (const field of fields) {
+    const group = field.group ?? 'General';
+    if (!groups.has(group)) groups.set(group, []);
+    groups.get(group)!.push(field);
+  }
+  return groups;
+}
+
 function selectChart(slug: string, name: string) {
   selectedSlug = slug;
+  selectedName = name;
   currentValues = {};
 
   // Update button states
@@ -43,106 +81,202 @@ function selectChart(slug: string, name: string) {
   if (fieldsEl) fieldsEl.classList.remove('hidden');
   if (titleEl) titleEl.textContent = name;
   if (docsLink) docsLink.href = `/docs/charts/${slug}`;
+  if (deployHint) deployHint.classList.remove('hidden');
 
-  // Build controls
+  // Build scenario buttons
+  const chartScenarios = getScenarios(slug);
+  if (scenariosEl && scenarioBtnsEl) {
+    if (chartScenarios.length > 0) {
+      scenariosEl.classList.remove('hidden');
+      scenarioBtnsEl.innerHTML = '';
+      chartScenarios.forEach((scenario) => {
+        const btn = document.createElement('button');
+        btn.className =
+          'playground-scenario-btn px-3 py-1.5 rounded-lg text-xs font-semibold border border-border bg-bg-surface/60 text-text-muted transition-all hover:border-primary/40 hover:text-text-base';
+        btn.textContent = scenario.label;
+        btn.title = scenario.description;
+        btn.addEventListener('click', () => applyScenario(scenario));
+        scenarioBtnsEl.appendChild(btn);
+      });
+    } else {
+      scenariosEl.classList.add('hidden');
+    }
+  }
+
+  // Build controls grouped
   const fields = getFields(slug);
   if (!controlsEl) return;
   controlsEl.innerHTML = '';
 
-  fields.forEach((field) => {
-    currentValues[field.key] = field.default;
-    const div = document.createElement('div');
-    div.className = 'flex items-center justify-between gap-4';
+  const groups = groupFields(fields);
 
-    const labelDiv = document.createElement('div');
-    labelDiv.className = 'min-w-0';
-    labelDiv.innerHTML = `
-      <div class="text-sm font-semibold text-text-base">${field.label}</div>
-      <div class="text-xs text-text-muted">${field.description}</div>
-    `;
-
-    const controlDiv = document.createElement('div');
-    controlDiv.className = 'shrink-0';
-
-    if (field.type === 'select') {
-      const select = document.createElement('select');
-      select.className =
-        'rounded-lg border border-border bg-bg-surface/80 px-3 py-1.5 text-sm text-text-base focus:outline-none focus:ring-2 focus:ring-primary-light';
-      (field.options ?? []).forEach((opt) => {
-        const option = document.createElement('option');
-        option.value = opt;
-        option.textContent = opt;
-        if (opt === field.default) option.selected = true;
-        select.appendChild(option);
-      });
-      select.addEventListener('change', () => {
-        currentValues[field.key] = select.value;
-        updateOutput();
-      });
-      controlDiv.appendChild(select);
-    } else if (field.type === 'toggle') {
-      const btn = document.createElement('button');
-      btn.className = `relative inline-flex h-6 w-11 items-center rounded-full transition-colors ${field.default === 'true' ? 'bg-primary' : 'bg-border'}`;
-      btn.innerHTML = `<span class="inline-block h-4 w-4 transform rounded-full bg-white transition-transform ${field.default === 'true' ? 'translate-x-6' : 'translate-x-1'}"></span>`;
-      btn.addEventListener('click', () => {
-        const isOn = currentValues[field.key] === 'true';
-        currentValues[field.key] = isOn ? 'false' : 'true';
-        btn.className = `relative inline-flex h-6 w-11 items-center rounded-full transition-colors ${!isOn ? 'bg-primary' : 'bg-border'}`;
-        const dot = btn.querySelector('span')!;
-        dot.className = `inline-block h-4 w-4 transform rounded-full bg-white transition-transform ${!isOn ? 'translate-x-6' : 'translate-x-1'}`;
-        updateOutput();
-      });
-      controlDiv.appendChild(btn);
-    } else if (field.type === 'number') {
-      const input = document.createElement('input');
-      input.type = 'number';
-      input.min = '1';
-      input.max = '10';
-      input.value = field.default;
-      input.className =
-        'w-20 rounded-lg border border-border bg-bg-surface/80 px-3 py-1.5 text-sm text-text-base text-center focus:outline-none focus:ring-2 focus:ring-primary-light';
-      input.addEventListener('input', () => {
-        currentValues[field.key] = input.value;
-        updateOutput();
-      });
-      controlDiv.appendChild(input);
-    } else {
-      const input = document.createElement('input');
-      input.type = 'text';
-      input.value = field.default;
-      input.className =
-        'w-28 rounded-lg border border-border bg-bg-surface/80 px-3 py-1.5 text-sm text-text-base focus:outline-none focus:ring-2 focus:ring-primary-light';
-      input.addEventListener('input', () => {
-        currentValues[field.key] = input.value;
-        updateOutput();
-      });
-      controlDiv.appendChild(input);
+  for (const [groupName, groupFields] of groups) {
+    // Group header
+    const groupHeader = document.createElement('div');
+    groupHeader.className = 'text-xs font-bold uppercase tracking-[0.12em] text-text-muted mb-2';
+    if (controlsEl.children.length > 0) {
+      groupHeader.classList.add('mt-3', 'pt-3', 'border-t', 'border-border');
     }
+    groupHeader.textContent = groupName;
+    controlsEl.appendChild(groupHeader);
 
-    div.appendChild(labelDiv);
-    div.appendChild(controlDiv);
-    controlsEl.appendChild(div);
+    // Fields
+    for (const field of groupFields) {
+      currentValues[field.key] = field.default;
+      const div = document.createElement('div');
+      div.className = 'flex items-center justify-between gap-4';
+      div.dataset.fieldKey = field.key;
+
+      const labelDiv = document.createElement('div');
+      labelDiv.className = 'min-w-0';
+      labelDiv.innerHTML = `
+        <div class="text-sm font-semibold text-text-base">${field.label}</div>
+        <div class="text-xs text-text-muted">${field.description}</div>
+      `;
+
+      const controlDiv = document.createElement('div');
+      controlDiv.className = 'shrink-0';
+
+      if (field.type === 'select') {
+        const select = document.createElement('select');
+        select.className =
+          'rounded-lg border border-border bg-bg-surface/80 px-3 py-1.5 text-sm text-text-base focus:outline-none focus:ring-2 focus:ring-primary-light';
+        select.dataset.fieldKey = field.key;
+        (field.options ?? []).forEach((opt) => {
+          const option = document.createElement('option');
+          option.value = opt;
+          option.textContent = opt;
+          if (opt === field.default) option.selected = true;
+          select.appendChild(option);
+        });
+        select.addEventListener('change', () => {
+          currentValues[field.key] = select.value;
+          updateOutput();
+        });
+        controlDiv.appendChild(select);
+      } else if (field.type === 'toggle') {
+        const btn = document.createElement('button');
+        const isOn = field.default === 'true';
+        btn.className = `relative inline-flex h-6 w-11 items-center rounded-full transition-colors ${isOn ? 'bg-primary' : 'bg-border'}`;
+        btn.innerHTML = `<span class="inline-block h-4 w-4 transform rounded-full bg-white transition-transform ${isOn ? 'translate-x-6' : 'translate-x-1'}"></span>`;
+        btn.dataset.fieldKey = field.key;
+        btn.addEventListener('click', () => {
+          const wasOn = currentValues[field.key] === 'true';
+          currentValues[field.key] = wasOn ? 'false' : 'true';
+          btn.className = `relative inline-flex h-6 w-11 items-center rounded-full transition-colors ${!wasOn ? 'bg-primary' : 'bg-border'}`;
+          const dot = btn.querySelector('span')!;
+          dot.className = `inline-block h-4 w-4 transform rounded-full bg-white transition-transform ${!wasOn ? 'translate-x-6' : 'translate-x-1'}`;
+          updateOutput();
+        });
+        controlDiv.appendChild(btn);
+      } else if (field.type === 'number') {
+        const input = document.createElement('input');
+        input.type = 'number';
+        input.min = '1';
+        input.max = '10';
+        input.value = field.default;
+        input.dataset.fieldKey = field.key;
+        input.className =
+          'w-20 rounded-lg border border-border bg-bg-surface/80 px-3 py-1.5 text-sm text-text-base text-center focus:outline-none focus:ring-2 focus:ring-primary-light';
+        input.addEventListener('input', () => {
+          currentValues[field.key] = input.value;
+          updateOutput();
+        });
+        controlDiv.appendChild(input);
+      } else {
+        const input = document.createElement('input');
+        input.type = 'text';
+        input.value = field.default;
+        input.dataset.fieldKey = field.key;
+        input.className =
+          'w-32 rounded-lg border border-border bg-bg-surface/80 px-3 py-1.5 text-sm text-text-base focus:outline-none focus:ring-2 focus:ring-primary-light';
+        input.addEventListener('input', () => {
+          currentValues[field.key] = input.value;
+          updateOutput();
+        });
+        controlDiv.appendChild(input);
+      }
+
+      div.appendChild(labelDiv);
+      div.appendChild(controlDiv);
+      controlsEl.appendChild(div);
+    }
+  }
+
+  updateOutput();
+  updateUrlState();
+}
+
+function applyScenario(scenario: Scenario) {
+  const fields = getFields(selectedSlug);
+
+  // Reset all to defaults first
+  fields.forEach((f) => {
+    currentValues[f.key] = f.default;
+  });
+
+  // Apply scenario values
+  for (const [key, val] of Object.entries(scenario.values)) {
+    currentValues[key] = val;
+  }
+
+  // Update all UI controls to match
+  if (controlsEl) {
+    const controls = controlsEl.querySelectorAll<HTMLElement>('[data-field-key]');
+    controls.forEach((el) => {
+      const key = el.dataset.fieldKey ?? '';
+      const val = currentValues[key];
+      if (val === undefined) return;
+
+      if (el instanceof HTMLSelectElement) {
+        el.value = val;
+      } else if (el instanceof HTMLInputElement) {
+        el.value = val;
+      } else if (el.tagName === 'BUTTON' && el.classList.contains('inline-flex')) {
+        // Toggle button
+        const isOn = val === 'true';
+        el.className = `relative inline-flex h-6 w-11 items-center rounded-full transition-colors ${isOn ? 'bg-primary' : 'bg-border'}`;
+        const dot = el.querySelector('span');
+        if (dot) {
+          dot.className = `inline-block h-4 w-4 transform rounded-full bg-white transition-transform ${isOn ? 'translate-x-6' : 'translate-x-1'}`;
+        }
+      }
+    });
+  }
+
+  // Highlight active scenario
+  document.querySelectorAll('.playground-scenario-btn').forEach((btn) => {
+    if (btn.textContent === scenario.label) {
+      btn.classList.add('border-primary/60', 'bg-primary/5', 'text-primary-light');
+      btn.classList.remove('text-text-muted');
+    } else {
+      btn.classList.remove('border-primary/60', 'bg-primary/5', 'text-primary-light');
+      btn.classList.add('text-text-muted');
+    }
   });
 
   updateOutput();
 }
 
-function buildSetFlags(): string[] {
+function getChangedValues(): { key: string; value: string; defaultValue: string }[] {
   const fields = getFields(selectedSlug);
-  const flags: string[] = [];
+  const changes: { key: string; value: string; defaultValue: string }[] = [];
   fields.forEach((field) => {
     const val = currentValues[field.key];
-    if (val !== field.default) {
-      flags.push(`--set ${field.key}=${val}`);
+    if (val !== undefined && val !== field.default && val !== '') {
+      changes.push({ key: field.key, value: val, defaultValue: field.default });
     }
   });
-  return flags;
+  return changes;
 }
 
-function updateOutput() {
-  if (!codeEl || !selectedSlug) return;
-  if (copyBtn) copyBtn.disabled = false;
+function buildSetFlags(): string[] {
+  const changes = getChangedValues();
+  return changes.map((c) => `--set ${c.key}=${c.value}`);
+}
 
+function generateHelmOutput(): string {
+  if (!selectedSlug) return '';
   const flags = buildSetFlags();
   const lines: string[] = [];
 
@@ -154,11 +288,61 @@ function updateOutput() {
   });
 
   lines.push(`  --wait --timeout 5m`);
-
-  codeEl.innerHTML = lines.join('\n');
+  return lines.join('\n');
 }
 
-function getPlainCommand(): string {
+function generateValuesYaml(): string {
+  if (!selectedSlug) return '';
+  const changes = getChangedValues();
+  if (changes.length === 0) {
+    return '<span class="text-zinc-500"># No values changed from defaults</span>\n<span class="text-zinc-500"># Modify settings above to generate a custom values.yaml</span>';
+  }
+
+  const lines: string[] = [];
+  lines.push(`<span class="text-zinc-500"># values.yaml for ${selectedName}</span>`);
+  lines.push(`<span class="text-zinc-500"># Generated at helmforge.dev/playground</span>`);
+  lines.push('');
+
+  // Build nested YAML from dotted keys
+  const tree: Record<string, any> = {};
+  changes.forEach(({ key, value }) => {
+    const parts = key.split('.');
+    let node = tree;
+    for (let i = 0; i < parts.length - 1; i++) {
+      if (!node[parts[i]]) node[parts[i]] = {};
+      node = node[parts[i]];
+    }
+    // Convert booleans and numbers
+    if (value === 'true' || value === 'false') {
+      node[parts[parts.length - 1]] = value === 'true';
+    } else if (/^\d+$/.test(value)) {
+      node[parts[parts.length - 1]] = parseInt(value, 10);
+    } else {
+      node[parts[parts.length - 1]] = value;
+    }
+  });
+
+  function renderYaml(obj: Record<string, any>, indent: number): void {
+    for (const [k, v] of Object.entries(obj)) {
+      const pad = '  '.repeat(indent);
+      if (typeof v === 'object' && v !== null && !Array.isArray(v)) {
+        lines.push(`${pad}<span class="text-sky-400">${k}</span>:`);
+        renderYaml(v, indent + 1);
+      } else if (typeof v === 'boolean') {
+        lines.push(`${pad}<span class="text-sky-400">${k}</span>: <span class="text-amber-300">${v}</span>`);
+      } else if (typeof v === 'number') {
+        lines.push(`${pad}<span class="text-sky-400">${k}</span>: <span class="text-amber-300">${v}</span>`);
+      } else {
+        lines.push(`${pad}<span class="text-sky-400">${k}</span>: ${v}`);
+      }
+    }
+  }
+
+  renderYaml(tree, 0);
+  return lines.join('\n');
+}
+
+function getPlainHelmCommand(): string {
   const flags = buildSetFlags();
   const parts = [`helm install ${selectedSlug} helmforge/${selectedSlug}`, '  --namespace helmforge'];
   flags.forEach((f) => parts.push(`  ${f}`));
@@ -166,18 +350,189 @@ function getPlainCommand(): string {
   return parts.join(' \\\n');
 }
 
-// Event listeners
+function getPlainValuesYaml(): string {
+  const changes = getChangedValues();
+  if (changes.length === 0) return '# No values changed from defaults\n';
+
+  const lines: string[] = [];
+  lines.push(`# values.yaml for ${selectedName}`);
+  lines.push(`# Generated at helmforge.dev/playground`);
+  lines.push('');
+
+  const tree: Record<string, any> = {};
+  changes.forEach(({ key, value }) => {
+    const parts = key.split('.');
+    let node = tree;
+    for (let i = 0; i < parts.length - 1; i++) {
+      if (!node[parts[i]]) node[parts[i]] = {};
+      node = node[parts[i]];
+    }
+    if (value === 'true' || value === 'false') {
+      node[parts[parts.length - 1]] = value === 'true';
+    } else if (/^\d+$/.test(value)) {
+      node[parts[parts.length - 1]] = parseInt(value, 10);
+    } else {
+      node[parts[parts.length - 1]] = value;
+    }
+  });
+
+  function renderYaml(obj: Record<string, any>, indent: number): void {
+    for (const [k, v] of Object.entries(obj)) {
+      const pad = '  '.repeat(indent);
+      if (typeof v === 'object' && v !== null && !Array.isArray(v)) {
+        lines.push(`${pad}${k}:`);
+        renderYaml(v, indent + 1);
+      } else {
+        lines.push(`${pad}${k}: ${v}`);
+      }
+    }
+  }
+
+  renderYaml(tree, 0);
+  return lines.join('\n');
+}
+
+function updateOutput() {
+  if (!codeEl || !selectedSlug) return;
+  if (copyBtn) copyBtn.disabled = false;
+  if (shareBtn) shareBtn.disabled = false;
+
+  // Update output
+  if (outputMode === 'helm') {
+    codeEl.innerHTML = generateHelmOutput();
+    if (filenameEl) filenameEl.textContent = 'terminal';
+  } else {
+    codeEl.innerHTML = generateValuesYaml();
+    if (filenameEl) filenameEl.textContent = 'values.yaml';
+  }
+
+  // Update diff view
+  const changes = getChangedValues();
+  if (diffEl && diffCountEl && diffListEl) {
+    if (changes.length > 0) {
+      diffEl.classList.remove('hidden');
+      diffCountEl.textContent = String(changes.length);
+      diffListEl.innerHTML = '';
+      changes.forEach((c) => {
+        const tag = document.createElement('span');
+        tag.className =
+          'inline-flex items-center gap-1.5 px-2.5 py-1 rounded-lg text-xs font-medium bg-primary/5 border border-primary/20 text-primary-light';
+        tag.innerHTML = `<span class="font-mono text-[10px]">${c.key}</span><span class="text-text-muted">=</span><span class="font-mono">${c.value}</span>`;
+        diffListEl.appendChild(tag);
+      });
+    } else {
+      diffEl.classList.add('hidden');
+    }
+  }
+
+  updateUrlState();
+}
+
+// URL state management for shareable links
+function updateUrlState() {
+  if (!selectedSlug) return;
+  const params = new URLSearchParams();
+  params.set('chart', selectedSlug);
+  const changes = getChangedValues();
+  changes.forEach((c) => {
+    params.set(c.key, c.value);
+  });
+  const url = `${window.location.pathname}?${params.toString()}`;
+  window.history.replaceState({}, '', url);
+}
+
+function loadFromUrl() {
+  const params = new URLSearchParams(window.location.search);
+  const chart = params.get('chart');
+  if (!chart) return;
+
+  // Find and click the chart button
+  const btn = Array.from(chartBtns).find((b) => b.dataset.slug === chart);
+  if (!btn) return;
+
+  selectChart(chart, btn.dataset.name ?? chart);
+
+  // Apply URL params
+  const fields = getFields(chart);
+  let hasChanges = false;
+  fields.forEach((field) => {
+    const val = params.get(field.key);
+    if (val !== null) {
+      currentValues[field.key] = val;
+      hasChanges = true;
+    }
+  });
+
+  if (hasChanges) {
+    // Update UI controls
+    if (controlsEl) {
+      const controls = controlsEl.querySelectorAll<HTMLElement>('[data-field-key]');
+      controls.forEach((el) => {
+        const key = el.dataset.fieldKey ?? '';
+        const val = currentValues[key];
+        if (val === undefined) return;
+
+        if (el instanceof HTMLSelectElement) {
+          el.value = val;
+        } else if (el instanceof HTMLInputElement) {
+          el.value = val;
+        } else if (el.tagName === 'BUTTON' && el.classList.contains('inline-flex')) {
+          const isOn = val === 'true';
+          el.className = `relative inline-flex h-6 w-11 items-center rounded-full transition-colors ${isOn ? 'bg-primary' : 'bg-border'}`;
+          const dot = el.querySelector('span');
+          if (dot) {
+            dot.className = `inline-block h-4 w-4 transform rounded-full bg-white transition-transform ${isOn ? 'translate-x-6' : 'translate-x-1'}`;
+          }
+        }
+      });
+    }
+    updateOutput();
+  }
+}
+
+// Output format toggle
+outputBtns.forEach((btn) => {
+  btn.addEventListener('click', () => {
+    outputMode = (btn.dataset.output as OutputMode) ?? 'helm';
+    outputBtns.forEach((b) => {
+      if (b === btn) {
+        b.classList.add('bg-primary', 'text-white');
+        b.classList.remove('text-text-muted');
+      } else {
+        b.classList.remove('bg-primary', 'text-white');
+        b.classList.add('text-text-muted');
+      }
+    });
+    updateOutput();
+  });
+});
+
+// Chart selection
 chartBtns.forEach((btn) => {
   btn.addEventListener('click', () => {
     selectChart(btn.dataset.slug ?? '', btn.dataset.name ?? '');
   });
 });
 
+// Search filter
+if (searchInput) {
+  searchInput.addEventListener('input', () => {
+    const term = searchInput.value.toLowerCase().trim();
+    chartItems.forEach((item) => {
+      const slug = item.dataset.slug ?? '';
+      const name = (item.dataset.name ?? '').toLowerCase();
+      item.style.display = slug.includes(term) || name.includes(term) ? '' : 'none';
+    });
+  });
+}
+
+// Copy
 if (copyBtn) {
   copyBtn.addEventListener('click', async () => {
     if (!selectedSlug) return;
+    const text = outputMode === 'helm' ? getPlainHelmCommand() : getPlainValuesYaml();
     try {
-      await navigator.clipboard.writeText(getPlainCommand());
+      await navigator.clipboard.writeText(text);
       copyBtn.textContent = 'Copied!';
       setTimeout(() => (copyBtn.textContent = 'Copy to clipboard'), 2000);
     } catch {
@@ -185,3 +540,20 @@ if (copyBtn) {
     }
   });
 }
+
+// Share
+if (shareBtn) {
+  shareBtn.addEventListener('click', async () => {
+    if (!selectedSlug) return;
+    try {
+      await navigator.clipboard.writeText(window.location.href);
+      shareBtn.textContent = 'Link copied!';
+      setTimeout(() => (shareBtn.textContent = 'Share'), 2000);
+    } catch {
+      // Fallback
+    }
+  });
+}
+
+// Load state from URL on page load
+loadFromUrl();

--- a/src/scripts/stack-builder.ts
+++ b/src/scripts/stack-builder.ts
@@ -257,7 +257,18 @@ formatBtns.forEach((btn) => {
   });
 });
 
-checkboxes.forEach((cb) => cb.addEventListener('change', update));
+checkboxes.forEach((cb) => {
+  cb.addEventListener('change', update);
+  // Prevent sr-only checkbox focus from scrolling the page
+  cb.addEventListener('focus', () => {
+    const scrollY = window.scrollY;
+    requestAnimationFrame(() => {
+      if (window.scrollY !== scrollY) {
+        window.scrollTo({ top: scrollY });
+      }
+    });
+  });
+});
 
 // Copy
 if (copyBtn) {


### PR DESCRIPTION
## Summary
- Expanded playground with grouped config fields: ingress, resources, backup, and auth settings per chart
- Added pre-built scenario buttons (Development, Staging, Production) for postgresql, mysql, redis, keycloak
- Added values.yaml output mode alongside helm install command
- Added shareable URLs that encode config state in query params
- Added visual diff showing changed values from defaults
- Added deploy-to-cluster documentation popup
- Added chart search filter to playground
- Fixed Stack Builder checkbox focus scrolling past footer (sr-only element positioning)

## Test plan
- [ ] Verify playground chart selection and config controls work
- [ ] Verify scenario buttons apply correct values
- [ ] Verify values.yaml output generates correct nested YAML
- [ ] Verify shareable URLs reload with correct state
- [ ] Verify Stack Builder no longer scrolls past footer on chart click
- [ ] Verify all existing E2E tests pass