### PR TITLE
fix(site): playground resource output on toggle and hero terminal height

### DIFF
--- a/src/components/Hero.astro
+++ b/src/components/Hero.astro
@@ -128,7 +128,7 @@ import { chartCount, stableCount } from '../data/charts';
         </div>
 
         <!-- Terminal Body -->
-        <div class="relative p-5 font-mono text-[13px] leading-[1.7] h-[340px] overflow-hidden text-zinc-300">
+        <div class="relative p-5 font-mono text-[13px] leading-[1.7] h-[400px] overflow-hidden text-zinc-300">
           <!-- Scan-line overlay -->
           <div
             class="absolute inset-0 pointer-events-none opacity-[0.03] bg-[repeating-linear-gradient(0deg,transparent,transparent_1px,rgba(255,255,255,0.1)_1px,rgba(255,255,255,0.1)_2px)]"

--- a/src/pages/playground.astro
+++ b/src/pages/playground.astro
@@ -2778,7 +2778,16 @@ const scenariosJson = JSON.stringify(scenarios);
             <div id="playground-fields" class="hidden">
               <div class="flex items-center justify-between mb-3">
                 <h3 id="playground-chart-title" class="text-lg font-bold text-text-base heading-font"></h3>
-                <a id="playground-docs-link" href="#" class="text-xs text-primary-light hover:underline">View docs</a>
+                <div class="flex items-center gap-3">
+                  <a id="playground-docs-link" href="#" class="text-xs text-primary-light hover:underline">View docs</a>
+                  <a
+                    id="playground-values-link"
+                    href="#"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    class="text-xs text-text-muted hover:text-primary-light hover:underline">Full values.yaml</a
+                  >
+                </div>
               </div>
 
               <!-- Scenario buttons -->

--- a/src/scripts/playground.ts
+++ b/src/scripts/playground.ts
@@ -31,6 +31,7 @@ const fieldsEl = document.getElementById('playground-fields');
 const controlsEl = document.getElementById('playground-controls');
 const titleEl = document.getElementById('playground-chart-title');
 const docsLink = document.getElementById('playground-docs-link') as HTMLAnchorElement | null;
+const valuesLink = document.getElementById('playground-values-link') as HTMLAnchorElement | null;
 const codeEl = document.getElementById('playground-code');
 const copyBtn = document.getElementById('playground-copy') as HTMLButtonElement | null;
 const shareBtn = document.getElementById('playground-share') as HTMLButtonElement | null;
@@ -95,6 +96,7 @@ function selectChart(slug: string, name: string) {
   if (fieldsEl) fieldsEl.classList.remove('hidden');
   if (titleEl) titleEl.textContent = name;
   if (docsLink) docsLink.href = `/docs/charts/${slug}`;
+  if (valuesLink) valuesLink.href = `https://github.com/helmforgedev/charts/blob/main/charts/${slug}/values.yaml`;
   if (deployHint) deployHint.classList.remove('hidden');
 
   // Build scenario buttons
@@ -434,7 +436,12 @@ function getChangedValues(): { key: string; value: string; defaultValue: string 
 
     for (const field of group.fields) {
       const val = currentValues[field.key];
-      if (val !== undefined && val !== field.default && val !== '') {
+      if (group.collapsible && expandedSections.has(group.name)) {
+        // Expanded collapsible sections emit all fields (enabling means user wants these values)
+        if (val !== undefined && val !== '') {
+          changes.push({ key: field.key, value: val, defaultValue: field.default });
+        }
+      } else if (val !== undefined && val !== field.default && val !== '') {
         changes.push({ key: field.key, value: val, defaultValue: field.default });
       }
     }


### PR DESCRIPTION
## Summary

- **Playground fix**: Expanding a collapsible section (Resources, S3 Backup, Ingress) now immediately emits all field values in the output, even if they match defaults. Previously, enabling Resources showed no changes until a value was manually edited.
- **Full values.yaml link**: Added "Full values.yaml" link next to "View docs" in the playground, pointing to the chart's `values.yaml` on GitHub for quick reference.
- **Hero terminal**: Increased terminal body height from 340px to 400px to prevent content clipping — the full animation (commands, outputs, kubectl pods, final message) is now fully visible.

## Test plan

- [x] Playwright E2E: 75 passed (Chromium)
- [x] Build successful
- [ ] CI pipeline passes