### PR TITLE
docs(fastmcp-server): sync values reference

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,11 @@
+* text=auto eol=lf
+
+*.png binary
+*.jpg binary
+*.jpeg binary
+*.gif binary
+*.webp binary
+*.ico binary
+*.pdf binary
+*.woff binary
+*.woff2 binary

--- a/src/pages/docs/charts/fastmcp-server.mdx
+++ b/src/pages/docs/charts/fastmcp-server.mdx
@@ -1,7 +1,7 @@
 ---
 layout: ../../../layouts/DocsLayout.astro
 title: FastMCP Server
-description: Helm chart for FastMCP server — deploy MCP tools, resources, prompts, and knowledge bases on Kubernetes with multi-source loading from inline, S3, and Git.
+description: Helm chart for FastMCP server — deploy MCP tools, resources, prompts, and knowledge bases on Kubernetes with inline, S3, Git, OCI, gateway, and multi-auth configuration.
 ---
 
 # FastMCP Server
@@ -10,9 +10,9 @@ Helm chart for deploying [FastMCP Server](https://github.com/helmforgedev/fastmc
 
 ## Key Features
 
-- **Multi-source loading** — tools, resources, prompts, and knowledge from inline ConfigMaps, S3-compatible storage (AWS S3, MinIO, R2), or Git repositories
-- **Merge precedence** — Inline (highest) > S3 > Git (lowest) — override S3 tools locally without touching the bucket
-- **Bearer and JWT authentication** — built-in via FastMCP's `StaticTokenVerifier` and `JWTVerifier`
+- **Multi-source loading** — tools, resources, prompts, and knowledge from inline ConfigMaps, S3-compatible storage (AWS S3, MinIO, R2), Git repositories, or OCI artifacts
+- **Merge precedence** — Inline (highest) > S3 > Git > OCI (lowest) — override remote tools locally without touching the upstream source
+- **Bearer, JWT, and multi-auth** — configure one auth mode or combine multiple providers through FastMCP
 - **Knowledge base support** — serve Markdown files as MCP resources for RAG and context injection
 - **Extra pip packages** — install additional Python packages at startup before loading tools
 - **Tool metadata** — optional `__tags__`, `__timeout__`, `__annotations_mcp__` module variables for tool categorization and behavior hints
@@ -30,7 +30,7 @@ Helm chart for deploying [FastMCP Server](https://github.com/helmforgedev/fastmc
 - **Hot reload** — automatic tool/resource reload on filesystem changes via `MCP_HOT_RELOAD=true`
 - **Periodic sync** — poll S3/Git sources for changes at configurable intervals
 - **Webhook reload** — `POST /reload` endpoint for CI/CD-triggered reloads
-- **OCI artifact source** — pull tool bundles from OCI registries via ORAS
+- **OCI artifact source** — pull tool bundles from OCI registries via ORAS with optional registry credentials
 - **Selective sync** — include/exclude glob patterns for source filtering
 - **Gateway mode** — compose multiple MCP servers via `MCP_MODE=gateway` and `MCP_MOUNT_SERVERS`
 - **Tag visibility** — enable/disable tools by tags with `MCP_ENABLE_TAGS` and `MCP_DISABLE_TAGS`
@@ -94,8 +94,14 @@ sources:
     bucket: mcp-tools
     region: us-east-1
     prefix: production
-    accessKey: minioadmin
-    secretKey: minioadmin
+    accessKey: '<access-key>'
+    secretKey: '<secret-key>'
+    include:
+      - 'tools/**/*.py'
+      - 'knowledge/**/*.md'
+    exclude:
+      - '**/*.tmp'
+    syncInterval: 300
 ```
 
 ## Git Source
@@ -107,7 +113,34 @@ sources:
     repository: 'https://github.com/your-org/mcp-tools.git'
     branch: main
     path: '' # optional subdirectory
-    token: ghp_xxx # for private repos
+    token: '<github-token>' # for private repos
+    allowedRepositories:
+      - 'https://github.com/your-org/mcp-tools.git'
+    allowedBranches:
+      - main
+    include:
+      - 'tools/**/*.py'
+      - 'resources/**/*.py'
+    exclude:
+      - '**/private/**'
+    syncInterval: 300
+```
+
+## OCI Source
+
+```yaml
+sources:
+  oci:
+    enabled: true
+    registry: ghcr.io/your-org/mcp-bundle
+    tag: '1.0.0'
+    username: '<registry-user>'
+    password: '<registry-token>'
+    include:
+      - 'tools/**/*.py'
+      - 'knowledge/**/*.md'
+    exclude:
+      - '**/*.tmp'
 ```
 
 ## Authentication
@@ -133,6 +166,70 @@ auth:
     issuer: 'https://auth.example.com'
     audience: 'mcp-server'
     jwksUri: 'https://auth.example.com/.well-known/jwks.json'
+```
+
+### Multi-Auth and Scopes
+
+```yaml
+auth:
+  type: multi
+  providers:
+    - bearer
+    - jwt
+  bearer:
+    existingSecret: fastmcp-auth
+    existingSecretKey: token
+  jwt:
+    issuer: 'https://auth.example.com'
+    audience: 'mcp-server'
+    jwksUri: 'https://auth.example.com/.well-known/jwks.json'
+    algorithm: RS256
+  scopes:
+    - tools:read
+    - tools:execute
+  requiredScopes:
+    - tools:execute
+  clientId: fastmcp-server
+  requireHumanApprovalForDestructive: true
+```
+
+## Gateway Mode
+
+```yaml
+gateway:
+  enabled: true
+  mountServers:
+    github:
+      transport: streamable-http
+      url: 'https://github-mcp.example.com/mcp'
+      auth:
+        type: bearer
+        tokenEnv: GITHUB_MCP_TOKEN
+    internal:
+      transport: streamable-http
+      url: 'http://internal-mcp.default.svc.cluster.local:8000/mcp'
+
+extraEnv:
+  - name: GITHUB_MCP_TOKEN
+    valueFrom:
+      secretKeyRef:
+        name: github-mcp-auth
+        key: token
+```
+
+## Visibility and Reload
+
+```yaml
+hotReload:
+  enabled: true
+
+visibility:
+  mode: allowlist
+  enableTags:
+    - public
+    - approved
+  disableTags:
+    - destructive
 ```
 
 ## Observability
@@ -231,38 +328,99 @@ pdb:
 
 ## Key Values
 
-| Key                          | Default                              | Description                              |
-| ---------------------------- | ------------------------------------ | ---------------------------------------- |
-| `image.repository`           | `docker.io/helmforge/fastmcp-server` | Container image                          |
-| `image.tag`                  | `1.0.0`                              | Image tag                                |
-| `server.name`                | `fastmcp-server`                     | Server name in MCP responses             |
-| `server.port`                | `8000`                               | HTTP port                                |
-| `server.path`                | `/mcp`                               | MCP endpoint path                        |
-| `server.logFormat`           | `text`                               | Log format: `text` or `json`             |
-| `server.strictLoading`       | `false`                              | Fail on boot if component errors         |
-| `ui.enabled`                 | `true`                               | Enable Web UI at `/ui`                   |
-| `metrics.enabled`            | `false`                              | Enable Prometheus metrics at `/metrics`  |
-| `auth.type`                  | `none`                               | Authentication: `none`, `bearer`, `jwt`  |
-| `rateLimiting.default`       | `""`                                 | Default rate limit (e.g., `100/min`)     |
-| `caching.enabled`            | `true`                               | Enable result caching                    |
-| `sandboxing.maxMemoryMb`     | `0`                                  | Default max memory per tool (MB)         |
-| `sandboxing.maxOutputSizeKb` | `0`                                  | Default max output per tool (KB)         |
-| `sources.inline.tools`       | `{}`                                 | Inline Python tool files                 |
-| `sources.inline.knowledge`   | `{}`                                 | Inline knowledge base files              |
-| `sources.s3.enabled`         | `false`                              | Enable S3 source                         |
-| `sources.s3.bucket`          | `""`                                 | S3 bucket name                           |
-| `sources.git.enabled`        | `false`                              | Enable Git source                        |
-| `sources.git.repository`     | `""`                                 | Git repository HTTPS URL                 |
-| `extraPipPackages`           | `[]`                                 | Extra pip packages to install at startup |
-| `initSync.enabled`           | `false`                              | Run source sync as init container        |
-| `persistence.enabled`        | `false`                              | Enable persistent workspace volume       |
-| `autoscaling.enabled`        | `false`                              | Enable HPA                               |
-| `pdb.enabled`                | `false`                              | Enable PodDisruptionBudget               |
-| `ingress.enabled`            | `false`                              | Enable ingress                           |
+| Key                                           | Default                              | Description                                       |
+| --------------------------------------------- | ------------------------------------ | ------------------------------------------------- |
+| `image.repository`                            | `docker.io/helmforge/fastmcp-server` | Container image                                   |
+| `image.tag`                                   | `0.11.0`                             | Image tag                                         |
+| `server.name`                                 | `fastmcp-server`                     | Server name in MCP responses                      |
+| `server.version`                              | `""`                                 | Server version env; empty uses chart appVersion   |
+| `server.environment`                          | `dev`                                | Runtime environment (`MCP_ENV`)                   |
+| `server.host`                                 | `0.0.0.0`                            | Bind host                                         |
+| `server.port`                                 | `8000`                               | HTTP port                                         |
+| `server.path`                                 | `/mcp`                               | MCP endpoint path                                 |
+| `server.workspace`                            | `/app/workspace`                     | Runtime source workspace                          |
+| `server.logFormat`                            | `text`                               | Log format: `text` or `json`                      |
+| `server.strictLoading`                        | `false`                              | Fail on boot if component errors                  |
+| `server.maskErrorDetails`                     | `""`                                 | Override runtime error masking behavior           |
+| `server.onDuplicateTools`                     | `error`                              | Duplicate tool policy: `error`, `warn`, `replace` |
+| `server.corsAllowedOrigins`                   | `[]`                                 | Allowed CORS origins                              |
+| `server.maxSourceFileSizeBytes`               | `1048576`                            | Max source file size                              |
+| `server.maxKnowledgeBytes`                    | `10485760`                           | Max knowledge file size                           |
+| `server.allowedKnowledgeExtensions`           | `[".md", ".txt"]`                    | Knowledge file extensions                         |
+| `server.strategy.type`                        | `Recreate`                           | Deployment strategy                               |
+| `server.revisionHistoryLimit`                 | `10`                                 | Deployment revision history                       |
+| `ui.enabled`                                  | `true`                               | Enable Web UI at `/ui`                            |
+| `metrics.enabled`                             | `false`                              | Enable Prometheus metrics at `/metrics`           |
+| `metrics.serviceMonitor.enabled`              | `false`                              | Create ServiceMonitor when metrics are enabled    |
+| `auth.type`                                   | `none`                               | Authentication: `none`, `bearer`, `jwt`, `multi`  |
+| `auth.allowNoAuth`                            | `false`                              | Explicitly allow no-auth production deployments   |
+| `auth.bearer.token`                           | `""`                                 | Bearer token secret value                         |
+| `auth.bearer.existingSecret`                  | `""`                                 | Existing bearer token secret                      |
+| `auth.jwt.issuer`                             | `""`                                 | JWT issuer                                        |
+| `auth.jwt.audience`                           | `""`                                 | JWT audience                                      |
+| `auth.jwt.jwksUri`                            | `""`                                 | JWT JWKS URI                                      |
+| `auth.jwt.algorithm`                          | `RS256`                              | JWT verification algorithm                        |
+| `auth.jwt.publicKeyExistingSecret`            | `""`                                 | Existing JWT public key secret                    |
+| `auth.scopes`                                 | `[]`                                 | Advertised auth scopes                            |
+| `auth.requiredScopes`                         | `[]`                                 | Required request scopes                           |
+| `auth.clientId`                               | `""`                                 | OAuth client identifier                           |
+| `auth.providers`                              | `[]`                                 | Providers used by `multi` auth                    |
+| `auth.reloadRequiredScopes`                   | `[]`                                 | Scopes required for reload operations             |
+| `auth.requireHumanApprovalForDestructive`     | `true`                               | Require approval metadata for destructive tools   |
+| `rateLimiting.default`                        | `""`                                 | Default rate limit (e.g., `100/min`)              |
+| `caching.enabled`                             | `true`                               | Enable result caching                             |
+| `sandboxing.maxMemoryMb`                      | `0`                                  | Default max memory per tool (MB)                  |
+| `sandboxing.maxOutputSizeKb`                  | `0`                                  | Default max output per tool (KB)                  |
+| `sources.blockedFileAllowlist`                | `[]`                                 | Explicit allowlist for blocked file names         |
+| `sources.inline.dir`                          | `/workspace/inline`                  | Inline ConfigMap mount directory                  |
+| `sources.inline.tools`                        | `{}`                                 | Inline Python tool files                          |
+| `sources.inline.resources`                    | `{}`                                 | Inline resource files                             |
+| `sources.inline.prompts`                      | `{}`                                 | Inline prompt files                               |
+| `sources.inline.knowledge`                    | `{}`                                 | Inline knowledge base files                       |
+| `sources.s3.enabled`                          | `false`                              | Enable S3 source                                  |
+| `sources.s3.bucket`                           | `""`                                 | S3 bucket name                                    |
+| `sources.s3.include`                          | `[]`                                 | S3 include glob patterns                          |
+| `sources.s3.exclude`                          | `[]`                                 | S3 exclude glob patterns                          |
+| `sources.s3.syncInterval`                     | `0`                                  | S3 polling interval in seconds                    |
+| `sources.git.enabled`                         | `false`                              | Enable Git source                                 |
+| `sources.git.repository`                      | `""`                                 | Git repository HTTPS URL                          |
+| `sources.git.username`                        | `""`                                 | Optional Git username                             |
+| `sources.git.allowedRepositories`             | `[]`                                 | Allowed Git repository URLs                       |
+| `sources.git.allowedBranches`                 | `[]`                                 | Allowed Git branches                              |
+| `sources.git.include`                         | `[]`                                 | Git include glob patterns                         |
+| `sources.git.exclude`                         | `[]`                                 | Git exclude glob patterns                         |
+| `sources.git.syncInterval`                    | `0`                                  | Git polling interval in seconds                   |
+| `sources.oci.enabled`                         | `false`                              | Enable OCI artifact source                        |
+| `sources.oci.registry`                        | `""`                                 | OCI artifact reference                            |
+| `sources.oci.tag`                             | `""`                                 | OCI artifact tag; empty lets runtime decide       |
+| `sources.oci.existingSecret`                  | `""`                                 | Existing OCI registry credential secret           |
+| `sources.oci.include`                         | `[]`                                 | OCI include glob patterns                         |
+| `sources.oci.exclude`                         | `[]`                                 | OCI exclude glob patterns                         |
+| `hotReload.enabled`                           | `false`                              | Enable filesystem hot reload                      |
+| `gateway.enabled`                             | `false`                              | Run server in gateway mode                        |
+| `gateway.mountServers`                        | `{}`                                 | Gateway mount server map                          |
+| `gateway.rawMountServersJson`                 | `""`                                 | Raw `MCP_MOUNT_SERVERS` JSON override             |
+| `visibility.mode`                             | `blocklist`                          | Tool visibility mode                              |
+| `visibility.enableTags`                       | `[]`                                 | Allowlisted tags                                  |
+| `visibility.disableTags`                      | `[]`                                 | Hidden tags                                       |
+| `extraPipPackages`                            | `[]`                                 | Extra pip packages to install at startup          |
+| `initSync.enabled`                            | `false`                              | Run source sync as init container                 |
+| `persistence.enabled`                         | `false`                              | Enable persistent workspace volume                |
+| `serviceAccount.create`                       | `true`                               | Create a dedicated Kubernetes ServiceAccount      |
+| `serviceAccount.automountServiceAccountToken` | `false`                              | Automount Kubernetes API token                    |
+| `networkPolicy.enabled`                       | `false`                              | Create NetworkPolicy                              |
+| `networkPolicy.ingress`                       | `[]`                                 | Custom ingress rules; empty uses service port     |
+| `networkPolicy.egress`                        | `[]`                                 | Custom egress rules; empty allows outbound sync   |
+| `autoscaling.enabled`                         | `false`                              | Enable HPA                                        |
+| `pdb.enabled`                                 | `false`                              | Enable PodDisruptionBudget                        |
+| `ingress.enabled`                             | `false`                              | Enable ingress                                    |
 
 ## Operational Notes
 
-- Merge precedence is Inline > S3 > Git — if a tool with the same filename exists in multiple sources, the highest-precedence version wins
+- Merge precedence is Inline > S3 > Git > OCI — if a tool with the same filename exists in multiple sources, the highest-precedence version wins
+- Production-like environments require an auth mode unless `auth.allowNoAuth=true` is set explicitly
+- `ServiceMonitor` requires `metrics.enabled=true`
+- Gateway mode requires either `gateway.mountServers` or `gateway.rawMountServersJson`
 - Knowledge base files are served as MCP resources at `knowledge://{filename}` URIs
 - Tools are Python files with top-level functions; resources need a `RESOURCE_URI` or `RESOURCES` module-level variable
 - Tools support optional metadata: `__tags__` (set), `__timeout__` (float), `__annotations_mcp__` (dict)
@@ -270,8 +428,10 @@ pdb:
 - The `extraPipPackages` list installs before tools load — use it when tools import external libraries
 - The Web UI auto-refreshes every 15 seconds and requires no external dependencies
 - Init container pattern (`initSync.enabled`) separates source syncing from server startup for better Kubernetes readiness semantics
+- Default readiness requires at least one loaded tool, resource, prompt, or knowledge file
 
 ## More Information
 
-- [Docker image source](https://github.com/helmforgedev/fastmcp-server)
+- [FastMCP Server source](https://github.com/helmforgedev/fastmcp-server)
+- [FastMCP upstream project](https://github.com/jlowin/fastmcp)
 - [Chart source and full values reference](https://github.com/helmforgedev/charts/tree/main/charts/fastmcp-server)


### PR DESCRIPTION
Related to #111

## Summary
- Updates the FastMCP Server chart documentation page with the expanded values surface and runtime capabilities.
- Documents inline/S3/Git/OCI sources, multi-auth, JWT/scopes, gateway mode, visibility controls, reload/hot reload, security defaults, and operations notes.
- Adds official upstream links for FastMCP Server and FastMCP.
- Formats the site with Prettier and adds `.gitattributes` to keep text files on LF.

## Validation
- Branch rebased after updating `main`.
- `npm run format`: completed
- `npm run format:check`: passed
- `npm run lint`: passed
- `npm run build`: passed
- MCP HelmForge `check_site_sync`: passed for defaults and architecture
- MCP HelmForge `validate_compliance`: 26/27 passed, 0 blockers

## Related
- Companion chart PR: https://github.com/helmforgedev/charts/pull/112