### PR TITLE
feat(site): test coverage, vulnerability fixes, and a11y improvements

### DIFF
--- a/e2e/blog.spec.ts
+++ b/e2e/blog.spec.ts
@@ -1,0 +1,51 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('Blog', () => {
+  test('blog index renders post cards', async ({ page }) => {
+    await page.goto('/blog');
+    await expect(page).toHaveTitle(/Blog/i);
+    const cards = page.locator('a[href^="/blog/"]');
+    expect(await cards.count()).toBeGreaterThanOrEqual(3);
+  });
+
+  test('blog post renders with content', async ({ page }) => {
+    await page.goto('/blog');
+    const firstPost = page.locator('a[href^="/blog/"]').first();
+    const href = await firstPost.getAttribute('href');
+    expect(href).toBeTruthy();
+
+    await page.goto(href!);
+    await expect(page.locator('article')).toBeVisible();
+    // Reading time should be visible
+    await expect(page.locator('text=/\\d+ min read/')).toBeVisible();
+  });
+
+  test('blog post has date and tags', async ({ page }) => {
+    await page.goto('/blog');
+    const firstPost = page.locator('a[href^="/blog/"]').first();
+    const href = await firstPost.getAttribute('href');
+    await page.goto(href!);
+
+    // Should have a time element
+    await expect(page.locator('time')).toBeVisible();
+    // Should have at least one tag
+    expect(
+      await page
+        .locator('[class*="tag"], [class*="badge"], span:has-text("helm"), span:has-text("kubernetes")')
+        .count(),
+    ).toBeGreaterThan(0);
+  });
+
+  test('blog post has share links', async ({ page }) => {
+    await page.goto('/blog');
+    const firstPost = page.locator('a[href^="/blog/"]').first();
+    const href = await firstPost.getAttribute('href');
+    await page.goto(href!);
+
+    // Should have share links (Twitter/X, LinkedIn, or copy)
+    const shareLinks = page.locator(
+      'a[href*="twitter.com"], a[href*="x.com"], a[href*="linkedin.com"], button:has-text("Copy")',
+    );
+    expect(await shareLinks.count()).toBeGreaterThan(0);
+  });
+});

--- a/e2e/docs-components.spec.ts
+++ b/e2e/docs-components.spec.ts
@@ -1,0 +1,59 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('Docs Components', () => {
+  test('DocsTabs switches between tabs', async ({ page }) => {
+    await page.goto('/docs/charts/postgresql');
+    const tabGroup = page.locator('[role="tablist"]').first();
+
+    if ((await tabGroup.count()) > 0) {
+      const tabs = tabGroup.locator('[role="tab"]');
+      const tabCount = await tabs.count();
+      expect(tabCount).toBeGreaterThanOrEqual(2);
+
+      // Click second tab
+      await tabs.nth(1).click();
+      await page.waitForTimeout(200);
+
+      // Verify the second tab is now active
+      await expect(tabs.nth(1)).toHaveAttribute('aria-selected', 'true');
+
+      // Click first tab back
+      await tabs.nth(0).click();
+      await expect(tabs.nth(0)).toHaveAttribute('aria-selected', 'true');
+    }
+  });
+
+  test('Callout components render on troubleshooting page', async ({ page }) => {
+    await page.goto('/docs/troubleshooting');
+    await expect(page).toHaveTitle(/Troubleshooting/i);
+    // Callout components should be present
+    const callouts = page.locator('[class*="callout"], [class*="Callout"], aside, [role="note"]');
+    expect(await callouts.count()).toBeGreaterThan(0);
+  });
+
+  test('FAQ page has collapsible details sections', async ({ page }) => {
+    await page.goto('/docs/faq');
+    await expect(page).toHaveTitle(/FAQ/i);
+
+    const details = page.locator('details');
+    expect(await details.count()).toBeGreaterThan(5);
+
+    // Click to expand first details
+    const first = details.first();
+    const summary = first.locator('summary');
+    await summary.click();
+    await expect(first).toHaveAttribute('open', '');
+  });
+
+  test('install section on homepage has tabs and copy', async ({ page }) => {
+    await page.goto('/');
+    // Look for the install section with helm/OCI tabs
+    const installSection = page.locator('#install, [data-section="install"]').first();
+
+    if ((await installSection.count()) > 0) {
+      // Should have tab-like controls
+      const tabs = installSection.locator('button, [role="tab"]');
+      expect(await tabs.count()).toBeGreaterThanOrEqual(1);
+    }
+  });
+});

