### PR TITLE
fix(docs): restore envoy layout and sync chart navigation

### DIFF
--- a/src/data/navigation.ts
+++ b/src/data/navigation.ts
@@ -65,6 +65,7 @@ export const chartCategories: ChartCategory[] = [
     label: 'Networking & DNS',
     charts: [
       { label: 'Cloudflared', href: '/docs/charts/cloudflared', maturity: 'stable' },
+      { label: 'Envoy Gateway', href: '/docs/charts/envoy-gateway', maturity: 'beta' },
       { label: 'DDNS Updater', href: '/docs/charts/ddns-updater', maturity: 'stable' },
       { label: 'Pi-hole', href: '/docs/charts/pihole', maturity: 'stable' },
       { label: 'AdGuard Home', href: '/docs/charts/adguard-home', maturity: 'stable' },
@@ -81,6 +82,10 @@ export const chartCategories: ChartCategory[] = [
       { label: 'Automatisch', href: '/docs/charts/automatisch', maturity: 'stable' },
       { label: 'FastMCP Server', href: '/docs/charts/fastmcp-server', maturity: 'stable' },
     ],
+  },
+  {
+    label: 'Home Automation',
+    charts: [{ label: 'openHAB', href: '/docs/charts/openhab', maturity: 'beta' }],
   },
   {
     label: 'Monitoring & Ops',
@@ -128,6 +133,7 @@ export const chartCategories: ChartCategory[] = [
       { label: 'Apache Superset', href: '/docs/charts/superset', maturity: 'stable' },
       { label: 'CKAN', href: '/docs/charts/ckan', maturity: 'stable' },
       { label: 'Apache Druid', href: '/docs/charts/druid', maturity: 'stable' },
+      { label: 'Elasticsearch', href: '/docs/charts/elasticsearch', maturity: 'alpha' },
     ],
   },
   {

--- a/src/pages/docs/charts/envoy-gateway.mdx
+++ b/src/pages/docs/charts/envoy-gateway.mdx
@@ -1,4 +1,5 @@
 ---
+layout: ../../../layouts/DocsLayout.astro
 title: Envoy Gateway Chart
 description: Deploy Envoy Gateway v1.7.1 on Kubernetes with HelmForge's production-ready Helm chart featuring Gateway API, SecurityPolicy (JWT/OIDC/CORS), BackendTrafficPolicy, and comprehensive observability.
 ---

--- a/src/pages/docs/charts/index.mdx
+++ b/src/pages/docs/charts/index.mdx
@@ -48,6 +48,7 @@ HelmForge provides production-ready Helm charts for common Kubernetes workloads.
 | [Pi-hole](/docs/charts/pihole)            | DNS sinkhole with custom records and Unbound recursive DNS |
 | [AdGuard Home](/docs/charts/adguard-home) | DNS ad/tracker blocker with sync and S3 backup             |
 | [Cloudflared](/docs/charts/cloudflared)   | Cloudflare Tunnel for secure outbound-only connections     |
+| [Envoy Gateway](/docs/charts/envoy-gateway) | Kubernetes Gateway API implementation with advanced traffic policies |
 | [DDNS Updater](/docs/charts/ddns-updater) | Dynamic DNS updater for 50+ providers                      |
 
 ## CMS & Applications
@@ -105,6 +106,7 @@ HelmForge provides production-ready Helm charts for common Kubernetes workloads.
 | [Umami](/docs/charts/umami)              | Privacy-focused web analytics with PostgreSQL                           |
 | [Metabase](/docs/charts/metabase)        | Open-source business intelligence and analytics with PostgreSQL         |
 | [Liwan](/docs/charts/liwan)              | Ultra-lightweight privacy-first web analytics with embedded DuckDB      |
+| [Elasticsearch](/docs/charts/elasticsearch) | Search and analytics engine with multi-role cluster support and production presets |
 
 ## AI & Automation
 
@@ -114,6 +116,13 @@ HelmForge provides production-ready Helm charts for common Kubernetes workloads.
 | [OliveTin](/docs/charts/olivetin)       | Browser-based UI for predefined shell commands and system actions           |
 | [Cronicle](/docs/charts/cronicle)       | Multi-server task scheduler with web UI and persistent job storage          |
 | [Automatisch](/docs/charts/automatisch) | Open-source workflow automation platform with PostgreSQL and Redis          |
+| [FastMCP Server](/docs/charts/fastmcp-server) | Model Context Protocol server for tools, prompts, and resources with multi-source loading |
+
+## Home Automation
+
+| Chart                            | Description                                                                     |
+| -------------------------------- | ------------------------------------------------------------------------------- |
+| [openHAB](/docs/charts/openhab) | Home automation platform with GitOps-friendly live configuration reload and Prometheus metrics |
 
 ## Archiving & Fitness
 

--- a/src/pages/docs/charts/index.mdx
+++ b/src/pages/docs/charts/index.mdx
@@ -43,13 +43,13 @@ HelmForge provides production-ready Helm charts for common Kubernetes workloads.
 
 ## Networking & DNS
 
-| Chart                                     | Description                                                |
-| ----------------------------------------- | ---------------------------------------------------------- |
-| [Pi-hole](/docs/charts/pihole)            | DNS sinkhole with custom records and Unbound recursive DNS |
-| [AdGuard Home](/docs/charts/adguard-home) | DNS ad/tracker blocker with sync and S3 backup             |
-| [Cloudflared](/docs/charts/cloudflared)   | Cloudflare Tunnel for secure outbound-only connections     |
+| Chart                                       | Description                                                          |
+| ------------------------------------------- | -------------------------------------------------------------------- |
+| [Pi-hole](/docs/charts/pihole)              | DNS sinkhole with custom records and Unbound recursive DNS           |
+| [AdGuard Home](/docs/charts/adguard-home)   | DNS ad/tracker blocker with sync and S3 backup                       |
+| [Cloudflared](/docs/charts/cloudflared)     | Cloudflare Tunnel for secure outbound-only connections               |
 | [Envoy Gateway](/docs/charts/envoy-gateway) | Kubernetes Gateway API implementation with advanced traffic policies |
-| [DDNS Updater](/docs/charts/ddns-updater) | Dynamic DNS updater for 50+ providers                      |
+| [DDNS Updater](/docs/charts/ddns-updater)   | Dynamic DNS updater for 50+ providers                                |
 
 ## CMS & Applications
 
@@ -97,31 +97,31 @@ HelmForge provides production-ready Helm charts for common Kubernetes workloads.
 
 ## Analytics & Data
 
-| Chart                                    | Description                                                             |
-| ---------------------------------------- | ----------------------------------------------------------------------- |
-| [Apache Superset](/docs/charts/superset) | Data exploration and visualization with Celery workers and PostgreSQL   |
-| [CKAN](/docs/charts/ckan)                | Open data portal with DataPusher, Solr, PostgreSQL, and Redis           |
-| [Apache Druid](/docs/charts/druid)       | Distributed analytics database with coordinator, broker, and historical |
-| [Countly](/docs/charts/countly)          | Product analytics with event tracking, crash reporting, and MongoDB     |
-| [Umami](/docs/charts/umami)              | Privacy-focused web analytics with PostgreSQL                           |
-| [Metabase](/docs/charts/metabase)        | Open-source business intelligence and analytics with PostgreSQL         |
-| [Liwan](/docs/charts/liwan)              | Ultra-lightweight privacy-first web analytics with embedded DuckDB      |
+| Chart                                       | Description                                                                        |
+| ------------------------------------------- | ---------------------------------------------------------------------------------- |
+| [Apache Superset](/docs/charts/superset)    | Data exploration and visualization with Celery workers and PostgreSQL              |
+| [CKAN](/docs/charts/ckan)                   | Open data portal with DataPusher, Solr, PostgreSQL, and Redis                      |
+| [Apache Druid](/docs/charts/druid)          | Distributed analytics database with coordinator, broker, and historical            |
+| [Countly](/docs/charts/countly)             | Product analytics with event tracking, crash reporting, and MongoDB                |
+| [Umami](/docs/charts/umami)                 | Privacy-focused web analytics with PostgreSQL                                      |
+| [Metabase](/docs/charts/metabase)           | Open-source business intelligence and analytics with PostgreSQL                    |
+| [Liwan](/docs/charts/liwan)                 | Ultra-lightweight privacy-first web analytics with embedded DuckDB                 |
 | [Elasticsearch](/docs/charts/elasticsearch) | Search and analytics engine with multi-role cluster support and production presets |
 
 ## AI & Automation
 
-| Chart                                   | Description                                                                 |
-| --------------------------------------- | --------------------------------------------------------------------------- |
-| [Open WebUI](/docs/charts/open-webui)   | Self-hosted AI chat platform with Ollama/OpenAI, RAG, PostgreSQL, and Redis |
-| [OliveTin](/docs/charts/olivetin)       | Browser-based UI for predefined shell commands and system actions           |
-| [Cronicle](/docs/charts/cronicle)       | Multi-server task scheduler with web UI and persistent job storage          |
-| [Automatisch](/docs/charts/automatisch) | Open-source workflow automation platform with PostgreSQL and Redis          |
+| Chart                                         | Description                                                                               |
+| --------------------------------------------- | ----------------------------------------------------------------------------------------- |
+| [Open WebUI](/docs/charts/open-webui)         | Self-hosted AI chat platform with Ollama/OpenAI, RAG, PostgreSQL, and Redis               |
+| [OliveTin](/docs/charts/olivetin)             | Browser-based UI for predefined shell commands and system actions                         |
+| [Cronicle](/docs/charts/cronicle)             | Multi-server task scheduler with web UI and persistent job storage                        |
+| [Automatisch](/docs/charts/automatisch)       | Open-source workflow automation platform with PostgreSQL and Redis                        |
 | [FastMCP Server](/docs/charts/fastmcp-server) | Model Context Protocol server for tools, prompts, and resources with multi-source loading |
 
 ## Home Automation
 
-| Chart                            | Description                                                                     |
-| -------------------------------- | ------------------------------------------------------------------------------- |
+| Chart                           | Description                                                                                    |
+| ------------------------------- | ---------------------------------------------------------------------------------------------- |
 | [openHAB](/docs/charts/openhab) | Home automation platform with GitOps-friendly live configuration reload and Prometheus metrics |
 
 ## Archiving & Fitness


### PR DESCRIPTION
## Summary
- restore docs layout for nvoy-gateway by adding DocsLayout
- add missing charts to docs left sidebar navigation (nvoy-gateway, lasticsearch, openHAB)
- sync /docs/charts overview entries and include missing chart references (astmcp-server, nvoy-gateway, lasticsearch, openHAB)

## Validation
- 
pm run build
- checked docs/sidebar consistency via local script

## Context
Fixes broken unstyled Envoy docs page and missing chart visibility in docs navigation.