### PR TITLE
docs(fastmcp-server): v1.0.0 — Production Grade

### DIFF
--- a/src/pages/docs/charts/fastmcp-server.mdx
+++ b/src/pages/docs/charts/fastmcp-server.mdx
@@ -20,6 +20,13 @@ Helm chart for deploying [FastMCP Server](https://github.com/helmforgedev/fastmc
 - **Multiple resources per file** — `RESOURCES` dict maps multiple URIs to handler functions
 - **Error masking** — hide internal error details from clients via `MCP_MASK_ERROR_DETAILS`
 - **Duplicate handling** — control behavior when tools share names via `MCP_ON_DUPLICATE_TOOLS`
+- **Built-in Web UI** — dashboard at `/ui` with tools/resources/prompts explorer (Alpine.js + Tailwind CDN)
+- **Prometheus metrics** — tool call counts, durations, errors, source sync status at `/metrics`
+- **Structured JSON logging** — `LOG_FORMAT=json` for Loki, ELK, CloudWatch, Datadog
+- **Dedicated health endpoints** — `/healthz` (liveness), `/readyz` (readiness), `/startupz` (startup)
+- **Diagnostic endpoint** — `GET /debug/info` with full server introspection
+- **Init container pattern** — pre-sync sources before server starts via `initSync.enabled`
+- **Strict loading** — `MCP_STRICT_LOADING=true` fails on boot if any tool/resource has errors
 
 ## Installation
 
@@ -112,15 +119,52 @@ auth:
     jwksUri: 'https://auth.example.com/.well-known/jwks.json'
 ```
 
+## Observability
+
+### Prometheus Metrics
+
+```yaml
+metrics:
+  enabled: true
+  serviceMonitor:
+    enabled: true  # requires Prometheus Operator
+    interval: 30s
+```
+
+Metrics exposed at `/metrics`: tool call counts, durations, errors, source sync status, auth attempts.
+
+### Structured Logging
+
+```yaml
+server:
+  logFormat: json  # JSON output for log aggregation
+```
+
+### Health Endpoints
+
+| Endpoint | Type | When 200 |
+|----------|------|----------|
+| `/healthz` | Liveness | Always (process running) |
+| `/readyz` | Readiness | Sources synced + components loaded |
+| `/startupz` | Startup | Full initialization complete |
+
+### Diagnostics
+
+`GET /debug/info` returns server version, FastMCP version, uptime, registered components, source status, auth type, and configuration.
+
 ## Key Values
 
 | Key                        | Default                              | Description                              |
 | -------------------------- | ------------------------------------ | ---------------------------------------- |
 | `image.repository`         | `docker.io/helmforge/fastmcp-server` | Container image                          |
-| `image.tag`                | `0.3.0`                              | Image tag                                |
+| `image.tag`                | `0.4.0`                              | Image tag                                |
 | `server.name`              | `fastmcp-server`                     | Server name in MCP responses             |
 | `server.port`              | `8000`                               | HTTP port                                |
 | `server.path`              | `/mcp`                               | MCP endpoint path                        |
+| `server.logFormat`         | `text`                               | Log format: `text` or `json`             |
+| `server.strictLoading`     | `false`                              | Fail on boot if component errors         |
+| `ui.enabled`               | `true`                               | Enable Web UI at `/ui`                   |
+| `metrics.enabled`          | `false`                              | Enable Prometheus metrics at `/metrics`  |
 | `auth.type`                | `none`                               | Authentication: `none`, `bearer`, `jwt`  |
 | `sources.inline.tools`     | `{}`                                 | Inline Python tool files                 |
 | `sources.inline.knowledge` | `{}`                                 | Inline knowledge base files              |
@@ -129,6 +173,7 @@ auth:
 | `sources.git.enabled`      | `false`                              | Enable Git source                        |
 | `sources.git.repository`   | `""`                                 | Git repository HTTPS URL                 |
 | `extraPipPackages`         | `[]`                                 | Extra pip packages to install at startup |
+| `initSync.enabled`         | `false`                              | Run source sync as init container        |
 | `persistence.enabled`      | `false`                              | Enable persistent workspace volume       |
 | `ingress.enabled`          | `false`                              | Enable ingress                           |
 
@@ -136,11 +181,12 @@ auth:
 
 - Merge precedence is Inline > S3 > Git — if a tool with the same filename exists in multiple sources, the highest-precedence version wins
 - Knowledge base files are served as MCP resources at `knowledge://{filename}` URIs
-- The server health endpoint is at the configured `server.path` (default `/mcp`)
 - Tools are Python files with top-level functions; resources need a `RESOURCE_URI` or `RESOURCES` module-level variable
 - Tools support optional metadata: `__tags__` (set), `__timeout__` (float), `__annotations_mcp__` (dict)
 - Resource URIs can use `{param}` placeholders for dynamic templates
 - The `extraPipPackages` list installs before tools load — use it when tools import external libraries
+- The Web UI auto-refreshes every 15 seconds and requires no external dependencies
+- Init container pattern (`initSync.enabled`) separates source syncing from server startup for better Kubernetes readiness semantics
 
 ## More Information
 

--- a/src/pages/docs/charts/fastmcp-server.mdx
+++ b/src/pages/docs/charts/fastmcp-server.mdx
@@ -27,6 +27,22 @@ Helm chart for deploying [FastMCP Server](https://github.com/helmforgedev/fastmc
 - **Diagnostic endpoint** — `GET /debug/info` with full server introspection
 - **Init container pattern** — pre-sync sources before server starts via `initSync.enabled`
 - **Strict loading** — `MCP_STRICT_LOADING=true` fails on boot if any tool/resource has errors
+- **Hot reload** — automatic tool/resource reload on filesystem changes via `MCP_HOT_RELOAD=true`
+- **Periodic sync** — poll S3/Git sources for changes at configurable intervals
+- **Webhook reload** — `POST /reload` endpoint for CI/CD-triggered reloads
+- **OCI artifact source** — pull tool bundles from OCI registries via ORAS
+- **Selective sync** — include/exclude glob patterns for source filtering
+- **Gateway mode** — compose multiple MCP servers via `MCP_MODE=gateway` and `MCP_MOUNT_SERVERS`
+- **Tag visibility** — enable/disable tools by tags with `MCP_ENABLE_TAGS` and `MCP_DISABLE_TAGS`
+- **Multi-auth** — combine bearer + JWT providers via `MCP_AUTH_PROVIDERS`
+- **Tool-level scopes** — `__required_scopes__` module variable for authorization
+- **Context integration** — tools can use `ctx: Context` for progress, logging, sampling, elicitation, and session state
+- **Rate limiting** — `__rate_limit__` module variable or `MCP_RATE_LIMIT_DEFAULT` env var (sliding window)
+- **Caching** — `__cache_ttl__` module variable for idempotent tool result caching
+- **Tool sandboxing** — `__max_memory_mb__` and `__max_output_size_kb__` resource limits per tool
+- **PodDisruptionBudget** — `pdb.enabled` for zero-downtime rolling updates
+- **HorizontalPodAutoscaler** — `autoscaling.enabled` for auto-scaling based on CPU/memory
+- **Security** — Trivy vulnerability scan, CycloneDX SBOM, Cosign keyless signing, SLSA provenance
 
 ## Installation
 
@@ -152,12 +168,73 @@ server:
 
 `GET /debug/info` returns server version, FastMCP version, uptime, registered components, source status, auth type, and configuration.
 
+## Rate Limiting
+
+```yaml
+rateLimiting:
+  default: "100/min"    # global default
+  perTool:
+    DEPLOY: "5/min"     # per-tool override
+    DELETE_DATA: "2/min"
+```
+
+Or via module-level variable:
+
+```python
+__rate_limit__ = "5/min"
+
+def deploy(service: str, version: str) -> str:
+    """Deploy a service (rate limited)."""
+    return f"Deployed {service}@{version}"
+```
+
+## Caching
+
+```python
+__cache_ttl__ = 300  # cache results for 5 minutes
+
+def get_exchange_rate(currency: str) -> float:
+    """Get current exchange rate (cached 5min)."""
+    ...
+```
+
+```yaml
+caching:
+  enabled: true     # default
+  maxSize: 1000     # max entries per tool
+```
+
+## Tool Sandboxing
+
+```python
+__max_memory_mb__ = 256
+__max_output_size_kb__ = 100
+
+def process_data(data: str) -> str:
+    """Process data with resource limits."""
+    ...
+```
+
+## Autoscaling
+
+```yaml
+autoscaling:
+  enabled: true
+  minReplicas: 2
+  maxReplicas: 10
+  targetCPUUtilizationPercentage: 80
+
+pdb:
+  enabled: true
+  minAvailable: 1
+```
+
 ## Key Values
 
 | Key                        | Default                              | Description                              |
 | -------------------------- | ------------------------------------ | ---------------------------------------- |
 | `image.repository`         | `docker.io/helmforge/fastmcp-server` | Container image                          |
-| `image.tag`                | `0.4.0`                              | Image tag                                |
+| `image.tag`                | `1.0.0`                              | Image tag                                |
 | `server.name`              | `fastmcp-server`                     | Server name in MCP responses             |
 | `server.port`              | `8000`                               | HTTP port                                |
 | `server.path`              | `/mcp`                               | MCP endpoint path                        |
@@ -166,6 +243,10 @@ server:
 | `ui.enabled`               | `true`                               | Enable Web UI at `/ui`                   |
 | `metrics.enabled`          | `false`                              | Enable Prometheus metrics at `/metrics`  |
 | `auth.type`                | `none`                               | Authentication: `none`, `bearer`, `jwt`  |
+| `rateLimiting.default`     | `""`                                 | Default rate limit (e.g., `100/min`)     |
+| `caching.enabled`          | `true`                               | Enable result caching                    |
+| `sandboxing.maxMemoryMb`   | `0`                                  | Default max memory per tool (MB)         |
+| `sandboxing.maxOutputSizeKb` | `0`                                | Default max output per tool (KB)         |
 | `sources.inline.tools`     | `{}`                                 | Inline Python tool files                 |
 | `sources.inline.knowledge` | `{}`                                 | Inline knowledge base files              |
 | `sources.s3.enabled`       | `false`                              | Enable S3 source                         |
@@ -175,6 +256,8 @@ server:
 | `extraPipPackages`         | `[]`                                 | Extra pip packages to install at startup |
 | `initSync.enabled`         | `false`                              | Run source sync as init container        |
 | `persistence.enabled`      | `false`                              | Enable persistent workspace volume       |
+| `autoscaling.enabled`      | `false`                              | Enable HPA                               |
+| `pdb.enabled`              | `false`                              | Enable PodDisruptionBudget               |
 | `ingress.enabled`          | `false`                              | Enable ingress                           |
 
 ## Operational Notes

--- a/src/pages/docs/fastmcp-tools.mdx
+++ b/src/pages/docs/fastmcp-tools.mdx
@@ -1,0 +1,149 @@
+---
+layout: ../../layouts/DocsLayout.astro
+title: FastMCP Tools
+description: Reusable MCP tool catalog for fastmcp-server — Kubernetes, GitHub, HTTP, database, and notification tools ready to deploy.
+---
+
+# FastMCP Tools
+
+A curated collection of reusable MCP tools for [fastmcp-server](/docs/charts/fastmcp-server). Each tool is a standalone Python file ready to deploy via inline ConfigMap, S3, or Git source.
+
+Source: [helmforgedev/fastmcp-tools](https://github.com/helmforgedev/fastmcp-tools)
+
+## Kubernetes
+
+| Tool | Description | Dependencies |
+|------|-------------|-------------|
+| `get_pods` | List pods in a namespace with status and restart counts | `kubernetes` |
+| `get_logs` | Get pod logs with container and tail options | `kubernetes` |
+| `describe_resource` | Get detailed info about pods, services, deployments, configmaps, secrets | `kubernetes` |
+
+```yaml
+sources:
+  git:
+    enabled: true
+    repository: 'https://github.com/helmforgedev/fastmcp-tools.git'
+    branch: main
+    path: tools/kubernetes
+extraPipPackages:
+  - kubernetes
+```
+
+## GitHub
+
+| Tool | Description | Dependencies |
+|------|-------------|-------------|
+| `list_issues` | List issues with state/label filtering (cached 60s) | `requests` |
+| `create_pr` | Create pull requests | `requests` |
+| `get_file` | Get file contents from a repository (cached 120s) | `requests` |
+
+Requires `GITHUB_TOKEN` env var for private repos and write operations.
+
+```yaml
+sources:
+  git:
+    enabled: true
+    repository: 'https://github.com/helmforgedev/fastmcp-tools.git'
+    branch: main
+    path: tools/github
+extraPipPackages:
+  - requests
+extraEnv:
+  - name: GITHUB_TOKEN
+    valueFrom:
+      secretKeyRef:
+        name: github-token
+        key: token
+```
+
+## HTTP
+
+| Tool | Description | Dependencies |
+|------|-------------|-------------|
+| `fetch_url` | Fetch content from any URL (GET/POST/etc) with custom headers | `requests` |
+| `post_json` | POST JSON data to a URL | `requests` |
+
+```yaml
+sources:
+  git:
+    enabled: true
+    repository: 'https://github.com/helmforgedev/fastmcp-tools.git'
+    branch: main
+    path: tools/http
+extraPipPackages:
+  - requests
+```
+
+## Database
+
+| Tool | Description | Dependencies |
+|------|-------------|-------------|
+| `query_postgres` | Execute read-only SQL on PostgreSQL (rate limited 30/min) | `psycopg2-binary` |
+| `query_mysql` | Execute read-only SQL on MySQL (rate limited 30/min) | `pymysql` |
+
+Both tools enforce read-only mode — only `SELECT` and `WITH` queries are allowed.
+
+```yaml
+sources:
+  git:
+    enabled: true
+    repository: 'https://github.com/helmforgedev/fastmcp-tools.git'
+    branch: main
+    path: tools/database
+extraPipPackages:
+  - psycopg2-binary
+  - pymysql
+extraEnv:
+  - name: DATABASE_URL
+    valueFrom:
+      secretKeyRef:
+        name: db-credentials
+        key: url
+```
+
+## Notifications
+
+| Tool | Description | Dependencies |
+|------|-------------|-------------|
+| `send_slack` | Send messages via Slack webhook (rate limited 10/min) | `requests` |
+| `send_email` | Send email via SMTP (rate limited 5/min) | stdlib only |
+
+```yaml
+sources:
+  git:
+    enabled: true
+    repository: 'https://github.com/helmforgedev/fastmcp-tools.git'
+    branch: main
+    path: tools/notifications
+extraPipPackages:
+  - requests
+extraEnv:
+  - name: SLACK_WEBHOOK_URL
+    valueFrom:
+      secretKeyRef:
+        name: slack-config
+        key: webhook-url
+```
+
+## Tool Metadata
+
+All tools use fastmcp-server module-level magic variables for enhanced behavior:
+
+| Variable | Example | Description |
+|----------|---------|-------------|
+| `__tags__` | `["kubernetes", "read"]` | Tool categorization for visibility control |
+| `__timeout__` | `30.0` | Execution timeout in seconds |
+| `__rate_limit__` | `"30/min"` | Rate limiting |
+| `__cache_ttl__` | `60` | Result caching TTL in seconds |
+| `__max_output_size_kb__` | `500` | Output truncation limit |
+
+## Contributing
+
+Tools should follow these conventions:
+
+1. One file per tool function
+2. Clear docstring explaining what the tool does
+3. Type annotations on all parameters
+4. Environment variable fallbacks for credentials
+5. Appropriate `__tags__`, `__timeout__`, and rate limits
+6. Read-only by default for data access tools


### PR DESCRIPTION
## Summary
- Docs for all features from v0.5.0 through v1.0.0
- Rate limiting, caching, sandboxing sections with code examples
- HPA/PDB autoscaling section
- Updated key values table with new fields
- Features list updated with hot reload, gateway, visibility, multi-auth, context, security

## Test plan
- [x] Markdown renders correctly
- [x] All code examples are valid