--- a/e2e/footer.spec.ts
+++ b/e2e/footer.spec.ts
@@ -1,0 +1,22 @@
+import { test, expect } from '@playwright/test';
+
+const pages = ['/', '/stack', '/blog', '/docs', '/playground', '/roadmap', '/community', '/changelog', '/request'];
+
+test.describe('Footer', () => {
+  for (const path of pages) {
+    test(`no gap below footer on ${path}`, async ({ page }) => {
+      await page.goto(path);
+      await page.waitForTimeout(300);
+
+      const gap = await page.evaluate(() => {
+        const footer = document.querySelector('footer');
+        if (!footer) return -1;
+        const bodyHeight = document.body.scrollHeight;
+        const footerBottom = footer.getBoundingClientRect().bottom + window.scrollY;
+        return Math.round(bodyHeight - footerBottom);
+      });
+
+      expect(gap).toBeLessThanOrEqual(5);
+    });
+  }
+});

--- a/e2e/icons.spec.ts
+++ b/e2e/icons.spec.ts
@@ -1,0 +1,68 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('Chart Icons', () => {
+  test('all chart icons load on homepage catalog', async ({ page }) => {
+    await page.goto('/');
+    const chartGrid = page.locator('#chart-grid-container');
+    await expect(chartGrid).toBeVisible();
+
+    // Get all image sources in the chart grid
+    const images = chartGrid.locator('img');
+    const count = await images.count();
+    expect(count).toBeGreaterThan(10);
+
+    // Scroll to make lazy images visible, then check they load
+    for (let i = 0; i < count; i++) {
+      const img = images.nth(i);
+      await img.scrollIntoViewIfNeeded();
+    }
+    // Wait for lazy images to load
+    await page.waitForTimeout(1000);
+
+    // Verify all images loaded via fetch (avoids lazy loading issues)
+    const failedSrcs = await page.evaluate(() => {
+      const imgs = document.querySelectorAll<HTMLImageElement>('#chart-grid-container img');
+      const failed: string[] = [];
+      imgs.forEach((img) => {
+        if (!img.complete || img.naturalWidth === 0) {
+          failed.push(img.src);
+        }
+      });
+      return failed;
+    });
+    expect(failedSrcs, `Failed to load icons: ${failedSrcs.join(', ')}`).toHaveLength(0);
+  });
+
+  test('SVG icons are not corrupted', async ({ page }) => {
+    await page.goto('/');
+    const chartGrid = page.locator('#chart-grid-container');
+    const svgImages = chartGrid.locator('img[src$=".svg"]');
+    const count = await svgImages.count();
+
+    for (let i = 0; i < count; i++) {
+      const img = svgImages.nth(i);
+      const src = await img.getAttribute('src');
+
+      // Fetch the SVG content and verify it starts with SVG markup
+      const response = await page.request.get(src!);
+      expect(response.status(), `SVG returned error status: ${src}`).toBe(200);
+      const body = await response.text();
+      expect(body, `SVG content is not valid SVG: ${src}`).toMatch(/^(<\?xml|<svg)/);
+    }
+  });
+
+  test('playground chart icons load', async ({ page }) => {
+    await page.goto('/playground');
+    const chartList = page.locator('.playground-chart-btn');
+    const images = page.locator('.playground-chart-btn img');
+    const count = await images.count();
+    expect(count).toBeGreaterThan(10);
+
+    for (let i = 0; i < Math.min(count, 10); i++) {
+      const img = images.nth(i);
+      const loaded = await img.evaluate((el: HTMLImageElement) => el.naturalWidth > 0 && el.complete);
+      const src = await img.getAttribute('src');
+      expect(loaded, `Playground icon failed: ${src}`).toBe(true);
+    }
+  });
+});

