### PR TITLE
fix(docs): update Strapi image references to 0.1.7

### DIFF
--- a/src/pages/docs/charts/strapi.mdx
+++ b/src/pages/docs/charts/strapi.mdx
@@ -56,7 +56,7 @@ helm install strapi oci://ghcr.io/helmforgedev/helm/strapi
 
 The chart uses **HelmForge's production-ready Strapi base image** instead of the generic Strapi image. This provides significant advantages for Kubernetes deployments:
 
-**Image:** `docker.io/helmforge/strapi-base:0.1.6`
+**Image:** `docker.io/helmforge/strapi-base:0.1.7`
 
 ### Key Features
 
@@ -76,7 +76,7 @@ The chart uses **HelmForge's production-ready Strapi base image** instead of the
 ```yaml
 image:
   repository: docker.io/helmforge/strapi-base
-  tag: '0.1.6'
+  tag: '0.1.7'
 ```
 
 This provides a working Strapi instance with default configuration, perfect for:
@@ -92,7 +92,7 @@ For production deployments with custom content types and configurations:
 
 ```dockerfile
 # Dockerfile
-FROM docker.io/helmforge/strapi-base:0.1.6
+FROM docker.io/helmforge/strapi-base:0.1.7
 
 # Copy your Strapi project
 COPY --chown=strapi:strapi . /opt/app
@@ -118,7 +118,7 @@ image:
 | ------------------ | ------------------------------ |
 | **Registry**       | docker.io                      |
 | **Repository**     | helmforge/strapi-base          |
-| **Current Tag**    | 0.1.6                          |
+| **Current Tag**    | 0.1.7                          |
 | **Strapi Version** | 5.42.0                         |
 | **Base Image**     | node:20-alpine                 |
 | **User**           | strapi (UID 1000, GID 1000)    |
@@ -178,7 +178,7 @@ Simplest deployment for development or testing:
 ```yaml
 image:
   repository: docker.io/helmforge/strapi-base
-  tag: '0.1.6'
+  tag: '0.1.7'
 
 persistence:
   enabled: true
@@ -203,7 +203,7 @@ replicaCount: 3
 
 image:
   repository: docker.io/helmforge/strapi-base
-  tag: '0.1.6'
+  tag: '0.1.7'
 
 # S3 uploads enable multi-replica scaling
 strapi:
@@ -731,7 +731,7 @@ kubectl port-forward svc/strapi 1337:80 -n strapi
 | -------------------------- | ----------------------- | ----------------------------------------------------- |
 | `replicaCount`             | `1`                     | Number of replicas (requires S3/Cloudinary if > 1)    |
 | `image.repository`         | `helmforge/strapi-base` | Strapi application image (HelmForge production-ready) |
-| `image.tag`                | `0.1.6`                 | HelmForge Strapi base image version                   |
+| `image.tag`                | `0.1.7`                 | HelmForge Strapi base image version                   |
 | `strapi.url`               | `""`                    | Public URL (auto-detected from ingress)               |
 | `strapi.nodeEnv`           | `production`            | Node environment                                      |
 | `strapi.telemetryDisabled` | `true`                  | Disable Strapi telemetry                              |
@@ -805,7 +805,7 @@ replicaCount: 1
 
 image:
   repository: docker.io/helmforge/strapi-base
-  tag: '0.1.6'
+  tag: '0.1.7'
   pullPolicy: IfNotPresent
 
 database:
@@ -840,7 +840,7 @@ replicaCount: 2
 
 image:
   repository: docker.io/helmforge/strapi-base
-  tag: '0.1.6'
+  tag: '0.1.7'
 
 database:
   mode: external
@@ -885,7 +885,7 @@ replicaCount: 3
 
 image:
   repository: docker.io/helmforge/strapi-base
-  tag: '0.1.6'
+  tag: '0.1.7'
 
 postgresql:
   enabled: true


### PR DESCRIPTION
## Summary

Updates all Strapi documentation references from `helmforge/strapi-base:0.1.6` to `0.1.7`.

## Changes

- ✅ Updated 10 occurrences of version 0.1.6 to 0.1.7
- ✅ Formatted with Prettier

## Context

Version 0.1.7 fixes critical bug where TypeScript config files were not being compiled to JavaScript, causing container startup failures.

## Related

- Chart PR: helmforgedev/charts#69
- Base image fix: helmforgedev/strapi-base@c7cbb98