### PR TITLE
fix(roadmap): mark growth phase as completed

### DIFF
--- a/src/pages/roadmap.astro
+++ b/src/pages/roadmap.astro
@@ -61,11 +61,11 @@ const staticRoadmap = [
   },
   {
     phase: 'Growth',
-    status: 'active' as const,
+    status: 'done' as const,
     items: [
       { text: 'Application charts (n8n, Keycloak, Gitea, WordPress, Appwrite, etc.)', done: true },
       { text: 'Networking charts (Pi-hole, Cloudflared, Uptime Kuma)', done: true },
-      { text: 'AI/ML charts (Flowise, Open WebUI)', done: false },
+      { text: 'AI/ML charts (Flowise, Open WebUI)', done: true },
       { text: 'Chart maturity promotion pipeline', done: true },
       { text: 'Website with docs, playground, and stack builder', done: true },
     ],


### PR DESCRIPTION
## Summary
- Mark AI/ML charts item (Flowise, Open WebUI) as done — both are now stable
- Change Growth phase status from `active` to `done`

## Test plan
- [ ] Verify roadmap page renders Growth phase with "Completed" badge
- [ ] Verify all Growth items show green checkmarks