### PR TITLE
fix(docs): update Strapi image references to 0.1.9

### DIFF
--- a/src/pages/docs/charts/strapi.mdx
+++ b/src/pages/docs/charts/strapi.mdx
@@ -56,7 +56,11 @@ helm install strapi oci://ghcr.io/helmforgedev/helm/strapi
 
 The chart uses **HelmForge's production-ready Strapi base image** instead of the generic Strapi image. This provides significant advantages for Kubernetes deployments:
 
-**Image:** `docker.io/helmforge/strapi-base:0.1.7`
+<<<<<<< HEAD
+**Image:** `docker.io/helmforge/strapi-base:0.1.9`
+=======
+**Image:** `docker.io/helmforge/strapi-base:0.1.9`
+>>>>>>> f881cfb (fix(docs): update Strapi image references to 0.1.9)
 
 ### Key Features
 
@@ -76,7 +80,11 @@ The chart uses **HelmForge's production-ready Strapi base image** instead of the
 ```yaml
 image:
   repository: docker.io/helmforge/strapi-base
-  tag: '0.1.7'
+<<<<<<< HEAD
+  tag: '0.1.9'
+=======
+  tag: '0.1.9'
+>>>>>>> f881cfb (fix(docs): update Strapi image references to 0.1.9)
 ```
 
 This provides a working Strapi instance with default configuration, perfect for:
@@ -92,7 +100,11 @@ For production deployments with custom content types and configurations:
 
 ```dockerfile
 # Dockerfile
-FROM docker.io/helmforge/strapi-base:0.1.7
+<<<<<<< HEAD
+FROM docker.io/helmforge/strapi-base:0.1.9
+=======
+FROM docker.io/helmforge/strapi-base:0.1.9
+>>>>>>> f881cfb (fix(docs): update Strapi image references to 0.1.9)
 
 # Copy your Strapi project
 COPY --chown=strapi:strapi . /opt/app
@@ -118,7 +130,11 @@ image:
 | ------------------ | ------------------------------ |
 | **Registry**       | docker.io                      |
 | **Repository**     | helmforge/strapi-base          |
-| **Current Tag**    | 0.1.7                          |
+<<<<<<< HEAD
+| **Current Tag**    | 0.1.9                          |
+=======
+| **Current Tag**    | 0.1.9                          |
+>>>>>>> f881cfb (fix(docs): update Strapi image references to 0.1.9)
 | **Strapi Version** | 5.42.0                         |
 | **Base Image**     | node:20-alpine                 |
 | **User**           | strapi (UID 1000, GID 1000)    |
@@ -178,7 +194,11 @@ Simplest deployment for development or testing:
 ```yaml
 image:
   repository: docker.io/helmforge/strapi-base
-  tag: '0.1.7'
+<<<<<<< HEAD
+  tag: '0.1.9'
+=======
+  tag: '0.1.9'
+>>>>>>> f881cfb (fix(docs): update Strapi image references to 0.1.9)
 
 persistence:
   enabled: true
@@ -203,7 +223,11 @@ replicaCount: 3
 
 image:
   repository: docker.io/helmforge/strapi-base
-  tag: '0.1.7'
+<<<<<<< HEAD
+  tag: '0.1.9'
+=======
+  tag: '0.1.9'
+>>>>>>> f881cfb (fix(docs): update Strapi image references to 0.1.9)
 
 # S3 uploads enable multi-replica scaling
 strapi:
@@ -731,7 +755,11 @@ kubectl port-forward svc/strapi 1337:80 -n strapi
 | -------------------------- | ----------------------- | ----------------------------------------------------- |
 | `replicaCount`             | `1`                     | Number of replicas (requires S3/Cloudinary if > 1)    |
 | `image.repository`         | `helmforge/strapi-base` | Strapi application image (HelmForge production-ready) |
-| `image.tag`                | `0.1.7`                 | HelmForge Strapi base image version                   |
+<<<<<<< HEAD
+| `image.tag`                | `0.1.9`                 | HelmForge Strapi base image version                   |
+=======
+| `image.tag`                | `0.1.9`                 | HelmForge Strapi base image version                   |
+>>>>>>> f881cfb (fix(docs): update Strapi image references to 0.1.9)
 | `strapi.url`               | `""`                    | Public URL (auto-detected from ingress)               |
 | `strapi.nodeEnv`           | `production`            | Node environment                                      |
 | `strapi.telemetryDisabled` | `true`                  | Disable Strapi telemetry                              |
@@ -805,7 +833,11 @@ replicaCount: 1
 
 image:
   repository: docker.io/helmforge/strapi-base
-  tag: '0.1.7'
+<<<<<<< HEAD
+  tag: '0.1.9'
+=======
+  tag: '0.1.9'
+>>>>>>> f881cfb (fix(docs): update Strapi image references to 0.1.9)
   pullPolicy: IfNotPresent
 
 database:
@@ -840,7 +872,11 @@ replicaCount: 2
 
 image:
   repository: docker.io/helmforge/strapi-base
-  tag: '0.1.7'
+<<<<<<< HEAD
+  tag: '0.1.9'
+=======
+  tag: '0.1.9'
+>>>>>>> f881cfb (fix(docs): update Strapi image references to 0.1.9)
 
 database:
   mode: external
@@ -885,7 +921,11 @@ replicaCount: 3
 
 image:
   repository: docker.io/helmforge/strapi-base
-  tag: '0.1.7'
+<<<<<<< HEAD
+  tag: '0.1.9'
+=======
+  tag: '0.1.9'
+>>>>>>> f881cfb (fix(docs): update Strapi image references to 0.1.9)
 
 postgresql:
   enabled: true

