### PR TITLE
feat(site): update roadmap growth status and rename enterprise phase

### DIFF
--- a/src/pages/roadmap.astro
+++ b/src/pages/roadmap.astro
@@ -52,44 +52,44 @@ const staticRoadmap = [
     phase: 'Foundation',
     status: 'done' as const,
     items: [
-      'Core database charts (PostgreSQL, MySQL, Redis, MongoDB)',
-      'S3-compatible backup CronJobs',
-      'Cosign-signed OCI artifacts',
-      'Automated semantic versioning & release notes',
-      'ArtifactHub integration',
+      { text: 'Core database charts (PostgreSQL, MySQL, Redis, MongoDB)', done: true },
+      { text: 'S3-compatible backup CronJobs', done: true },
+      { text: 'Cosign-signed OCI artifacts', done: true },
+      { text: 'Automated semantic versioning & release notes', done: true },
+      { text: 'ArtifactHub integration', done: true },
     ],
   },
   {
     phase: 'Growth',
     status: 'active' as const,
     items: [
-      'Application charts (n8n, Keycloak, Gitea, WordPress, etc.)',
-      'Networking charts (Pi-hole, Cloudflared, Uptime Kuma)',
-      'AI/ML charts (Flowise, Open WebUI)',
-      'Chart maturity promotion pipeline',
-      'Website with docs, playground, and stack builder',
+      { text: 'Application charts (n8n, Keycloak, Gitea, WordPress, Appwrite, etc.)', done: true },
+      { text: 'Networking charts (Pi-hole, Cloudflared, Uptime Kuma)', done: true },
+      { text: 'AI/ML charts (Flowise, Open WebUI)', done: false },
+      { text: 'Chart maturity promotion pipeline', done: true },
+      { text: 'Website with docs, playground, and stack builder', done: true },
     ],
   },
   {
-    phase: 'Enterprise',
+    phase: 'Production Ready',
     status: 'planned' as const,
     items: [
-      'HA and multi-region deployment patterns',
-      'Monitoring and alerting integrations',
-      'Operator-based lifecycle management',
-      'Terraform and Pulumi modules',
-      'Compliance and policy templates (OPA, Kyverno)',
+      { text: 'HA and multi-region deployment patterns', done: false },
+      { text: 'Monitoring and alerting integrations', done: false },
+      { text: 'Operator-based lifecycle management', done: false },
+      { text: 'Terraform and Pulumi modules', done: false },
+      { text: 'Compliance and policy templates (OPA, Kyverno)', done: false },
     ],
   },
   {
     phase: 'Ecosystem',
     status: 'planned' as const,
     items: [
-      'GitOps-native install (ArgoCD, Flux catalogs)',
-      'Chart dependency graph and compatibility matrix',
-      'Community chart contribution pipeline',
-      'Cloud marketplace listings (AWS, Azure, GCP)',
-      'Interactive tutorials and learning paths',
+      { text: 'GitOps-native install (ArgoCD, Flux catalogs)', done: false },
+      { text: 'Chart dependency graph and compatibility matrix', done: false },
+      { text: 'Community chart contribution pipeline', done: false },
+      { text: 'Cloud marketplace listings (AWS, Azure, GCP)', done: false },
+      { text: 'Interactive tutorials and learning paths', done: false },
     ],
   },
 ];
@@ -208,7 +208,7 @@ const statusColors = {
                       <ul class="space-y-2">
                         {phase.items.map((item) => (
                           <li class="flex items-start gap-2.5 text-sm text-text-muted">
-                            {phase.status === 'done' ? (
+                            {item.done ? (
                               <svg
                                 class="w-4 h-4 text-emerald-400 shrink-0 mt-0.5"
                                 fill="none"
@@ -232,7 +232,7 @@ const statusColors = {
                                 <circle cx="12" cy="12" r="3" />
                               </svg>
                             )}
-                            <span>{item}</span>
+                            <span>{item.text}</span>
                           </li>
                         ))}
                       </ul>

--- a/src/pages/roadmap.astro
+++ b/src/pages/roadmap.astro
@@ -71,7 +71,7 @@ const staticRoadmap = [
     ],
   },
   {
-    phase: 'Production Ready',
+    phase: 'Resilience & Scale',
     status: 'planned' as const,
     items: [
       { text: 'HA and multi-region deployment patterns', done: false },


### PR DESCRIPTION
## Summary
- Mark completed Growth items with per-item checkmarks (application charts, networking, maturity pipeline, website)
- AI/ML charts remain in-progress (Open WebUI pending)
- Rename "Enterprise" phase to "Production Ready" — community-friendly name, same planned features (HA, monitoring, operators, Terraform/Pulumi, compliance)

## Test plan
- [ ] Verify roadmap page renders correctly with checkmarks on completed items
- [ ] Verify Growth shows 4/5 items completed, 1 in-progress
- [ ] Verify "Production Ready" phase displays correctly