### PR TITLE
feat(site): add playground configs for all 33 stable charts

### DIFF
--- a/src/pages/playground.astro
+++ b/src/pages/playground.astro
@@ -1194,6 +1194,1273 @@ const chartConfigs: Record<string, ChartConfig> = {
       ],
     },
   ],
+  'adguard-home': [
+    {
+      name: 'General',
+      fields: [
+        {
+          label: 'Storage Size',
+          key: 'persistence.size',
+          type: 'text',
+          default: '2Gi',
+          description: 'Config storage size',
+        },
+      ],
+    },
+    {
+      name: 'Resources',
+      collapsible: true,
+      fields: [
+        {
+          label: 'CPU Request',
+          key: 'resources.requests.cpu',
+          type: 'text',
+          default: '100m',
+          description: 'CPU request',
+        },
+        {
+          label: 'Memory Request',
+          key: 'resources.requests.memory',
+          type: 'text',
+          default: '128Mi',
+          description: 'Memory request',
+        },
+        { label: 'CPU Limit', key: 'resources.limits.cpu', type: 'text', default: '500m', description: 'CPU limit' },
+        {
+          label: 'Memory Limit',
+          key: 'resources.limits.memory',
+          type: 'text',
+          default: '256Mi',
+          description: 'Memory limit',
+        },
+      ],
+    },
+    {
+      name: 'Ingress',
+      collapsible: true,
+      gateField: 'ingress.enabled',
+      fields: [
+        {
+          label: 'Hostname',
+          key: 'ingress.hostname',
+          type: 'text',
+          default: 'adguard.example.com',
+          description: 'Ingress hostname',
+        },
+        {
+          label: 'Ingress Class',
+          key: 'ingress.ingressClassName',
+          type: 'select',
+          default: 'traefik',
+          options: ['traefik', 'nginx'],
+          description: 'Ingress controller class',
+        },
+        { label: 'TLS', key: 'ingress.tls', type: 'toggle', default: 'false', description: 'Enable TLS' },
+      ],
+    },
+    {
+      name: 'S3 Backup',
+      collapsible: true,
+      gateField: 'backup.enabled',
+      fields: [
+        {
+          label: 'Schedule',
+          key: 'backup.schedule',
+          type: 'text',
+          default: '0 2 * * *',
+          description: 'Cron schedule for backups',
+        },
+      ],
+    },
+  ],
+  answer: [
+    {
+      name: 'General',
+      fields: [
+        {
+          label: 'Replica Count',
+          key: 'replicaCount',
+          type: 'number',
+          default: '1',
+          description: 'Number of replicas',
+        },
+        {
+          label: 'Storage Size',
+          key: 'persistence.size',
+          type: 'text',
+          default: '5Gi',
+          description: 'PVC storage size',
+        },
+      ],
+    },
+    {
+      name: 'Resources',
+      collapsible: true,
+      fields: [
+        {
+          label: 'CPU Request',
+          key: 'resources.requests.cpu',
+          type: 'text',
+          default: '100m',
+          description: 'CPU request',
+        },
+        {
+          label: 'Memory Request',
+          key: 'resources.requests.memory',
+          type: 'text',
+          default: '128Mi',
+          description: 'Memory request',
+        },
+        { label: 'CPU Limit', key: 'resources.limits.cpu', type: 'text', default: '500m', description: 'CPU limit' },
+        {
+          label: 'Memory Limit',
+          key: 'resources.limits.memory',
+          type: 'text',
+          default: '256Mi',
+          description: 'Memory limit',
+        },
+      ],
+    },
+    {
+      name: 'Ingress',
+      collapsible: true,
+      gateField: 'ingress.enabled',
+      fields: [
+        {
+          label: 'Hostname',
+          key: 'ingress.hostname',
+          type: 'text',
+          default: 'answer.example.com',
+          description: 'Ingress hostname',
+        },
+        {
+          label: 'Ingress Class',
+          key: 'ingress.ingressClassName',
+          type: 'select',
+          default: 'traefik',
+          options: ['traefik', 'nginx'],
+          description: 'Ingress controller class',
+        },
+        { label: 'TLS', key: 'ingress.tls', type: 'toggle', default: 'false', description: 'Enable TLS' },
+      ],
+    },
+    {
+      name: 'S3 Backup',
+      collapsible: true,
+      gateField: 'backup.enabled',
+      fields: [
+        {
+          label: 'Schedule',
+          key: 'backup.schedule',
+          type: 'text',
+          default: '0 2 * * *',
+          description: 'Cron schedule for backups',
+        },
+      ],
+    },
+  ],
+  authelia: [
+    {
+      name: 'General',
+      fields: [
+        {
+          label: 'Replica Count',
+          key: 'replicaCount',
+          type: 'number',
+          default: '1',
+          description: 'Number of replicas',
+        },
+        {
+          label: 'Storage Size',
+          key: 'persistence.size',
+          type: 'text',
+          default: '1Gi',
+          description: 'Data storage size',
+        },
+      ],
+    },
+    {
+      name: 'Resources',
+      collapsible: true,
+      fields: [
+        {
+          label: 'CPU Request',
+          key: 'resources.requests.cpu',
+          type: 'text',
+          default: '100m',
+          description: 'CPU request',
+        },
+        {
+          label: 'Memory Request',
+          key: 'resources.requests.memory',
+          type: 'text',
+          default: '128Mi',
+          description: 'Memory request',
+        },
+        { label: 'CPU Limit', key: 'resources.limits.cpu', type: 'text', default: '500m', description: 'CPU limit' },
+        {
+          label: 'Memory Limit',
+          key: 'resources.limits.memory',
+          type: 'text',
+          default: '256Mi',
+          description: 'Memory limit',
+        },
+      ],
+    },
+    {
+      name: 'Ingress',
+      collapsible: true,
+      gateField: 'ingress.enabled',
+      fields: [
+        {
+          label: 'Hostname',
+          key: 'ingress.hostname',
+          type: 'text',
+          default: 'auth.example.com',
+          description: 'Ingress hostname',
+        },
+        {
+          label: 'Ingress Class',
+          key: 'ingress.ingressClassName',
+          type: 'select',
+          default: 'traefik',
+          options: ['traefik', 'nginx'],
+          description: 'Ingress controller class',
+        },
+        { label: 'TLS', key: 'ingress.tls', type: 'toggle', default: 'false', description: 'Enable TLS' },
+      ],
+    },
+    {
+      name: 'S3 Backup',
+      collapsible: true,
+      gateField: 'backup.enabled',
+      fields: [
+        {
+          label: 'Schedule',
+          key: 'backup.schedule',
+          type: 'text',
+          default: '0 2 * * *',
+          description: 'Cron schedule for backups',
+        },
+      ],
+    },
+  ],
+  'ddns-updater': [
+    {
+      name: 'General',
+      fields: [
+        {
+          label: 'Storage Size',
+          key: 'persistence.size',
+          type: 'text',
+          default: '256Mi',
+          description: 'Update history storage',
+        },
+      ],
+    },
+    {
+      name: 'Resources',
+      collapsible: true,
+      fields: [
+        {
+          label: 'CPU Request',
+          key: 'resources.requests.cpu',
+          type: 'text',
+          default: '50m',
+          description: 'CPU request',
+        },
+        {
+          label: 'Memory Request',
+          key: 'resources.requests.memory',
+          type: 'text',
+          default: '32Mi',
+          description: 'Memory request',
+        },
+        { label: 'CPU Limit', key: 'resources.limits.cpu', type: 'text', default: '100m', description: 'CPU limit' },
+        {
+          label: 'Memory Limit',
+          key: 'resources.limits.memory',
+          type: 'text',
+          default: '64Mi',
+          description: 'Memory limit',
+        },
+      ],
+    },
+    {
+      name: 'Ingress',
+      collapsible: true,
+      gateField: 'ingress.enabled',
+      fields: [
+        {
+          label: 'Hostname',
+          key: 'ingress.hostname',
+          type: 'text',
+          default: 'ddns.example.com',
+          description: 'Ingress hostname',
+        },
+        {
+          label: 'Ingress Class',
+          key: 'ingress.ingressClassName',
+          type: 'select',
+          default: 'traefik',
+          options: ['traefik', 'nginx'],
+          description: 'Ingress controller class',
+        },
+      ],
+    },
+  ],
+  docmost: [
+    {
+      name: 'General',
+      fields: [
+        {
+          label: 'Storage Size',
+          key: 'persistence.size',
+          type: 'text',
+          default: '5Gi',
+          description: 'Local storage size',
+        },
+      ],
+    },
+    {
+      name: 'Resources',
+      collapsible: true,
+      fields: [
+        {
+          label: 'CPU Request',
+          key: 'resources.requests.cpu',
+          type: 'text',
+          default: '100m',
+          description: 'CPU request',
+        },
+        {
+          label: 'Memory Request',
+          key: 'resources.requests.memory',
+          type: 'text',
+          default: '256Mi',
+          description: 'Memory request',
+        },
+        { label: 'CPU Limit', key: 'resources.limits.cpu', type: 'text', default: '500m', description: 'CPU limit' },
+        {
+          label: 'Memory Limit',
+          key: 'resources.limits.memory',
+          type: 'text',
+          default: '512Mi',
+          description: 'Memory limit',
+        },
+      ],
+    },
+    {
+      name: 'Ingress',
+      collapsible: true,
+      gateField: 'ingress.enabled',
+      fields: [
+        {
+          label: 'Hostname',
+          key: 'ingress.hostname',
+          type: 'text',
+          default: 'docs.example.com',
+          description: 'Ingress hostname',
+        },
+        {
+          label: 'Ingress Class',
+          key: 'ingress.ingressClassName',
+          type: 'select',
+          default: 'traefik',
+          options: ['traefik', 'nginx'],
+          description: 'Ingress controller class',
+        },
+        { label: 'TLS', key: 'ingress.tls', type: 'toggle', default: 'false', description: 'Enable TLS' },
+      ],
+    },
+  ],
+  dolibarr: [
+    {
+      name: 'General',
+      fields: [
+        {
+          label: 'Storage Size',
+          key: 'persistence.size',
+          type: 'text',
+          default: '5Gi',
+          description: 'Documents storage size',
+        },
+      ],
+    },
+    {
+      name: 'Resources',
+      collapsible: true,
+      fields: [
+        {
+          label: 'CPU Request',
+          key: 'resources.requests.cpu',
+          type: 'text',
+          default: '250m',
+          description: 'CPU request',
+        },
+        {
+          label: 'Memory Request',
+          key: 'resources.requests.memory',
+          type: 'text',
+          default: '256Mi',
+          description: 'Memory request',
+        },
+        { label: 'CPU Limit', key: 'resources.limits.cpu', type: 'text', default: '1000m', description: 'CPU limit' },
+        {
+          label: 'Memory Limit',
+          key: 'resources.limits.memory',
+          type: 'text',
+          default: '512Mi',
+          description: 'Memory limit',
+        },
+      ],
+    },
+    {
+      name: 'Ingress',
+      collapsible: true,
+      gateField: 'ingress.enabled',
+      fields: [
+        {
+          label: 'Hostname',
+          key: 'ingress.hostname',
+          type: 'text',
+          default: 'erp.example.com',
+          description: 'Ingress hostname',
+        },
+        {
+          label: 'Ingress Class',
+          key: 'ingress.ingressClassName',
+          type: 'select',
+          default: 'traefik',
+          options: ['traefik', 'nginx'],
+          description: 'Ingress controller class',
+        },
+        { label: 'TLS', key: 'ingress.tls', type: 'toggle', default: 'false', description: 'Enable TLS' },
+      ],
+    },
+  ],
+  guacamole: [
+    {
+      name: 'General',
+      fields: [
+        {
+          label: 'Replica Count',
+          key: 'replicaCount',
+          type: 'number',
+          default: '1',
+          description: 'Number of replicas',
+        },
+      ],
+    },
+    {
+      name: 'Resources',
+      collapsible: true,
+      fields: [
+        {
+          label: 'CPU Request',
+          key: 'resources.requests.cpu',
+          type: 'text',
+          default: '250m',
+          description: 'CPU request',
+        },
+        {
+          label: 'Memory Request',
+          key: 'resources.requests.memory',
+          type: 'text',
+          default: '256Mi',
+          description: 'Memory request',
+        },
+        { label: 'CPU Limit', key: 'resources.limits.cpu', type: 'text', default: '1000m', description: 'CPU limit' },
+        {
+          label: 'Memory Limit',
+          key: 'resources.limits.memory',
+          type: 'text',
+          default: '512Mi',
+          description: 'Memory limit',
+        },
+      ],
+    },
+    {
+      name: 'Ingress',
+      collapsible: true,
+      gateField: 'ingress.enabled',
+      fields: [
+        {
+          label: 'Hostname',
+          key: 'ingress.hostname',
+          type: 'text',
+          default: 'remote.example.com',
+          description: 'Ingress hostname',
+        },
+        {
+          label: 'Ingress Class',
+          key: 'ingress.ingressClassName',
+          type: 'select',
+          default: 'traefik',
+          options: ['traefik', 'nginx'],
+          description: 'Ingress controller class',
+        },
+        { label: 'TLS', key: 'ingress.tls', type: 'toggle', default: 'false', description: 'Enable TLS' },
+      ],
+    },
+    {
+      name: 'S3 Backup',
+      collapsible: true,
+      gateField: 'backup.enabled',
+      fields: [
+        {
+          label: 'Schedule',
+          key: 'backup.schedule',
+          type: 'text',
+          default: '0 2 * * *',
+          description: 'Cron schedule for backups',
+        },
+      ],
+    },
+  ],
+  heimdall: [
+    {
+      name: 'General',
+      fields: [
+        {
+          label: 'Storage Size',
+          key: 'persistence.size',
+          type: 'text',
+          default: '1Gi',
+          description: 'Config storage size',
+        },
+      ],
+    },
+    {
+      name: 'Resources',
+      collapsible: true,
+      fields: [
+        {
+          label: 'CPU Request',
+          key: 'resources.requests.cpu',
+          type: 'text',
+          default: '50m',
+          description: 'CPU request',
+        },
+        {
+          label: 'Memory Request',
+          key: 'resources.requests.memory',
+          type: 'text',
+          default: '64Mi',
+          description: 'Memory request',
+        },
+        { label: 'CPU Limit', key: 'resources.limits.cpu', type: 'text', default: '250m', description: 'CPU limit' },
+        {
+          label: 'Memory Limit',
+          key: 'resources.limits.memory',
+          type: 'text',
+          default: '128Mi',
+          description: 'Memory limit',
+        },
+      ],
+    },
+    {
+      name: 'Ingress',
+      collapsible: true,
+      gateField: 'ingress.enabled',
+      fields: [
+        {
+          label: 'Hostname',
+          key: 'ingress.hostname',
+          type: 'text',
+          default: 'dash.example.com',
+          description: 'Ingress hostname',
+        },
+        {
+          label: 'Ingress Class',
+          key: 'ingress.ingressClassName',
+          type: 'select',
+          default: 'traefik',
+          options: ['traefik', 'nginx'],
+          description: 'Ingress controller class',
+        },
+        { label: 'TLS', key: 'ingress.tls', type: 'toggle', default: 'false', description: 'Enable TLS' },
+      ],
+    },
+    {
+      name: 'S3 Backup',
+      collapsible: true,
+      gateField: 'backup.enabled',
+      fields: [
+        {
+          label: 'Schedule',
+          key: 'backup.schedule',
+          type: 'text',
+          default: '0 2 * * *',
+          description: 'Cron schedule for backups',
+        },
+      ],
+    },
+  ],
+  homarr: [
+    {
+      name: 'General',
+      fields: [
+        {
+          label: 'Storage Size',
+          key: 'persistence.size',
+          type: 'text',
+          default: '2Gi',
+          description: 'App data storage size',
+        },
+      ],
+    },
+    {
+      name: 'Resources',
+      collapsible: true,
+      fields: [
+        {
+          label: 'CPU Request',
+          key: 'resources.requests.cpu',
+          type: 'text',
+          default: '100m',
+          description: 'CPU request',
+        },
+        {
+          label: 'Memory Request',
+          key: 'resources.requests.memory',
+          type: 'text',
+          default: '128Mi',
+          description: 'Memory request',
+        },
+        { label: 'CPU Limit', key: 'resources.limits.cpu', type: 'text', default: '500m', description: 'CPU limit' },
+        {
+          label: 'Memory Limit',
+          key: 'resources.limits.memory',
+          type: 'text',
+          default: '256Mi',
+          description: 'Memory limit',
+        },
+      ],
+    },
+    {
+      name: 'Ingress',
+      collapsible: true,
+      gateField: 'ingress.enabled',
+      fields: [
+        {
+          label: 'Hostname',
+          key: 'ingress.hostname',
+          type: 'text',
+          default: 'home.example.com',
+          description: 'Ingress hostname',
+        },
+        {
+          label: 'Ingress Class',
+          key: 'ingress.ingressClassName',
+          type: 'select',
+          default: 'traefik',
+          options: ['traefik', 'nginx'],
+          description: 'Ingress controller class',
+        },
+        { label: 'TLS', key: 'ingress.tls', type: 'toggle', default: 'false', description: 'Enable TLS' },
+      ],
+    },
+    {
+      name: 'S3 Backup',
+      collapsible: true,
+      gateField: 'backup.enabled',
+      fields: [
+        {
+          label: 'Schedule',
+          key: 'backup.schedule',
+          type: 'text',
+          default: '0 2 * * *',
+          description: 'Cron schedule for backups',
+        },
+      ],
+    },
+  ],
+  kafka: [
+    {
+      name: 'General',
+      fields: [
+        {
+          label: 'Architecture',
+          key: 'architecture',
+          type: 'select',
+          default: 'single-broker',
+          options: ['single-broker', 'cluster'],
+          description: 'Deployment architecture',
+        },
+        {
+          label: 'Storage Size',
+          key: 'persistence.size',
+          type: 'text',
+          default: '8Gi',
+          description: 'Broker storage size',
+        },
+      ],
+    },
+    {
+      name: 'Resources',
+      collapsible: true,
+      fields: [
+        {
+          label: 'CPU Request',
+          key: 'resources.requests.cpu',
+          type: 'text',
+          default: '500m',
+          description: 'CPU request',
+        },
+        {
+          label: 'Memory Request',
+          key: 'resources.requests.memory',
+          type: 'text',
+          default: '512Mi',
+          description: 'Memory request',
+        },
+        { label: 'CPU Limit', key: 'resources.limits.cpu', type: 'text', default: '2000m', description: 'CPU limit' },
+        {
+          label: 'Memory Limit',
+          key: 'resources.limits.memory',
+          type: 'text',
+          default: '1Gi',
+          description: 'Memory limit',
+        },
+      ],
+    },
+  ],
+  komga: [
+    {
+      name: 'General',
+      fields: [
+        {
+          label: 'Storage Size',
+          key: 'persistence.size',
+          type: 'text',
+          default: '5Gi',
+          description: 'Config storage size',
+        },
+      ],
+    },
+    {
+      name: 'Resources',
+      collapsible: true,
+      fields: [
+        {
+          label: 'CPU Request',
+          key: 'resources.requests.cpu',
+          type: 'text',
+          default: '100m',
+          description: 'CPU request',
+        },
+        {
+          label: 'Memory Request',
+          key: 'resources.requests.memory',
+          type: 'text',
+          default: '256Mi',
+          description: 'Memory request',
+        },
+        { label: 'CPU Limit', key: 'resources.limits.cpu', type: 'text', default: '500m', description: 'CPU limit' },
+        {
+          label: 'Memory Limit',
+          key: 'resources.limits.memory',
+          type: 'text',
+          default: '512Mi',
+          description: 'Memory limit',
+        },
+      ],
+    },
+    {
+      name: 'Ingress',
+      collapsible: true,
+      gateField: 'ingress.enabled',
+      fields: [
+        {
+          label: 'Hostname',
+          key: 'ingress.hostname',
+          type: 'text',
+          default: 'komga.example.com',
+          description: 'Ingress hostname',
+        },
+        {
+          label: 'Ingress Class',
+          key: 'ingress.ingressClassName',
+          type: 'select',
+          default: 'traefik',
+          options: ['traefik', 'nginx'],
+          description: 'Ingress controller class',
+        },
+        { label: 'TLS', key: 'ingress.tls', type: 'toggle', default: 'false', description: 'Enable TLS' },
+      ],
+    },
+    {
+      name: 'S3 Backup',
+      collapsible: true,
+      gateField: 'backup.enabled',
+      fields: [
+        {
+          label: 'Schedule',
+          key: 'backup.schedule',
+          type: 'text',
+          default: '0 2 * * *',
+          description: 'Cron schedule for backups',
+        },
+      ],
+    },
+  ],
+  mariadb: [
+    {
+      name: 'General',
+      fields: [
+        {
+          label: 'Architecture',
+          key: 'architecture',
+          type: 'select',
+          default: 'standalone',
+          options: ['standalone', 'replication'],
+          description: 'Deployment architecture',
+        },
+        {
+          label: 'Replica Count',
+          key: 'replicaCount',
+          type: 'number',
+          default: '1',
+          description: 'Number of replicas',
+        },
+        {
+          label: 'Storage Size',
+          key: 'persistence.size',
+          type: 'text',
+          default: '8Gi',
+          description: 'PVC storage size',
+        },
+      ],
+    },
+    {
+      name: 'Resources',
+      collapsible: true,
+      fields: [
+        {
+          label: 'CPU Request',
+          key: 'resources.requests.cpu',
+          type: 'text',
+          default: '250m',
+          description: 'CPU request',
+        },
+        {
+          label: 'Memory Request',
+          key: 'resources.requests.memory',
+          type: 'text',
+          default: '256Mi',
+          description: 'Memory request',
+        },
+        { label: 'CPU Limit', key: 'resources.limits.cpu', type: 'text', default: '1000m', description: 'CPU limit' },
+        {
+          label: 'Memory Limit',
+          key: 'resources.limits.memory',
+          type: 'text',
+          default: '512Mi',
+          description: 'Memory limit',
+        },
+      ],
+    },
+    {
+      name: 'S3 Backup',
+      collapsible: true,
+      gateField: 'backup.enabled',
+      fields: [
+        {
+          label: 'Schedule',
+          key: 'backup.schedule',
+          type: 'text',
+          default: '0 2 * * *',
+          description: 'Cron schedule for backups',
+        },
+        {
+          label: 'S3 Endpoint',
+          key: 'backup.s3.endpoint',
+          type: 'text',
+          default: 's3.amazonaws.com',
+          description: 'S3-compatible endpoint',
+        },
+        {
+          label: 'S3 Bucket',
+          key: 'backup.s3.bucket',
+          type: 'text',
+          default: 'my-backups',
+          description: 'Bucket name',
+        },
+      ],
+    },
+  ],
+  minecraft: [
+    {
+      name: 'General',
+      fields: [
+        {
+          label: 'Server Type',
+          key: 'server.type',
+          type: 'select',
+          default: 'VANILLA',
+          options: ['VANILLA', 'PAPER', 'FORGE', 'FABRIC'],
+          description: 'Minecraft server type',
+        },
+        {
+          label: 'Storage Size',
+          key: 'persistence.size',
+          type: 'text',
+          default: '10Gi',
+          description: 'World data storage size',
+        },
+      ],
+    },
+    {
+      name: 'Resources',
+      collapsible: true,
+      fields: [
+        {
+          label: 'CPU Request',
+          key: 'resources.requests.cpu',
+          type: 'text',
+          default: '500m',
+          description: 'CPU request',
+        },
+        {
+          label: 'Memory Request',
+          key: 'resources.requests.memory',
+          type: 'text',
+          default: '1Gi',
+          description: 'Memory request',
+        },
+        { label: 'CPU Limit', key: 'resources.limits.cpu', type: 'text', default: '2000m', description: 'CPU limit' },
+        {
+          label: 'Memory Limit',
+          key: 'resources.limits.memory',
+          type: 'text',
+          default: '2Gi',
+          description: 'Memory limit',
+        },
+      ],
+    },
+    {
+      name: 'S3 Backup',
+      collapsible: true,
+      gateField: 'backup.enabled',
+      fields: [
+        {
+          label: 'Schedule',
+          key: 'backup.schedule',
+          type: 'text',
+          default: '0 4 * * *',
+          description: 'Cron schedule for backups',
+        },
+      ],
+    },
+  ],
+  mosquitto: [
+    {
+      name: 'General',
+      fields: [
+        {
+          label: 'Architecture',
+          key: 'architecture',
+          type: 'select',
+          default: 'standalone',
+          options: ['standalone', 'federated'],
+          description: 'Deployment architecture',
+        },
+        {
+          label: 'Storage Size',
+          key: 'persistence.size',
+          type: 'text',
+          default: '1Gi',
+          description: 'PVC storage size',
+        },
+      ],
+    },
+    {
+      name: 'Resources',
+      collapsible: true,
+      fields: [
+        {
+          label: 'CPU Request',
+          key: 'resources.requests.cpu',
+          type: 'text',
+          default: '50m',
+          description: 'CPU request',
+        },
+        {
+          label: 'Memory Request',
+          key: 'resources.requests.memory',
+          type: 'text',
+          default: '32Mi',
+          description: 'Memory request',
+        },
+        { label: 'CPU Limit', key: 'resources.limits.cpu', type: 'text', default: '200m', description: 'CPU limit' },
+        {
+          label: 'Memory Limit',
+          key: 'resources.limits.memory',
+          type: 'text',
+          default: '64Mi',
+          description: 'Memory limit',
+        },
+      ],
+    },
+  ],
+  phpmyadmin: [
+    {
+      name: 'General',
+      fields: [
+        {
+          label: 'Replica Count',
+          key: 'replicaCount',
+          type: 'number',
+          default: '1',
+          description: 'Number of replicas',
+        },
+        {
+          label: 'DB Host',
+          key: 'phpmyadmin.host',
+          type: 'text',
+          default: '',
+          description: 'MySQL/MariaDB hostname',
+        },
+      ],
+    },
+    {
+      name: 'Resources',
+      collapsible: true,
+      fields: [
+        {
+          label: 'CPU Request',
+          key: 'resources.requests.cpu',
+          type: 'text',
+          default: '50m',
+          description: 'CPU request',
+        },
+        {
+          label: 'Memory Request',
+          key: 'resources.requests.memory',
+          type: 'text',
+          default: '64Mi',
+          description: 'Memory request',
+        },
+        { label: 'CPU Limit', key: 'resources.limits.cpu', type: 'text', default: '250m', description: 'CPU limit' },
+        {
+          label: 'Memory Limit',
+          key: 'resources.limits.memory',
+          type: 'text',
+          default: '128Mi',
+          description: 'Memory limit',
+        },
+      ],
+    },
+    {
+      name: 'Ingress',
+      collapsible: true,
+      gateField: 'ingress.enabled',
+      fields: [
+        {
+          label: 'Hostname',
+          key: 'ingress.hostname',
+          type: 'text',
+          default: 'pma.example.com',
+          description: 'Ingress hostname',
+        },
+        {
+          label: 'Ingress Class',
+          key: 'ingress.ingressClassName',
+          type: 'select',
+          default: 'traefik',
+          options: ['traefik', 'nginx'],
+          description: 'Ingress controller class',
+        },
+        { label: 'TLS', key: 'ingress.tls', type: 'toggle', default: 'false', description: 'Enable TLS' },
+      ],
+    },
+  ],
+  rabbitmq: [
+    {
+      name: 'General',
+      fields: [
+        {
+          label: 'Architecture',
+          key: 'architecture',
+          type: 'select',
+          default: 'single-node',
+          options: ['single-node', 'cluster'],
+          description: 'Deployment architecture',
+        },
+        {
+          label: 'Replica Count',
+          key: 'replicaCount',
+          type: 'number',
+          default: '1',
+          description: 'Number of replicas',
+        },
+        {
+          label: 'Storage Size',
+          key: 'persistence.size',
+          type: 'text',
+          default: '8Gi',
+          description: 'PVC storage size',
+        },
+      ],
+    },
+    {
+      name: 'Resources',
+      collapsible: true,
+      fields: [
+        {
+          label: 'CPU Request',
+          key: 'resources.requests.cpu',
+          type: 'text',
+          default: '250m',
+          description: 'CPU request',
+        },
+        {
+          label: 'Memory Request',
+          key: 'resources.requests.memory',
+          type: 'text',
+          default: '256Mi',
+          description: 'Memory request',
+        },
+        { label: 'CPU Limit', key: 'resources.limits.cpu', type: 'text', default: '1000m', description: 'CPU limit' },
+        {
+          label: 'Memory Limit',
+          key: 'resources.limits.memory',
+          type: 'text',
+          default: '512Mi',
+          description: 'Memory limit',
+        },
+      ],
+    },
+  ],
+  strapi: [
+    {
+      name: 'General',
+      fields: [
+        {
+          label: 'Replica Count',
+          key: 'replicaCount',
+          type: 'number',
+          default: '1',
+          description: 'Number of replicas',
+        },
+        {
+          label: 'Storage Size',
+          key: 'persistence.size',
+          type: 'text',
+          default: '5Gi',
+          description: 'Uploads storage size',
+        },
+      ],
+    },
+    {
+      name: 'Resources',
+      collapsible: true,
+      fields: [
+        {
+          label: 'CPU Request',
+          key: 'resources.requests.cpu',
+          type: 'text',
+          default: '250m',
+          description: 'CPU request',
+        },
+        {
+          label: 'Memory Request',
+          key: 'resources.requests.memory',
+          type: 'text',
+          default: '256Mi',
+          description: 'Memory request',
+        },
+        { label: 'CPU Limit', key: 'resources.limits.cpu', type: 'text', default: '1000m', description: 'CPU limit' },
+        {
+          label: 'Memory Limit',
+          key: 'resources.limits.memory',
+          type: 'text',
+          default: '512Mi',
+          description: 'Memory limit',
+        },
+      ],
+    },
+    {
+      name: 'Ingress',
+      collapsible: true,
+      gateField: 'ingress.enabled',
+      fields: [
+        {
+          label: 'Hostname',
+          key: 'ingress.hostname',
+          type: 'text',
+          default: 'cms.example.com',
+          description: 'Ingress hostname',
+        },
+        {
+          label: 'Ingress Class',
+          key: 'ingress.ingressClassName',
+          type: 'select',
+          default: 'traefik',
+          options: ['traefik', 'nginx'],
+          description: 'Ingress controller class',
+        },
+        { label: 'TLS', key: 'ingress.tls', type: 'toggle', default: 'false', description: 'Enable TLS' },
+      ],
+    },
+    {
+      name: 'S3 Backup',
+      collapsible: true,
+      gateField: 'backup.enabled',
+      fields: [
+        {
+          label: 'Schedule',
+          key: 'backup.schedule',
+          type: 'text',
+          default: '0 2 * * *',
+          description: 'Cron schedule for backups',
+        },
+      ],
+    },
+  ],
+  velero: [
+    {
+      name: 'General',
+      fields: [
+        {
+          label: 'Replica Count',
+          key: 'replicaCount',
+          type: 'number',
+          default: '1',
+          description: 'Number of replicas',
+        },
+      ],
+    },
+    {
+      name: 'Resources',
+      collapsible: true,
+      fields: [
+        {
+          label: 'CPU Request',
+          key: 'resources.requests.cpu',
+          type: 'text',
+          default: '250m',
+          description: 'CPU request',
+        },
+        {
+          label: 'Memory Request',
+          key: 'resources.requests.memory',
+          type: 'text',
+          default: '256Mi',
+          description: 'Memory request',
+        },
+        { label: 'CPU Limit', key: 'resources.limits.cpu', type: 'text', default: '1000m', description: 'CPU limit' },
+        {
+          label: 'Memory Limit',
+          key: 'resources.limits.memory',
+          type: 'text',
+          default: '512Mi',
+          description: 'Memory limit',
+        },
+      ],
+    },
+  ],
   _default: [
     {
       name: 'General',


### PR DESCRIPTION
## Summary
- Add playground configurations for the remaining 18 stable charts
- Every stable chart now has a playground config with proper collapsible sections
- Charts added: adguard-home, answer, authelia, ddns-updater, docmost, dolibarr, guacamole, heimdall, homarr, kafka, komga, mariadb, minecraft, mosquitto, phpmyadmin, rabbitmq, strapi, velero
- Each config includes Resources (collapsible), Ingress where applicable (collapsible with gate), and S3 Backup where supported (collapsible with gate)

## Test plan
- [ ] Select each newly added chart and verify fields render
- [ ] Toggle Resources/Ingress/Backup sections and verify expand/collapse
- [ ] Run `npx playwright test e2e/playground.spec.ts` — all 14 tests pass