### PR TITLE
docs(envoy-gateway): update rate limiting docs for redis subchart

### DIFF
--- a/src/pages/docs/charts/envoy-gateway.mdx
+++ b/src/pages/docs/charts/envoy-gateway.mdx
@@ -40,8 +40,8 @@ Modern Kubernetes Gateway API implementation powered by Envoy Proxy. Envoy Gatew
   - Request timeout settings
 
 - **Rate Limiting**: Distributed rate limiting with Redis
-  - Optional Redis StatefulSet deployment
-  - External Redis support
+  - [helmforge/redis](https://helmforge.dev/docs/charts/redis) subchart (standalone topology)
+  - External Redis support for bring-your-own setups
   - Pre-configured rate limit presets (API, Strict)
 
 - **Comprehensive Observability**: Production-grade monitoring
@@ -482,25 +482,91 @@ Distributed rate limiting with Redis backend for API protection.
 
 #### Enabling Rate Limiting
 
-**Option 1: Deploy Redis with the chart**
+Rate limiting state is stored in Redis. The chart uses [helmforge/redis](https://helmforge.dev/docs/charts/redis)
+as a subchart dependency — no separate Redis installation required.
+
+**Option 1: Redis subchart (recommended)**
 
 ```bash
 helm install envoy-gateway helmforge/envoy-gateway \
   --set rateLimiting.enabled=true \
-  --set rateLimiting.redis.enabled=true \
+  --set redis.enabled=true \
   --set rateLimiting.presets.api=true
 ```
 
-This deploys a Redis StatefulSet with persistent storage.
+This deploys an `envoy-gateway-redis` StatefulSet using the standalone topology from the
+helmforge/redis chart. Redis is available at `<release>-redis.<namespace>.svc.cluster.local:6379`.
 
-**Option 2: Use external Redis**
+**Option 2: External Redis (bring your own)**
 
 ```bash
 helm install envoy-gateway helmforge/envoy-gateway \
   --set rateLimiting.enabled=true \
-  --set rateLimiting.redis.enabled=false \
+  --set redis.enabled=false \
   --set rateLimiting.externalRedis.host=redis.example.com \
   --set rateLimiting.externalRedis.port=6379
+```
+
+#### Redis Subchart Configuration
+
+The `redis:` section is forwarded directly to the [helmforge/redis](https://helmforge.dev/docs/charts/redis) chart.
+
+**Persistent storage** (default: `enabled: true`, `1Gi`):
+
+```yaml
+redis:
+  enabled: true
+  architecture: standalone
+  auth:
+    enabled: true
+    password: 'changeme' # or use existingSecret
+  standalone:
+    persistence:
+      enabled: true
+      size: 2Gi
+      storageClass: fast-ssd
+  resources:
+    requests:
+      cpu: 100m
+      memory: 128Mi
+    limits:
+      cpu: 500m
+      memory: 512Mi
+```
+
+**Disable persistence** (test/dev environments):
+
+```yaml
+redis:
+  enabled: true
+  auth:
+    enabled: false
+  standalone:
+    persistence:
+      enabled: false
+```
+
+**External Redis with authentication**:
+
+```yaml
+redis:
+  enabled: false
+
+rateLimiting:
+  externalRedis:
+    host: redis.example.com
+    port: 6379
+    auth:
+      enabled: true
+      secretName: redis-auth
+      secretKey: password
+```
+
+Create the secret:
+
+```bash
+kubectl create secret generic redis-auth \
+  --from-literal=password=your-redis-password
 ```
 
 #### Rate Limit Presets
@@ -572,24 +638,6 @@ spec:
             name: envoy-gateway-ratelimit-api
 ```
 
-Or use `kubectl patch`:
-
-```bash
-kubectl patch httproute my-api --type=merge -p '
-spec:
-  rules:
-  - backendRefs:
-    - name: api-service
-      port: 80
-    filters:
-    - type: ExtensionRef
-      extensionRef:
-        group: gateway.envoyproxy.io
-        kind: BackendTrafficPolicy
-        name: envoy-gateway-ratelimit-api
-'
-```
-
 #### Custom Rate Limit Policies
 
 Create a custom `BackendTrafficPolicy` for specific needs:
@@ -625,62 +673,14 @@ spec:
             unit: Minute
 ```
 
-#### Redis Configuration
-
-**Persistent Storage**:
-
-```yaml
-rateLimiting:
-  redis:
-    persistence:
-      enabled: true
-      size: 2Gi
-      storageClass: fast-ssd
-```
-
-**Resources**:
-
-```yaml
-rateLimiting:
-  redis:
-    resources:
-      requests:
-        cpu: 200m
-        memory: 256Mi
-      limits:
-        cpu: 500m
-        memory: 512Mi
-```
-
-**External Redis with Authentication**:
-
-```yaml
-rateLimiting:
-  redis:
-    enabled: false
-  externalRedis:
-    host: redis.example.com
-    port: 6379
-    auth:
-      enabled: true
-      secretName: redis-auth
-      secretKey: password
-```
-
-Create the secret:
-
-```bash
-kubectl create secret generic redis-auth \
-  --from-literal=password=your-redis-password
-```
-
 #### Monitoring Rate Limits
 
 Check Redis status:
 
 ```bash
-kubectl get statefulset envoy-gateway-redis
-kubectl logs envoy-gateway-redis-0
+# With subchart (StatefulSet named <release>-redis)
+kubectl get statefulset envoy-gateway-redis -n <namespace>
+kubectl exec envoy-gateway-redis-0 -- redis-cli info clients
 ```
 
 View rate limit metrics:
@@ -1257,18 +1257,27 @@ clientTrafficPolicy:
 
 ### Rate Limiting
 
-| Parameter                                | Description                       | Default           |
-| ---------------------------------------- | --------------------------------- | ----------------- |
-| `rateLimiting.enabled`                   | Enable rate limiting              | `false`           |
-| `rateLimiting.redis.enabled`             | Deploy Redis StatefulSet          | `false`           |
-| `rateLimiting.redis.image.repository`    | Redis image                       | `docker.io/redis` |
-| `rateLimiting.redis.image.tag`           | Redis image tag                   | `8.0.2-alpine`    |
-| `rateLimiting.redis.persistence.enabled` | Enable persistence                | `true`            |
-| `rateLimiting.redis.persistence.size`    | PVC size                          | `1Gi`             |
-| `rateLimiting.externalRedis.host`        | External Redis host               | `""`              |
-| `rateLimiting.externalRedis.port`        | External Redis port               | `6379`            |
-| `rateLimiting.presets.api`               | Enable API preset (100 req/min)   | `false`           |
-| `rateLimiting.presets.strict`            | Enable strict preset (10 req/min) | `false`           |
+| Parameter                         | Description                                      | Default |
+| --------------------------------- | ------------------------------------------------ | ------- |
+| `rateLimiting.enabled`            | Enable rate limiting                             | `false` |
+| `rateLimiting.externalRedis.host` | External Redis host (when `redis.enabled=false`) | `""`    |
+| `rateLimiting.externalRedis.port` | External Redis port                              | `6379`  |
+| `rateLimiting.presets.api`        | Enable API preset (100 req/min per IP)           | `false` |
+| `rateLimiting.presets.strict`     | Enable strict preset (10 req/min per IP)         | `false` |
+
+### Redis Subchart
+
+Redis is deployed as a [helmforge/redis](https://helmforge.dev/docs/charts/redis) subchart.
+All `redis.*` values are forwarded to the redis chart — refer to its documentation for the full list.
+
+| Parameter                              | Description                              | Default      |
+| -------------------------------------- | ---------------------------------------- | ------------ |
+| `redis.enabled`                        | Deploy helmforge/redis subchart          | `false`      |
+| `redis.architecture`                   | Redis topology                           | `standalone` |
+| `redis.auth.enabled`                   | Enable password authentication           | `true`       |
+| `redis.auth.password`                  | Redis password (auto-generated if empty) | `""`         |
+| `redis.standalone.persistence.enabled` | Enable persistent storage                | `true`       |
+| `redis.standalone.persistence.size`    | PVC size                                 | `1Gi`        |
 
 ### Monitoring
 
@@ -1447,7 +1456,7 @@ Deploy as API gateway with rate limiting and monitoring:
 helm install envoy-gateway helmforge/envoy-gateway \
   --set profile=production-ha \
   --set rateLimiting.enabled=true \
-  --set rateLimiting.redis.enabled=true \
+  --set redis.enabled=true \
   --set rateLimiting.presets.api=true \
   --set monitoring.enabled=true \
   --set monitoring.prometheus.serviceMonitor=true \
@@ -2128,7 +2137,7 @@ Complete architectural redesign for EG v1.7.1 with operator-managed proxy provis
 
 - EG: v1.7.1 (was v1.0.0)
 - Envoy: distroless-v1.33.0 (was v1.29.0)
-- Redis: 8.0.2-alpine (was 7.2-alpine)
+- Redis: helmforge/redis subchart v1.6.9 (replaces inline StatefulSet)
 - Gateway API CRDs: v1.2.1 (was v1.0.0)
 - PrometheusRule: 6 alerts (was 7)
 
@@ -2141,7 +2150,7 @@ All features are opt-in and can be enabled individually:
 helm install envoy-gateway helmforge/envoy-gateway \
   --set profile=production-ha \
   --set rateLimiting.enabled=true \
-  --set rateLimiting.redis.enabled=true \
+  --set redis.enabled=true \
   --set rateLimiting.presets.api=true \
   --set monitoring.enabled=true \
   --set monitoring.prometheus.prometheusRule=true \


### PR DESCRIPTION
## Summary

Updates the Envoy Gateway documentation to reflect the redis subchart change merged in [charts#82](https://github.com/helmforgedev/charts/pull/82).

### Changes

- **Features list**: replaced "Optional Redis StatefulSet deployment" with helmforge/redis subchart link
- **Enabling Rate Limiting**: `redis.enabled=true` replaces `rateLimiting.redis.enabled=true`
- **Redis Subchart Configuration**: new dedicated section covering `redis.architecture`, `redis.auth`, `redis.standalone.persistence`, resources
- **External Redis**: simplified — `redis.enabled=false` + `rateLimiting.externalRedis.*`
- **Parameters table**: replaced `rateLimiting.redis.*` rows with a Redis Subchart table pointing to the helmforge/redis docs
- **Scenario 4 and changelog examples**: updated to use `redis.enabled=true`
- **Monitoring commands**: updated StatefulSet name to `<release>-redis`