### PR TITLE
feat(blog): embed newsletter form and simplify blog header CTAs

### DIFF
--- a/e2e/blog.spec.ts
+++ b/e2e/blog.spec.ts
@@ -20,11 +20,13 @@ test.describe('Blog', () => {
     await expect(subscribe).toHaveAttribute('href', '/rss.xml');
   });
 
-  test('blog index has follow-author cta', async ({ page }) => {
+  test('blog index keeps subscription actions near header', async ({ page }) => {
     await page.goto('/blog');
 
-    await expect(page.locator('a[aria-label="Follow Maicon Berlofa on GitHub"]')).toBeVisible();
-    await expect(page.locator('a[aria-label="Follow Maicon Berlofa on LinkedIn"]')).toBeVisible();
+    const actions = page.locator('[aria-label="Blog subscription actions"]');
+    await expect(actions).toBeVisible();
+    await expect(actions.locator('a[aria-label="Open newsletter page"]')).toBeVisible();
+    await expect(actions.locator('a[aria-label="Subscribe via RSS"]')).toBeVisible();
   });
 
   test('blog cards expose title, description, author, and date', async ({ page }) => {
@@ -101,7 +103,10 @@ test.describe('Blog', () => {
 
     const subscribeSection = page.locator('aside section').filter({ hasText: 'Newsletter and RSS' }).first();
     await expect(subscribeSection).toBeVisible();
-    await expect(subscribeSection.locator('a[aria-label="Open newsletter page"]')).toHaveAttribute('href', '/newsletter');
+    await expect(subscribeSection.locator('a[aria-label="Open newsletter page"]')).toHaveAttribute(
+      'href',
+      '/newsletter',
+    );
     await expect(subscribeSection.locator('a[aria-label="Subscribe via RSS"]')).toHaveAttribute('href', '/rss.xml');
   });
 
@@ -114,14 +119,21 @@ test.describe('Blog', () => {
     await expect(ctaSection.locator('a[aria-label="Subscribe via RSS"]')).toHaveAttribute('href', '/rss.xml');
   });
 
-  test('newsletter page is reachable and links to listmonk form', async ({ page }) => {
+  test('newsletter page embeds listmonk form', async ({ page }) => {
     await page.goto('/newsletter');
     await expect(page).toHaveTitle(/Newsletter/i);
     await expect(page.locator('h1')).toContainText('Stay ahead');
 
-    const formLink = page.locator('a[aria-label="Open HelmForge newsletter subscription form"]');
-    await expect(formLink).toBeVisible();
-    await expect(formLink).toHaveAttribute('href', 'https://newsletter.helmforge.dev/subscription/form');
+    const form = page.locator('form[aria-label="HelmForge newsletter form"]');
+    await expect(form).toBeVisible();
+    await expect(form).toHaveAttribute('action', 'https://newsletter.helmforge.dev/subscription/form');
+    await expect(form.locator('input[name="email"]')).toBeVisible();
+    await expect(form.locator('input[name="name"]')).toBeVisible();
+    await expect(form.locator('input[name="l"][value="7f91e9db-d5f1-4999-83fd-a908208bd8d5"]')).toBeChecked();
+    await expect(page.locator('altcha-widget')).toHaveAttribute(
+      'challengeurl',
+      'https://newsletter.helmforge.dev/api/public/captcha/altcha',
+    );
   });
 
   test('blog post exposes Person author in structured data', async ({ page }) => {

--- a/src/pages/blog/index.astro
+++ b/src/pages/blog/index.astro
@@ -20,71 +20,32 @@ const getAuthorName = (authorId: string) => (AUTHORS[authorId] ?? AUTHORS[DEFAUL
         title="News, guides, and deep dives."
         description="Tutorials, announcements, and practical Kubernetes insights from the HelmForge team."
       />
-
-      <section class="mt-8 glass-panel rounded-2xl p-6 sm:p-7" aria-label="Blog subscription and author follow">
-        <div class="grid grid-cols-1 md:grid-cols-2 gap-6 items-start">
-          <div>
-            <p class="text-xs uppercase tracking-wider text-text-muted mb-2">Subscribe</p>
-            <h2 class="text-xl font-bold text-text-base heading-font">Never miss a new post</h2>
-            <p class="mt-2 text-sm text-text-muted leading-relaxed">
-              Subscribe to the HelmForge newsletter and receive release notes, tutorials, and practical Kubernetes
-              updates.
-            </p>
-            <a
-              href="/newsletter"
-              class="mt-4 inline-flex items-center gap-2 rounded-lg border border-primary/40 bg-primary/10 px-4 py-2 text-sm font-semibold text-primary-light hover:bg-primary/20 transition-colors"
-              aria-label="Open newsletter page"
-            >
-              Subscribe to Newsletter
-              <svg class="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7"></path>
-              </svg>
-            </a>
-            <a
-              href="/rss.xml"
-              class="mt-3 inline-flex items-center gap-2 rounded-lg border border-border px-4 py-2 text-sm font-semibold text-text-base hover:border-primary/40 hover:text-primary-light transition-colors"
-              aria-label="Subscribe via RSS"
-            >
-              Subscribe via RSS
-              <svg class="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path
-                  stroke-linecap="round"
-                  stroke-linejoin="round"
-                  stroke-width="2"
-                  d="M4 11a9 9 0 019 9m-9-5a5 5 0 015 5m-5-9a13 13 0 0113 13M5 19h.01"></path>
-              </svg>
-            </a>
-          </div>
-
-          <div>
-            <p class="text-xs uppercase tracking-wider text-text-muted mb-2">Follow Author</p>
-            <h2 class="text-xl font-bold text-text-base heading-font">Maicon Berlofa</h2>
-            <p class="mt-2 text-sm text-text-muted leading-relaxed">
-              Follow on GitHub and LinkedIn for release notes, Kubernetes insights, and chart updates.
-            </p>
-            <div class="mt-4 flex flex-wrap gap-3">
-              <a
-                href="https://github.com/mberlofa"
-                target="_blank"
-                rel="noopener noreferrer"
-                class="inline-flex items-center gap-2 rounded-lg border border-border px-4 py-2 text-sm font-semibold text-text-base hover:border-primary/40 hover:text-primary-light transition-colors"
-                aria-label="Follow Maicon Berlofa on GitHub"
-              >
-                GitHub
-              </a>
-              <a
-                href="https://www.linkedin.com/in/berlofa"
-                target="_blank"
-                rel="noopener noreferrer"
-                class="inline-flex items-center gap-2 rounded-lg border border-border px-4 py-2 text-sm font-semibold text-text-base hover:border-primary/40 hover:text-primary-light transition-colors"
-                aria-label="Follow Maicon Berlofa on LinkedIn"
-              >
-                LinkedIn
-              </a>
-            </div>
-          </div>
-        </div>
-      </section>
+      <div class="mt-6 flex flex-wrap items-center gap-3" aria-label="Blog subscription actions">
+        <a
+          href="/newsletter"
+          class="inline-flex items-center gap-2 rounded-lg border border-primary/40 bg-primary/10 px-4 py-2 text-sm font-semibold text-primary-light hover:bg-primary/20 transition-colors"
+          aria-label="Open newsletter page"
+        >
+          Subscribe to Newsletter
+          <svg class="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7"></path>
+          </svg>
+        </a>
+        <a
+          href="/rss.xml"
+          class="inline-flex items-center gap-2 rounded-lg border border-border px-4 py-2 text-sm font-semibold text-text-base hover:border-primary/40 hover:text-primary-light transition-colors"
+          aria-label="Subscribe via RSS"
+        >
+          Subscribe via RSS
+          <svg class="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="2"
+              d="M4 11a9 9 0 019 9m-9-5a5 5 0 015 5m-5-9a13 13 0 0113 13M5 19h.01"></path>
+          </svg>
+        </a>
+      </div>
 
       <div class="mt-12 grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
         {

--- a/src/pages/newsletter.astro
+++ b/src/pages/newsletter.astro
@@ -20,32 +20,78 @@ import Container from '../components/Container.astro';
         <p class="mt-4 text-base text-text-muted leading-relaxed">
           Receive curated Helm and Kubernetes content, new chart releases, and production tips from HelmForge.
         </p>
+        <form
+          method="post"
+          action="https://newsletter.helmforge.dev/subscription/form"
+          class="mt-8 rounded-xl border border-border bg-bg-surface/60 p-5 sm:p-6"
+          aria-label="HelmForge newsletter form"
+        >
+          <input type="hidden" name="nonce" />
 
-        <div class="mt-6 flex flex-wrap gap-3">
-          <a
-            href="https://newsletter.helmforge.dev/subscription/form"
-            target="_blank"
-            rel="noopener noreferrer"
-            class="inline-flex items-center gap-2 rounded-lg border border-primary/40 bg-primary/10 px-4 py-2 text-sm font-semibold text-primary-light hover:bg-primary/20 transition-colors"
-            aria-label="Open HelmForge newsletter subscription form"
-          >
-            Subscribe to Newsletter
-          </a>
-          <a
-            href="/rss.xml"
-            class="inline-flex items-center gap-2 rounded-lg border border-border px-4 py-2 text-sm font-semibold text-text-base hover:border-primary/40 hover:text-primary-light transition-colors"
-            aria-label="Subscribe via RSS"
-          >
-            Subscribe via RSS
-          </a>
-        </div>
+          <label class="block text-sm font-medium text-text-base mb-2" for="newsletter-email">E-mail</label>
+          <input
+            id="newsletter-email"
+            type="email"
+            name="email"
+            required
+            placeholder="you@company.com"
+            class="w-full rounded-lg border border-border bg-bg-base px-3 py-2.5 text-text-base placeholder:text-text-muted/70 focus:outline-none focus:ring-2 focus:ring-primary/40"
+          />
 
-        <p class="mt-4 text-sm text-text-muted">
-          Prefer feeds? You can follow all posts directly from the RSS endpoint at
-          <a href="/rss.xml" class="text-primary-light hover:underline ml-1">/rss.xml</a>.
-        </p>
+          <label class="mt-4 block text-sm font-medium text-text-base mb-2" for="newsletter-name">Name (optional)</label
+          >
+          <input
+            id="newsletter-name"
+            type="text"
+            name="name"
+            placeholder="Your name"
+            class="w-full rounded-lg border border-border bg-bg-base px-3 py-2.5 text-text-base placeholder:text-text-muted/70 focus:outline-none focus:ring-2 focus:ring-primary/40"
+          />
+
+          <div class="mt-5 rounded-lg border border-border bg-bg-base/70 p-4">
+            <div class="flex items-start gap-2">
+              <input
+                id="list-helmforge-newsletter"
+                type="checkbox"
+                name="l"
+                checked
+                value="7f91e9db-d5f1-4999-83fd-a908208bd8d5"
+                class="mt-1 h-4 w-4 rounded border-border text-primary focus:ring-primary/40"
+              />
+              <div>
+                <label for="list-helmforge-newsletter" class="text-sm font-semibold text-text-base">
+                  HelmForge Newsletter
+                </label>
+                <p class="mt-1 text-sm text-text-muted">
+                  Official HelmForge newsletter with Kubernetes insights, chart updates, and release notes.
+                </p>
+              </div>
+            </div>
+          </div>
+
+          <div class="mt-5">
+            <altcha-widget challengeurl="https://newsletter.helmforge.dev/api/public/captcha/altcha"></altcha-widget>
+          </div>
+
+          <div class="mt-5 flex flex-wrap items-center gap-3">
+            <button
+              type="submit"
+              class="inline-flex items-center gap-2 rounded-lg border border-primary/40 bg-primary/10 px-4 py-2 text-sm font-semibold text-primary-light hover:bg-primary/20 transition-colors"
+            >
+              Subscribe
+            </button>
+            <a
+              href="/rss.xml"
+              class="inline-flex items-center gap-2 rounded-lg border border-border px-4 py-2 text-sm font-semibold text-text-base hover:border-primary/40 hover:text-primary-light transition-colors"
+              aria-label="Subscribe via RSS"
+            >
+              Subscribe via RSS
+            </a>
+          </div>
+        </form>
       </section>
     </Container>
   </main>
+  <script type="module" src="https://newsletter.helmforge.dev/public/static/altcha.umd.js" async defer></script>
   <Footer />
 </BaseLayout>


### PR DESCRIPTION
## Summary
- embed the Listmonk form directly on /newsletter (email, name, fixed HelmForge list UUID, ALTCHA challenge)
- simplify /blog top area by removing the large two-column block and keeping only subscribe actions next to the blog header
- update Playwright blog tests for the new header CTA layout and embedded newsletter form assertions

## Validation
- npx prettier --write src/pages/blog/index.astro src/pages/newsletter.astro e2e/blog.spec.ts
- npm run lint
- npm run build
- npx playwright test e2e/blog.spec.ts --project=chromium