### PR TITLE
feat(blog): integrate newsletter page and subscription CTAs

### DIFF
--- a/e2e/blog.spec.ts
+++ b/e2e/blog.spec.ts
@@ -8,12 +8,20 @@ test.describe('Blog', () => {
     expect(await cards.count()).toBeGreaterThanOrEqual(3);
   });
 
-  test('blog index has rss subscribe and follow-author cta', async ({ page }) => {
+  test('blog index has newsletter and rss subscribe ctas', async ({ page }) => {
     await page.goto('/blog');
+
+    const newsletter = page.locator('a[aria-label="Open newsletter page"]').first();
+    await expect(newsletter).toBeVisible();
+    await expect(newsletter).toHaveAttribute('href', '/newsletter');
 
     const subscribe = page.locator('a[aria-label="Subscribe via RSS"]').first();
     await expect(subscribe).toBeVisible();
     await expect(subscribe).toHaveAttribute('href', '/rss.xml');
+  });
+
+  test('blog index has follow-author cta', async ({ page }) => {
+    await page.goto('/blog');
 
     await expect(page.locator('a[aria-label="Follow Maicon Berlofa on GitHub"]')).toBeVisible();
     await expect(page.locator('a[aria-label="Follow Maicon Berlofa on LinkedIn"]')).toBeVisible();
@@ -88,12 +96,32 @@ test.describe('Blog', () => {
     await expect(authorCard.locator('a[aria-label*="LinkedIn"]')).toBeVisible();
   });
 
-  test('blog post has rss subscribe cta in sidebar', async ({ page }) => {
+  test('blog post has newsletter and rss subscribe cta in sidebar', async ({ page }) => {
     await page.goto('/blog/kubernetes-1-34-image-short-names');
 
-    const subscribeSection = page.locator('aside section').filter({ hasText: 'Subscribe via RSS' }).first();
+    const subscribeSection = page.locator('aside section').filter({ hasText: 'Newsletter and RSS' }).first();
     await expect(subscribeSection).toBeVisible();
+    await expect(subscribeSection.locator('a[aria-label="Open newsletter page"]')).toHaveAttribute('href', '/newsletter');
     await expect(subscribeSection.locator('a[aria-label="Subscribe via RSS"]')).toHaveAttribute('href', '/rss.xml');
+  });
+
+  test('blog post has end-of-article newsletter cta', async ({ page }) => {
+    await page.goto('/blog/kubernetes-1-34-image-short-names');
+
+    const ctaSection = page.locator('article section').filter({ hasText: 'Get the next post in your inbox' }).first();
+    await expect(ctaSection).toBeVisible();
+    await expect(ctaSection.locator('a[aria-label="Open newsletter page"]')).toHaveAttribute('href', '/newsletter');
+    await expect(ctaSection.locator('a[aria-label="Subscribe via RSS"]')).toHaveAttribute('href', '/rss.xml');
+  });
+
+  test('newsletter page is reachable and links to listmonk form', async ({ page }) => {
+    await page.goto('/newsletter');
+    await expect(page).toHaveTitle(/Newsletter/i);
+    await expect(page.locator('h1')).toContainText('Stay ahead');
+
+    const formLink = page.locator('a[aria-label="Open HelmForge newsletter subscription form"]');
+    await expect(formLink).toBeVisible();
+    await expect(formLink).toHaveAttribute('href', 'https://newsletter.helmforge.dev/subscription/form');
   });
 
   test('blog post exposes Person author in structured data', async ({ page }) => {

--- a/src/layouts/BlogLayout.astro
+++ b/src/layouts/BlogLayout.astro
@@ -99,6 +99,33 @@ const articleJsonLd = {
           <div class="prose prose-docs max-w-none">
             <slot />
           </div>
+
+          <section class="mt-8 rounded-xl border border-primary/20 bg-primary/5 p-5 sm:p-6 not-prose">
+            <p class="text-xs uppercase tracking-wider text-text-muted mb-2">Newsletter</p>
+            <h2 class="text-xl font-bold text-text-base heading-font">Get the next post in your inbox</h2>
+            <p class="mt-2 text-sm text-text-muted leading-relaxed">
+              Join the HelmForge newsletter for Kubernetes insights, chart updates, and practical operations tips.
+            </p>
+            <div class="mt-4 flex flex-wrap gap-3">
+              <a
+                href="/newsletter"
+                class="inline-flex items-center gap-2 rounded-lg border border-primary/40 bg-primary/10 px-4 py-2 text-sm font-semibold text-primary-light hover:bg-primary/20 transition-colors"
+                aria-label="Open newsletter page"
+              >
+                Subscribe to Newsletter
+                <svg class="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7"></path>
+                </svg>
+              </a>
+              <a
+                href="/rss.xml"
+                class="inline-flex items-center gap-2 rounded-lg border border-border px-4 py-2 text-sm font-semibold text-text-base hover:border-primary/40 hover:text-primary-light transition-colors"
+                aria-label="Subscribe via RSS"
+              >
+                Subscribe via RSS
+              </a>
+            </div>
+          </section>
         </article>
       </div>
 
@@ -171,11 +198,21 @@ const articleJsonLd = {
 
           <section class="glass-panel rounded-2xl p-5">
             <p class="text-xs uppercase tracking-wider text-text-muted mb-2">Subscribe</p>
-            <p class="text-lg font-semibold text-text-base">Subscribe via RSS</p>
-            <p class="text-sm text-text-muted mt-1">Receive every new HelmForge blog post in your feed reader.</p>
+            <p class="text-lg font-semibold text-text-base">Newsletter and RSS</p>
+            <p class="text-sm text-text-muted mt-1">Subscribe for inbox updates or follow every post in your feed reader.</p>
+            <a
+              href="/newsletter"
+              class="mt-4 inline-flex items-center gap-2 rounded-lg border border-primary/40 bg-primary/10 px-3 py-2 text-sm font-semibold text-primary-light hover:bg-primary/20 transition-colors"
+              aria-label="Open newsletter page"
+            >
+              Subscribe to Newsletter
+              <svg class="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7"></path>
+              </svg>
+            </a>
             <a
               href="/rss.xml"
-              class="mt-4 inline-flex items-center gap-2 rounded-lg border border-primary/40 bg-primary/10 px-3 py-2 text-sm font-semibold text-primary-light hover:bg-primary/20 transition-colors"
+              class="mt-3 inline-flex items-center gap-2 rounded-lg border border-border px-3 py-2 text-sm font-semibold text-text-base hover:border-primary/40 hover:text-primary-light transition-colors"
               aria-label="Subscribe via RSS"
             >
               Subscribe via RSS

--- a/src/layouts/BlogLayout.astro
+++ b/src/layouts/BlogLayout.astro
@@ -199,7 +199,9 @@ const articleJsonLd = {
           <section class="glass-panel rounded-2xl p-5">
             <p class="text-xs uppercase tracking-wider text-text-muted mb-2">Subscribe</p>
             <p class="text-lg font-semibold text-text-base">Newsletter and RSS</p>
-            <p class="text-sm text-text-muted mt-1">Subscribe for inbox updates or follow every post in your feed reader.</p>
+            <p class="text-sm text-text-muted mt-1">
+              Subscribe for inbox updates or follow every post in your feed reader.
+            </p>
             <a
               href="/newsletter"
               class="mt-4 inline-flex items-center gap-2 rounded-lg border border-primary/40 bg-primary/10 px-3 py-2 text-sm font-semibold text-primary-light hover:bg-primary/20 transition-colors"

--- a/src/pages/blog/index.astro
+++ b/src/pages/blog/index.astro
@@ -27,11 +27,22 @@ const getAuthorName = (authorId: string) => (AUTHORS[authorId] ?? AUTHORS[DEFAUL
             <p class="text-xs uppercase tracking-wider text-text-muted mb-2">Subscribe</p>
             <h2 class="text-xl font-bold text-text-base heading-font">Never miss a new post</h2>
             <p class="mt-2 text-sm text-text-muted leading-relaxed">
-              Follow HelmForge updates directly in your reader through the official RSS feed.
+              Subscribe to the HelmForge newsletter and receive release notes, tutorials, and practical Kubernetes
+              updates.
             </p>
             <a
-              href="/rss.xml"
+              href="/newsletter"
               class="mt-4 inline-flex items-center gap-2 rounded-lg border border-primary/40 bg-primary/10 px-4 py-2 text-sm font-semibold text-primary-light hover:bg-primary/20 transition-colors"
+              aria-label="Open newsletter page"
+            >
+              Subscribe to Newsletter
+              <svg class="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7"></path>
+              </svg>
+            </a>
+            <a
+              href="/rss.xml"
+              class="mt-3 inline-flex items-center gap-2 rounded-lg border border-border px-4 py-2 text-sm font-semibold text-text-base hover:border-primary/40 hover:text-primary-light transition-colors"
               aria-label="Subscribe via RSS"
             >
               Subscribe via RSS

--- a/src/pages/newsletter.astro
+++ b/src/pages/newsletter.astro
@@ -1,0 +1,51 @@
+---
+import BaseLayout from '../layouts/BaseLayout.astro';
+import Header from '../components/Header.astro';
+import Footer from '../components/Footer.astro';
+import Container from '../components/Container.astro';
+---
+
+<BaseLayout
+  title="Newsletter"
+  description="Subscribe to the HelmForge newsletter and receive practical Kubernetes and Helm chart updates."
+>
+  <Header />
+  <main id="main-content" class="py-16 sm:py-20" data-pagefind-body>
+    <Container>
+      <section class="mx-auto max-w-3xl glass-panel rounded-2xl p-6 sm:p-8 lg:p-10">
+        <p class="text-xs uppercase tracking-wider text-text-muted mb-3">HelmForge Newsletter</p>
+        <h1 class="text-3xl sm:text-4xl font-bold tracking-tight text-text-base heading-font">
+          Stay ahead with practical Kubernetes updates
+        </h1>
+        <p class="mt-4 text-base text-text-muted leading-relaxed">
+          Receive curated Helm and Kubernetes content, new chart releases, and production tips from HelmForge.
+        </p>
+
+        <div class="mt-6 flex flex-wrap gap-3">
+          <a
+            href="https://newsletter.helmforge.dev/subscription/form"
+            target="_blank"
+            rel="noopener noreferrer"
+            class="inline-flex items-center gap-2 rounded-lg border border-primary/40 bg-primary/10 px-4 py-2 text-sm font-semibold text-primary-light hover:bg-primary/20 transition-colors"
+            aria-label="Open HelmForge newsletter subscription form"
+          >
+            Subscribe to Newsletter
+          </a>
+          <a
+            href="/rss.xml"
+            class="inline-flex items-center gap-2 rounded-lg border border-border px-4 py-2 text-sm font-semibold text-text-base hover:border-primary/40 hover:text-primary-light transition-colors"
+            aria-label="Subscribe via RSS"
+          >
+            Subscribe via RSS
+          </a>
+        </div>
+
+        <p class="mt-4 text-sm text-text-muted">
+          Prefer feeds? You can follow all posts directly from the RSS endpoint at
+          <a href="/rss.xml" class="text-primary-light hover:underline ml-1">/rss.xml</a>.
+        </p>
+      </section>
+    </Container>
+  </main>
+  <Footer />
+</BaseLayout>


### PR DESCRIPTION
## Summary
- add a dedicated /newsletter page with CTA to the Listmonk subscription form and RSS fallback
- update blog index subscription block to prioritize newsletter subscription and keep RSS as secondary option
- add end-of-article newsletter CTA plus newsletter+RSS sidebar block on blog post layout
- extend Playwright blog tests to validate newsletter links and CTA presence

## Validation
- npm run lint
- npm run build
- npx playwright test e2e/blog.spec.ts --project=chromium