--- a/e2e/playground.spec.ts
+++ b/e2e/playground.spec.ts
@@ -1,0 +1,116 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('Playground', () => {
+  test('renders chart list and config panel', async ({ page }) => {
+    await page.goto('/playground');
+    await expect(page).toHaveTitle(/Playground/i);
+    const chartBtns = page.locator('.playground-chart-btn');
+    expect(await chartBtns.count()).toBeGreaterThan(10);
+    await expect(page.locator('#playground-empty')).toBeVisible();
+  });
+
+  test('selecting a chart shows config controls', async ({ page }) => {
+    await page.goto('/playground');
+    await page.locator('.playground-chart-btn[data-slug="postgresql"]').click();
+
+    await expect(page.locator('#playground-fields')).toBeVisible();
+    await expect(page.locator('#playground-chart-title')).toContainText('PostgreSQL');
+    await expect(page.locator('#playground-code')).toContainText('helm install postgresql');
+  });
+
+  test('changing values updates command output', async ({ page }) => {
+    await page.goto('/playground');
+    await page.locator('.playground-chart-btn[data-slug="postgresql"]').click();
+
+    // Change storage size
+    const storageInput = page.locator('input[data-field-key="persistence.size"]');
+    await storageInput.clear();
+    await storageInput.fill('20Gi');
+
+    const code = page.locator('#playground-code');
+    await expect(code).toContainText('persistence.size=20Gi');
+  });
+
+  test('values.yaml output mode works', async ({ page }) => {
+    await page.goto('/playground');
+    await page.locator('.playground-chart-btn[data-slug="postgresql"]').click();
+
+    // Change a value first
+    const storageInput = page.locator('input[data-field-key="persistence.size"]');
+    await storageInput.clear();
+    await storageInput.fill('20Gi');
+
+    // Switch to values.yaml output
+    await page.locator('.playground-output-btn[data-output="values"]').click();
+    await expect(page.locator('#playground-filename')).toContainText('values.yaml');
+    await expect(page.locator('#playground-code')).toContainText('persistence');
+  });
+
+  test('scenario buttons apply values', async ({ page }) => {
+    await page.goto('/playground');
+    await page.locator('.playground-chart-btn[data-slug="postgresql"]').click();
+
+    // Click Production scenario
+    const prodBtn = page.locator('.playground-scenario-btn:has-text("Production")');
+    if ((await prodBtn.count()) > 0) {
+      await prodBtn.click();
+      const code = page.locator('#playground-code');
+      await expect(code).toContainText('replicaCount');
+    }
+  });
+
+  test('copy button is enabled after selection', async ({ page }) => {
+    await page.goto('/playground');
+    const copyBtn = page.locator('#playground-copy');
+    await expect(copyBtn).toBeDisabled();
+    await page.locator('.playground-chart-btn').first().click();
+    await expect(copyBtn).toBeEnabled();
+  });
+
+  test('share button is enabled after selection', async ({ page }) => {
+    await page.goto('/playground');
+    const shareBtn = page.locator('#playground-share');
+    await expect(shareBtn).toBeDisabled();
+    await page.locator('.playground-chart-btn[data-slug="redis"]').click();
+    await expect(shareBtn).toBeEnabled();
+  });
+
+  test('URL state updates with chart selection', async ({ page }) => {
+    await page.goto('/playground');
+    await page.locator('.playground-chart-btn[data-slug="redis"]').click();
+    await page.waitForTimeout(300);
+    expect(page.url()).toContain('chart=redis');
+  });
+
+  test('loads state from URL params', async ({ page }) => {
+    await page.goto('/playground?chart=postgresql&persistence.size=50Gi');
+    await expect(page.locator('#playground-chart-title')).toContainText('PostgreSQL');
+    await expect(page.locator('#playground-code')).toContainText('persistence.size=50Gi');
+  });
+
+  test('search filter works', async ({ page }) => {
+    await page.goto('/playground');
+    const searchInput = page.locator('#playground-search');
+    await searchInput.fill('redis');
+
+    const visibleBtns = page.locator('.playground-chart-btn:visible');
+    expect(await visibleBtns.count()).toBeGreaterThanOrEqual(1);
+    expect(await visibleBtns.count()).toBeLessThan(10);
+  });
+
+  test('diff view shows changed values', async ({ page }) => {
+    await page.goto('/playground');
+    await page.locator('.playground-chart-btn[data-slug="postgresql"]').click();
+
+    // Initially no changes
+    await expect(page.locator('#playground-diff')).toBeHidden();
+
+    // Change a value
+    const storageInput = page.locator('input[data-field-key="persistence.size"]');
+    await storageInput.clear();
+    await storageInput.fill('20Gi');
+
+    await expect(page.locator('#playground-diff')).toBeVisible();
+    await expect(page.locator('#playground-diff-count')).toContainText('1');
+  });
+});

