### PR TITLE
fix(blog): remove ad placeholder and keep official references

### DIFF
--- a/e2e/blog.spec.ts
+++ b/e2e/blog.spec.ts
@@ -67,12 +67,6 @@ test.describe('Blog', () => {
     await expect(authorCard.locator('a[aria-label*="LinkedIn"]')).toBeVisible();
   });
 
-  test('blog post renders right rail ad placeholder', async ({ page }) => {
-    await page.goto('/blog/kubernetes-1-34-image-short-names');
-
-    await expect(page.locator('text=Ad slot placeholder for future sponsorship placements.')).toBeVisible();
-  });
-
   test('blog post exposes Person author in structured data', async ({ page }) => {
     await page.goto('/blog/kubernetes-1-34-image-short-names');
 

--- a/src/content/blog/kubernetes-1-34-image-short-names.mdx
+++ b/src/content/blog/kubernetes-1-34-image-short-names.mdx
@@ -18,12 +18,6 @@ The breaking behavior is linked to CRI-O 1.34 image resolution behavior, not a n
 
 In CRI-O `v1.34.0` (released on September 10, 2025), release notes include a change to enforce short-name resolution ambiguity checks (`#9401`). In plain terms: image references like `nginx:1.27` can fail when the runtime cannot safely decide which registry to use.
 
-That lines up with field incidents:
-
-- Replicated community report for Kubernetes 1.34 clusters.
-- Broadcom KB for Kubernetes 1.34 + CRI-O environments.
-- Grafana chart issue reports from users hitting the same class of error.
-
 ![Before and after Kubernetes 1.34 upgrade showing short image names failing after runtime enforcement.](/blog/2026-04-03-kubernetes-1-34-short-name-resolution-flow.webp)
 
 _Visual summary: short names that resolved before can fail after runtime enforcement, which is why pre-upgrade remediation is critical._
@@ -99,9 +93,6 @@ All HelmForge charts are already aligned with the corrected pattern: image repos
 
 ## References
 
-- [Replicated: breaking change write-up](https://www.replicated.com/blog/breaking-change-kubernetes-1-34-tightens-image-name-resolution-rules----what-it-means-for-you)
-- [Broadcom KB 423187](https://knowledge.broadcom.com/external/article/423187/short-name-mode-is-enforcing-but-image.html)
-- [Grafana Helm issue #3923](https://github.com/grafana/helm-charts/issues/3923)
 - [Kubernetes docs: Images](https://kubernetes.io/docs/concepts/containers/images/)
 - [CRI-O v1.34.0 release notes](https://github.com/cri-o/cri-o/releases/tag/v1.34.0)
 - [CRI-O PR #9401](https://github.com/cri-o/cri-o/pull/9401)

--- a/src/layouts/BlogLayout.astro
+++ b/src/layouts/BlogLayout.astro
@@ -143,11 +143,6 @@ const articleJsonLd = {
           </section>
 
           <section class="glass-panel rounded-2xl p-5">
-            <p class="text-xs uppercase tracking-wider text-text-muted mb-2">Reserved</p>
-            <p class="text-sm text-text-muted">Ad slot placeholder for future sponsorship placements.</p>
-          </section>
-
-          <section class="glass-panel rounded-2xl p-5">
             <p class="text-xs uppercase tracking-wider text-text-muted mb-2">Share</p>
             <div class="flex items-center gap-3">
               <a


### PR DESCRIPTION
## Summary
- remove the right-rail ad placeholder block from blog post layout
- remove ad placeholder assertion from blog e2e tests
- keep Kubernetes 1.34 short-name post references limited to official sources only

## Validation
- [x] npm run lint
- [x] npm run build

## Context
- follow-up fix after previous blog PR merge