### PR TITLE
feat(open-webui): promote maturity from alpha to stable

### DIFF
--- a/src/data/charts.ts
+++ b/src/data/charts.ts
@@ -338,7 +338,7 @@ export const charts: Chart[] = [
     name: 'Open WebUI',
     slug: 'open-webui',
     description: 'Self-hosted AI chat platform with Ollama/OpenAI, RAG, PostgreSQL, and Redis.',
-    maturity: 'alpha',
+    maturity: 'stable',
     backup: true,
   },
 ];

--- a/src/data/navigation.ts
+++ b/src/data/navigation.ts
@@ -71,7 +71,7 @@ export const chartCategories: ChartCategory[] = [
     charts: [
       { label: 'n8n', href: '/docs/charts/n8n', maturity: 'stable' },
       { label: 'Flowise', href: '/docs/charts/flowise', maturity: 'stable' },
-      { label: 'Open WebUI', href: '/docs/charts/open-webui', maturity: 'alpha' },
+      { label: 'Open WebUI', href: '/docs/charts/open-webui', maturity: 'stable' },
     ],
   },
   {


### PR DESCRIPTION
## Summary

- Updates open-webui maturity from `alpha` to `stable` in charts data and navigation

## Companion PR

- helmforgedev/charts#17

## Test plan

- [ ] Chart card shows stable badge on landing page
- [ ] Sidebar shows stable maturity for Open WebUI