### PR TITLE
fix(seo): make Bitnami explicit in homepage comparison section copy

### DIFF
--- a/src/components/ComparisonTable.astro
+++ b/src/components/ComparisonTable.astro
@@ -16,10 +16,11 @@ import { comparisonFull } from '../data/comparison';
         <Scale class="w-6 h-6" />
       </div>
       <h2 class="text-3xl sm:text-4xl lg:text-5xl font-bold tracking-tight text-text-base heading-font">
-        Side-by-side: HelmForge vs the rest.
+        HelmForge vs Bitnami — feature by feature.
       </h2>
       <p class="mt-5 text-lg text-text-muted leading-relaxed">
-        Official images, no vendor lock-in, MIT licensed. See exactly where HelmForge leads.
+        Official upstream images, MIT licensed, zero vendor lock-in. See exactly why teams switch from Bitnami to
+        HelmForge.
       </p>
     </div>
 


### PR DESCRIPTION
## Summary

Audit of the SEO work from #156 revealed that the homepage ComparisonTable.astro component used generic copy ('vs the rest') with no direct Bitnami mention in **visible** heading/text. The meta description and JSON-LD already had Bitnami references, but on-page visible h2/p content did not.

## Changes

- \src/components/ComparisonTable.astro\:
  - h2: \Side-by-side: HelmForge vs the rest.\ → \HelmForge vs Bitnami — feature by feature.\
  - paragraph: \...See exactly where HelmForge leads.\ → \...See exactly why teams switch from Bitnami to HelmForge.\

## What was confirmed working from #156

- \{backupCount}\ in comparison page = 38 (dynamic, correct — not hardcoded)
- \{chartCount}\ in comparison table = dynamic
- WebSite + SiteLinksSearchBox JSON-LD on homepage ✅
- TechArticle JSON-LD on all 62 chart pages ✅
- FAQPage JSON-LD with 10 Q&As ✅
- Sitemap priority/changefreq ✅
- robots.txt ✅
- All page titles/descriptions ✅

Related to #156