--- a/e2e/stack-builder.spec.ts
+++ b/e2e/stack-builder.spec.ts
@@ -1,0 +1,83 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('Stack Builder', () => {
+  test('renders chart list and output panel', async ({ page }) => {
+    await page.goto('/stack');
+    await expect(page).toHaveTitle(/Stack Builder/i);
+    const chartItems = page.locator('.stack-chart-item');
+    expect(await chartItems.count()).toBeGreaterThan(10);
+    await expect(page.locator('#stack-output')).toBeVisible();
+  });
+
+  test('selecting a chart updates output', async ({ page }) => {
+    await page.goto('/stack');
+    const firstChart = page.locator('.stack-chart-item').first();
+    await firstChart.click();
+
+    const code = page.locator('#stack-code');
+    await expect(code).toContainText('helm install');
+    await expect(page.locator('#stack-count')).toContainText('1 selected');
+  });
+
+  test('preset stacks select multiple charts', async ({ page }) => {
+    await page.goto('/stack');
+    const presetBtn = page.locator('.stack-preset').first();
+    await presetBtn.click();
+
+    const code = page.locator('#stack-code');
+    await expect(code).toContainText('helm install');
+    // Multiple charts should be selected
+    const countText = await page.locator('#stack-count').textContent();
+    const count = parseInt(countText ?? '0');
+    expect(count).toBeGreaterThanOrEqual(2);
+  });
+
+  test('format toggle switches output', async ({ page }) => {
+    await page.goto('/stack');
+    // Select a chart first
+    await page.locator('.stack-chart-item').first().click();
+
+    // Switch to Helmfile
+    await page.locator('.stack-format-btn[data-format="helmfile"]').click();
+    await expect(page.locator('#stack-code')).toContainText('repositories');
+    await expect(page.locator('#stack-filename')).toContainText('helmfile.yaml');
+
+    // Switch to ArgoCD
+    await page.locator('.stack-format-btn[data-format="argocd"]').click();
+    await expect(page.locator('#stack-code')).toContainText('Application');
+    await expect(page.locator('#stack-filename')).toContainText('applications.yaml');
+  });
+
+  test('copy button is enabled after selection', async ({ page }) => {
+    await page.goto('/stack');
+    const copyBtn = page.locator('#stack-copy-btn');
+    await expect(copyBtn).toBeDisabled();
+    await page.locator('.stack-chart-item').first().click();
+    await expect(copyBtn).toBeEnabled();
+  });
+
+  test('search filter hides non-matching charts', async ({ page }) => {
+    await page.goto('/stack');
+    const searchInput = page.locator('#stack-search');
+    await searchInput.fill('postgresql');
+
+    const visibleItems = page.locator('.stack-chart-item:visible');
+    expect(await visibleItems.count()).toBeGreaterThanOrEqual(1);
+    expect(await visibleItems.count()).toBeLessThan(10);
+  });
+
+  test('does not scroll past footer when clicking charts', async ({ page }) => {
+    await page.goto('/stack');
+    const chartList = page.locator('#stack-chart-list');
+    await chartList.evaluate((el) => (el.scrollTop = el.scrollHeight));
+    await page.waitForTimeout(200);
+
+    await page.locator('.stack-chart-item').last().click({ force: true });
+    await page.waitForTimeout(500);
+
+    const scrollY = await page.evaluate(() => window.scrollY);
+    const bodyHeight = await page.evaluate(() => document.body.scrollHeight);
+    const viewportHeight = await page.evaluate(() => window.innerHeight);
+    expect(scrollY).toBeLessThanOrEqual(bodyHeight - viewportHeight + 5);
+  });
+});

--- a/e2e/theme.spec.ts
+++ b/e2e/theme.spec.ts
@@ -1,0 +1,68 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('Theme Toggle', () => {
+  test('toggles between dark and light themes', async ({ page }) => {
+    await page.goto('/');
+
+    // Get initial theme
+    const initialTheme = await page.evaluate(() => document.documentElement.getAttribute('data-theme'));
+
+    // Find and click theme toggle
+    const themeToggle = page.locator('button[aria-label*="theme" i], button[aria-label*="Toggle" i]').first();
+    if ((await themeToggle.count()) === 0) return; // Skip if no toggle found
+
+    await themeToggle.click();
+    await page.waitForTimeout(300);
+
+    // Theme should have changed
+    const newTheme = await page.evaluate(() => document.documentElement.getAttribute('data-theme'));
+    expect(newTheme).not.toBe(initialTheme);
+
+    // Toggle back
+    await themeToggle.click();
+    await page.waitForTimeout(300);
+    const restoredTheme = await page.evaluate(() => document.documentElement.getAttribute('data-theme'));
+    expect(restoredTheme).toBe(initialTheme);
+  });
+
+  test('theme persists across navigation', async ({ page }) => {
+    await page.goto('/');
+
+    const themeToggle = page.locator('button[aria-label*="theme" i], button[aria-label*="Toggle" i]').first();
+    if ((await themeToggle.count()) === 0) return;
+
+    // Toggle theme
+    await themeToggle.click();
+    await page.waitForTimeout(300);
+    const theme = await page.evaluate(() => document.documentElement.getAttribute('data-theme'));
+
+    // Navigate to another page
+    await page.goto('/docs');
+    await page.waitForTimeout(300);
+    const themeAfterNav = await page.evaluate(() => document.documentElement.getAttribute('data-theme'));
+    expect(themeAfterNav).toBe(theme);
+  });
+
+  test('no broken styles in light mode', async ({ page }) => {
+    await page.goto('/');
+    // Force light mode
+    await page.evaluate(() => {
+      document.documentElement.setAttribute('data-theme', 'light');
+      localStorage.setItem('helmforge-theme', 'light');
+    });
+    await page.waitForTimeout(300);
+
+    // Check header is visible and has reasonable styling
+    const header = page.locator('header');
+    await expect(header).toBeVisible();
+    const headerBg = await header.evaluate((el) => window.getComputedStyle(el).backgroundColor);
+    // Should not be transparent (rgb(0,0,0,0))
+    expect(headerBg).not.toBe('rgba(0, 0, 0, 0)');
+
+    // Check main content area text is visible (not same color as background)
+    const body = page.locator('body');
+    const bodyBg = await body.evaluate((el) => window.getComputedStyle(el).backgroundColor);
+    const bodyColor = await body.evaluate((el) => window.getComputedStyle(el).color);
+    expect(bodyBg).not.toBe(bodyColor);
+  });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -2960,18 +2960,6 @@
         "node": ">= 8"
       }
     },
