### PR TITLE
ci: add daily schedule trigger for deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches: [main]
   workflow_dispatch:
+  schedule:
+    - cron: '0 6 * * *'
 
 jobs:
   deploy:


### PR DESCRIPTION
## Summary

- Adds daily cron rebuild (06:00 UTC) so the changelog page stays up to date with chart releases automatically

## Triggers after merge

| Trigger | Latency |
|---------|---------|
| `push` to main | immediate (existing) |
| `workflow_dispatch` | manual (existing) |
| `schedule` (daily 06:00 UTC) | up to 24h (new) |

## Test plan

- [ ] Verify site deploys on push to main (existing behavior unchanged)
- [ ] Verify daily cron triggers deploy (check Actions tab next day)