--- a/src/pages/docs/charts/strapi.mdx
+++ b/src/pages/docs/charts/strapi.mdx
@@ -56,11 +56,8 @@ helm install strapi oci://ghcr.io/helmforgedev/helm/strapi
 
 The chart uses **HelmForge's production-ready Strapi base image** instead of the generic Strapi image. This provides significant advantages for Kubernetes deployments:
 
-<<<<<<< HEAD
 **Image:** `docker.io/helmforge/strapi-base:0.1.9`
-=======
 **Image:** `docker.io/helmforge/strapi-base:0.1.9`
->>>>>>> f881cfb (fix(docs): update Strapi image references to 0.1.9)
 
 ### Key Features
 
@@ -80,11 +77,8 @@ The chart uses **HelmForge's production-ready Strapi base image** instead of the
 ```yaml
 image:
   repository: docker.io/helmforge/strapi-base
-<<<<<<< HEAD
   tag: '0.1.9'
-=======
   tag: '0.1.9'
->>>>>>> f881cfb (fix(docs): update Strapi image references to 0.1.9)
 ```
 
 This provides a working Strapi instance with default configuration, perfect for:
@@ -100,11 +94,8 @@ For production deployments with custom content types and configurations:
 
 ```dockerfile
 # Dockerfile
-<<<<<<< HEAD
 FROM docker.io/helmforge/strapi-base:0.1.9
-=======
 FROM docker.io/helmforge/strapi-base:0.1.9
->>>>>>> f881cfb (fix(docs): update Strapi image references to 0.1.9)
 
 # Copy your Strapi project
 COPY --chown=strapi:strapi . /opt/app
@@ -130,11 +121,8 @@ image:
 | ------------------ | ------------------------------ |
 | **Registry**       | docker.io                      |
 | **Repository**     | helmforge/strapi-base          |
-<<<<<<< HEAD
 | **Current Tag**    | 0.1.9                          |
-=======
 | **Current Tag**    | 0.1.9                          |
->>>>>>> f881cfb (fix(docs): update Strapi image references to 0.1.9)
 | **Strapi Version** | 5.42.0                         |
 | **Base Image**     | node:20-alpine                 |
 | **User**           | strapi (UID 1000, GID 1000)    |
@@ -194,11 +182,8 @@ Simplest deployment for development or testing:
 ```yaml
 image:
   repository: docker.io/helmforge/strapi-base
-<<<<<<< HEAD
   tag: '0.1.9'
-=======
   tag: '0.1.9'
->>>>>>> f881cfb (fix(docs): update Strapi image references to 0.1.9)
 
 persistence:
   enabled: true
@@ -223,11 +208,8 @@ replicaCount: 3
 
 image:
   repository: docker.io/helmforge/strapi-base
-<<<<<<< HEAD
   tag: '0.1.9'
-=======
   tag: '0.1.9'
->>>>>>> f881cfb (fix(docs): update Strapi image references to 0.1.9)
 
 # S3 uploads enable multi-replica scaling
 strapi:
@@ -755,11 +737,8 @@ kubectl port-forward svc/strapi 1337:80 -n strapi
 | -------------------------- | ----------------------- | ----------------------------------------------------- |
 | `replicaCount`             | `1`                     | Number of replicas (requires S3/Cloudinary if > 1)    |
 | `image.repository`         | `helmforge/strapi-base` | Strapi application image (HelmForge production-ready) |
-<<<<<<< HEAD
 | `image.tag`                | `0.1.9`                 | HelmForge Strapi base image version                   |
-=======
 | `image.tag`                | `0.1.9`                 | HelmForge Strapi base image version                   |
->>>>>>> f881cfb (fix(docs): update Strapi image references to 0.1.9)
 | `strapi.url`               | `""`                    | Public URL (auto-detected from ingress)               |
 | `strapi.nodeEnv`           | `production`            | Node environment                                      |
 | `strapi.telemetryDisabled` | `true`                  | Disable Strapi telemetry                              |
@@ -833,11 +812,8 @@ replicaCount: 1
 
 image:
   repository: docker.io/helmforge/strapi-base
-<<<<<<< HEAD
   tag: '0.1.9'
-=======
   tag: '0.1.9'
->>>>>>> f881cfb (fix(docs): update Strapi image references to 0.1.9)
   pullPolicy: IfNotPresent
 
 database:
@@ -872,11 +848,8 @@ replicaCount: 2
 
 image:
   repository: docker.io/helmforge/strapi-base
-<<<<<<< HEAD
   tag: '0.1.9'
-=======
   tag: '0.1.9'
->>>>>>> f881cfb (fix(docs): update Strapi image references to 0.1.9)
 
 database:
   mode: external
@@ -921,11 +894,8 @@ replicaCount: 3
 
 image:
   repository: docker.io/helmforge/strapi-base
-<<<<<<< HEAD
   tag: '0.1.9'
-=======
   tag: '0.1.9'
->>>>>>> f881cfb (fix(docs): update Strapi image references to 0.1.9)
 
 postgresql:
   enabled: true


### PR DESCRIPTION
## Summary

Updates all Strapi documentation references from `helmforge/strapi-base:0.1.6` to `0.1.9`.

## Changes

- ✅ Updated 10 occurrences of version 0.1.6 to 0.1.9
- ✅ Formatted with Prettier

## Context

Version 0.1.9 fixes critical bug where missing core plugins (users-permissions, cloud) caused container startup failures.

## Related

- Chart PR: helmforgedev/charts#70
- Base image fixes: helmforgedev/strapi-base commits 884c76a, 65edb9b, 7c551c6