### PR TITLE
fix(seo): expand homepage title to fix Bing title-too-short warning

### DIFF
--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -13,7 +13,7 @@ interface Props {
 const { title, description, image = '/og-default.png', url = Astro.url.href, ogType } = Astro.props;
 
 const siteName = 'HelmForge';
-const fullTitle = title === siteName ? title : `${title} | ${siteName}`;
+const fullTitle = title.includes(siteName) ? title : `${title} | ${siteName}`;
 
 // Detect page type from path
 const pathname = Astro.url.pathname;

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -12,7 +12,7 @@ import { chartCount } from '../data/charts';
 ---
 
 <BaseLayout
-  title="HelmForge"
+  title="HelmForge — Open-Source Helm Charts for Kubernetes"
   description={`HelmForge — ${chartCount}+ production-ready Helm charts for Kubernetes. The open-source, MIT-licensed alternative to Bitnami. Official images, built-in S3 backup, non-root security, zero vendor lock-in. Free forever.`}
 >
   <Header />


### PR DESCRIPTION
## Summary

Bing Webmaster Tools reported 'title too short' for https://helmforge.dev/ — the homepage \<title>\ was just 'HelmForge' (9 chars). Bing requires >=15 chars.

## Changes

- \src/pages/index.astro\: title \'HelmForge'\ → \'HelmForge — Open-Source Helm Charts for Kubernetes'\ (50 chars)
- \src/layouts/BaseLayout.astro\: \ullTitle\ logic updated from \	itle === siteName\ to \	itle.includes(siteName)\ — prevents brand name duplication when title already contains 'HelmForge' (e.g. 'Helm Charts FAQ — HelmForge | HelmForge')

## Why not fix /blog/ trailing slash?

The Bing report for \/blog/\ being a 'redirect' is a Bing quirk from crawling the non-trailing-slash version (\/blog\) which redirects to \/blog/\. All URLs on the site consistently use trailing slashes (Astro default). Changing \	railingSlash\ config would break all internal and external links — not worth it. Fix: submit \https://helmforge.dev/blog/\ via Bing Webmaster 'Submit URL'.

Related to #156