-    "node_modules/anymatch/node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
-      }
-    },
     "node_modules/arg": {
       "version": "5.0.2",
       "resolved": "https://registry.npmjs.org/arg/-/arg-5.0.2.tgz",
@@ -6380,19 +6368,6 @@
         "node": ">=8.6"
       }
     },
-    "node_modules/micromatch/node_modules/picomatch": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
-      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
-      }
-    },
     "node_modules/minimatch": {
       "version": "10.2.5",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
@@ -6781,9 +6756,9 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -7586,9 +7561,9 @@
       }
     },
     "node_modules/smol-toml": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/smol-toml/-/smol-toml-1.6.0.tgz",
-      "integrity": "sha512-4zemZi0HvTnYwLfrpk/CF9LOd9Lt87kAt50GnqhMpyF9U3poDAP2+iukq2bZsO/ufegbYehBkqINbsWxj4l4cw==",
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/smol-toml/-/smol-toml-1.6.1.tgz",
+      "integrity": "sha512-dWUG8F5sIIARXih1DTaQAX4SsiTXhInKf1buxdY9DIg4ZYPZK5nGM1VRIYmEbDbsHt7USo99xSLFu5Q1IqTmsg==",
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">= 18"

--- a/package.json
+++ b/package.json
@@ -24,6 +24,10 @@
     "tailwindcss": "^4.2.2",
     "web-vitals": "^5.2.0"
   },
+  "overrides": {
+    "picomatch": ">=2.3.2",
+    "smol-toml": ">=1.6.1"
+  },
   "devDependencies": {
     "@axe-core/playwright": "^4.11.1",
     "@eslint/js": "^10.0.1",

--- a/src/pages/changelog.astro
+++ b/src/pages/changelog.astro
@@ -78,7 +78,7 @@ function renderBody(body: string): string {
                 href="https://github.com/helmforgedev/charts/releases"
                 target="_blank"
                 rel="noopener noreferrer"
-                class="text-primary-light hover:underline"
+                class="text-primary-light underline hover:no-underline"
               >
                 GitHub Releases
               </a>


### PR DESCRIPTION
## Summary
- Add 41 new E2E tests covering all V3 features (blog, stack builder, playground, icons, docs components, theme toggle, footer gaps)
- Fix 5 GitHub security vulnerabilities via npm overrides (picomatch, smol-toml)
- Fix changelog link a11y contrast issue (underline for screen reader distinguishability)
- Total test count: 22 → 63

## New test suites
- `blog.spec.ts` — blog index, post rendering, date/tags, share links
- `stack-builder.spec.ts` — chart selection, presets, format toggle, search, scroll fix
- `playground.spec.ts` — config controls, values.yaml output, scenarios, URL sharing, diff view
- `icons.spec.ts` — chart icon loading, SVG corruption detection
- `docs-components.spec.ts` — DocsTabs switching, Callout rendering, FAQ collapsibles
- `theme.spec.ts` — dark/light toggle, persistence, no broken styles
- `footer.spec.ts` — no gap below footer on all 9 pages

## Test plan
- [ ] All 63 E2E tests pass locally and in CI
- [ ] npm audit shows 0 vulnerabilities
- [ ] Build succeeds