### PR TITLE
docs(cncf): align site with Apache licensing

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,21 +1,55 @@
-MIT License
+Apache License
+Version 2.0, January 2004
+https://www.apache.org/licenses/
 
-Copyright (c) 2026 HelmForge
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
+1. Definitions.
 
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
+"License" shall mean the terms and conditions for use, reproduction, and distribution as defined by Sections 1 through 9 of this document.
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
+"Licensor" shall mean the copyright owner or entity authorized by the copyright owner that is granting the License.
+
+"Legal Entity" shall mean the union of the acting entity and all other entities that control, are controlled by, or are under common control with that entity. For the purposes of this definition, "control" means (i) the power, direct or indirect, to cause the direction or management of such entity, whether by contract or otherwise, or (ii) ownership of fifty percent (50%) or more of the outstanding shares, or (iii) beneficial ownership of such entity.
+
+"You" (or "Your") shall mean an individual or Legal Entity exercising permissions granted by this License.
+
+"Source" form shall mean the preferred form for making modifications, including but not limited to software source code, documentation source, and configuration files.
+
+"Object" form shall mean any form resulting from mechanical transformation or translation of a Source form, including but not limited to compiled object code, generated documentation, and conversions to other media types.
+
+"Work" shall mean the work of authorship, whether in Source or Object form, made available under the License, as indicated by a copyright notice that is included in or attached to the work.
+
+"Derivative Works" shall mean any work, whether in Source or Object form, that is based on or derived from the Work and for which the editorial revisions, annotations, elaborations, or other modifications represent, as a whole, an original work of authorship. For the purposes of this License, Derivative Works shall not include works that remain separable from, or merely link or bind by name to the interfaces of, the Work and Derivative Works thereof.
+
+"Contribution" shall mean any work of authorship, including the original version of the Work and any modifications or additions to that Work or Derivative Works thereof, that is intentionally submitted to Licensor for inclusion in the Work by the copyright owner or by an individual or Legal Entity authorized to submit on behalf of the copyright owner. For the purposes of this definition, "submitted" means any form of electronic, verbal, or written communication sent to the Licensor or its representatives, including but not limited to communication on electronic mailing lists, source code control systems, and issue tracking systems that are managed by, or on behalf of, the Licensor for the purpose of discussing and improving the Work, but excluding communication that is conspicuously marked or otherwise designated in writing by the copyright owner as "Not a Contribution."
+
+"Contributor" shall mean Licensor and any individual or Legal Entity on behalf of whom a Contribution has been received by Licensor and subsequently incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of this License, each Contributor hereby grants You a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable copyright license to reproduce, prepare Derivative Works of, publicly display, publicly perform, sublicense, and distribute the Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of this License, each Contributor hereby grants You a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable patent license to make, have made, use, offer to sell, sell, import, and otherwise transfer the Work, where such license applies only to those patent claims licensable by such Contributor that are necessarily infringed by their Contribution alone or by combination of their Contribution with the Work to which such Contribution was submitted. If You institute patent litigation against any entity, including a cross-claim or counterclaim in a lawsuit, alleging that the Work or a Contribution incorporated within the Work constitutes direct or contributory patent infringement, then any patent licenses granted to You under this License for that Work shall terminate as of the date such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the Work or Derivative Works thereof in any medium, with or without modifications, and in Source or Object form, provided that You meet the following conditions:
+
+(a) You must give any other recipients of the Work or Derivative Works a copy of this License; and
+
+(b) You must cause any modified files to carry prominent notices stating that You changed the files; and
+
+(c) You must retain, in the Source form of any Derivative Works that You distribute, all copyright, patent, trademark, and attribution notices from the Source form of the Work, excluding those notices that do not pertain to any part of the Derivative Works; and
+
+(d) If the Work includes a "NOTICE" text file as part of its distribution, then any Derivative Works that You distribute must include a readable copy of the attribution notices contained within such NOTICE file, excluding those notices that do not pertain to any part of the Derivative Works, in at least one of the following places: within a NOTICE text file distributed as part of the Derivative Works; within the Source form or documentation, if provided along with the Derivative Works; or within a display generated by the Derivative Works, if and wherever such third-party notices normally appear. The contents of the NOTICE file are for informational purposes only and do not modify the License. You may add Your own attribution notices within Derivative Works that You distribute, alongside or as an addendum to the NOTICE text from the Work, provided that such additional attribution notices cannot be construed as modifying the License.
+
+You may add Your own copyright statement to Your modifications and may provide additional or different license terms and conditions for use, reproduction, or distribution of Your modifications, or for any such Derivative Works as a whole, provided Your use, reproduction, and distribution of the Work otherwise complies with the conditions stated in this License.
+
+5. Submission of Contributions. Unless You explicitly state otherwise, any Contribution intentionally submitted for inclusion in the Work by You to the Licensor shall be under the terms and conditions of this License, without any additional terms or conditions. Notwithstanding the above, nothing herein shall supersede or modify the terms of any separate license agreement you may have executed with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade names, trademarks, service marks, or product names of the Licensor, except as required for reasonable and customary use in describing the origin of the Work and reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or agreed to in writing, Licensor provides the Work on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied, including, without limitation, any warranties or conditions of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A PARTICULAR PURPOSE. You are solely responsible for determining the appropriateness of using or redistributing the Work and assume any risks associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory, whether in tort, including negligence, contract, or otherwise, unless required by applicable law, such as deliberate and grossly negligent acts, or agreed to in writing, shall any Contributor be liable to You for damages, including any direct, indirect, special, incidental, or consequential damages of any character arising as a result of this License or out of the use or inability to use the Work, including but not limited to damages for loss of goodwill, work stoppage, computer failure or malfunction, or any and all other commercial damages or losses, even if such Contributor has been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing the Work or Derivative Works thereof, You may choose to offer, and charge a fee for, acceptance of support, warranty, indemnity, or other liability obligations and rights consistent with this License. However, in accepting such obligations, You may act only on Your own behalf and on Your sole responsibility, not on behalf of any other Contributor, and only if You agree to indemnify, defend, and hold each Contributor harmless for any liability incurred by, or claims asserted against, such Contributor by reason of your accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
   <p>
     <a href="https://github.com/helmforgedev/site/actions/workflows/ci.yml"><img src="https://github.com/helmforgedev/site/actions/workflows/ci.yml/badge.svg" alt="CI" /></a>
     <a href="https://github.com/helmforgedev/site/actions/workflows/deploy.yml"><img src="https://github.com/helmforgedev/site/actions/workflows/deploy.yml/badge.svg" alt="Deploy" /></a>
-    <a href="https://opensource.org/licenses/MIT"><img src="https://img.shields.io/badge/License-MIT-blue.svg" alt="License: MIT" /></a>
+    <a href="https://www.apache.org/licenses/LICENSE-2.0"><img src="https://img.shields.io/badge/License-Apache--2.0-blue.svg" alt="License: Apache-2.0" /></a>
     <a href="CONTRIBUTING.md"><img src="https://img.shields.io/badge/PRs-welcome-brightgreen" alt="PRs Welcome" /></a>
   </p>
 
@@ -136,4 +136,4 @@ npx playwright install --with-deps chromium firefox webkit
 
 ## License
 
-This project is licensed under the [MIT License](LICENSE).
+This project is licensed under the [Apache License 2.0](LICENSE).

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "helmforge-site",
       "version": "1.0.0",
+      "license": "Apache-2.0",
       "dependencies": {
         "@astrojs/mdx": "^5.0.3",
         "@astrojs/rss": "^4.0.18",

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "helmforge-site",
   "type": "module",
   "version": "1.0.0",
+  "license": "Apache-2.0",
   "engines": {
     "node": ">=22.0.0"
   },

--- a/src/components/ComparisonTable.astro
+++ b/src/components/ComparisonTable.astro
@@ -19,7 +19,7 @@ import { comparisonFull } from '../data/comparison';
         HelmForge vs Bitnami — feature by feature.
       </h2>
       <p class="mt-5 text-lg text-text-muted leading-relaxed">
-        Official upstream images, MIT licensed, zero vendor lock-in. See exactly why teams switch from Bitnami to
+        Official upstream images, Apache-2.0 licensed, zero vendor lock-in. See exactly why teams switch from Bitnami to
         HelmForge.
       </p>
     </div>

--- a/src/components/Features.astro
+++ b/src/components/Features.astro
@@ -42,7 +42,7 @@ const features = [
   },
   {
     icon: `<svg class="w-7 h-7" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M3 6l3 1m0 0l-3 9a5.002 5.002 0 006.001 0M6 7l3 9M6 7l6-2m6 2l3-1m-3 1l-3 9a5.002 5.002 0 006.001 0M18 7l3 9m-3-9l-6-2m0-2v2m0 16V5m0 16H9m3 0h3" /></svg>`,
-    title: 'MIT Licensed',
+    title: 'Apache-2.0 Licensed',
     stat: 'Free forever',
     description: 'Use in production, modify, redistribute. No enterprise tiers, no usage limits, no surprises.',
     snippet: null,

--- a/src/components/Hero.astro
+++ b/src/components/Hero.astro
@@ -44,7 +44,7 @@ import { chartCount, stableCount } from '../data/charts';
 
       <p class="mt-6 text-lg text-text-muted leading-relaxed max-w-2xl mx-auto lg:mx-0">
         The open-source alternative to Bitnami. Official upstream images, built-in S3 backups, sane security defaults,
-        and day-two operations — MIT licensed, free forever.
+        and day-two operations — Apache-2.0 licensed, free forever.
       </p>
 
       <div class="mt-10 flex flex-col sm:flex-row items-center gap-4 justify-center lg:justify-start">
@@ -83,7 +83,7 @@ import { chartCount, stableCount } from '../data/charts';
               stroke-width="2"
               d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"></path></svg
           >
-          MIT Licensed
+          Apache-2.0 Licensed
         </span>
         <span class="inline-flex items-center gap-1.5">
           <svg class="w-4 h-4 text-blue-400" fill="none" stroke="currentColor" viewBox="0 0 24 24"

--- a/src/content/blog/helmforge-vs-bitnami.mdx
+++ b/src/content/blog/helmforge-vs-bitnami.mdx
@@ -29,7 +29,7 @@ The biggest difference between HelmForge and Bitnami is what runs inside your po
 
 ## Licensing
 
-HelmForge charts are MIT licensed. The chart code, templates, documentation — everything is MIT with no exceptions.
+HelmForge charts are Apache-2.0 licensed. The chart code, templates, documentation — everything is Apache-2.0.
 
 Bitnami charts are Apache 2.0 licensed, which is also permissive. However, some Bitnami images include components with different licensing terms, and the dependency on Bitnami's image infrastructure creates a soft vendor lock-in.
 
@@ -55,7 +55,7 @@ Bitnami charts do not include backup functionality. You need to build your own b
 
 - You want official upstream images with no modifications
 - You need built-in backup for databases and stateful apps
-- You prefer MIT licensing with no vendor dependency
+- You prefer Apache-2.0 licensing with no vendor dependency
 - You value security defaults (non-root, read-only FS)
 
 **Choose Bitnami when:**

--- a/src/content/blog/introducing-helmforge.mdx
+++ b/src/content/blog/introducing-helmforge.mdx
@@ -51,4 +51,4 @@ Since our first release, HelmForge has grown to over 30 stable charts covering d
 
 We are actively building more charts based on community requests. If there is an application you want to see in HelmForge, [request it](/request) and the community votes on priorities.
 
-HelmForge is MIT licensed and always will be. Check out the [getting started guide](/docs/getting-started) or browse the [chart catalog](/) to find what you need.
+HelmForge is Apache-2.0 licensed and always will be. Check out the [getting started guide](/docs/getting-started) or browse the [chart catalog](/) to find what you need.

--- a/src/data/comparison.ts
+++ b/src/data/comparison.ts
@@ -23,7 +23,7 @@ export const comparisonFull: ComparisonRow[] = [
   },
   {
     aspect: 'License',
-    helmforge: 'MIT — forever open source',
+    helmforge: 'Apache-2.0 — CNCF-aligned open source',
     bitnami: 'Apache 2.0 charts; images under EULA',
     community: 'Varies',
     highlight: true,
@@ -107,7 +107,7 @@ export const comparisonSummary: ComparisonSummaryRow[] = [
     feature: 'License',
     generic: 'Varies (some restrictive)',
     bitnami: 'Proprietary for production secure images',
-    helmforge: 'MIT — open source',
+    helmforge: 'Apache-2.0 — open source',
   },
   {
     feature: 'Pricing / Tiering',

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -66,7 +66,7 @@ const websiteJsonLd = isHomepage
       '@type': 'WebSite',
       name: 'HelmForge',
       url: 'https://helmforge.dev',
-      description: `Production-ready Helm charts for Kubernetes. ${chartCount}+ open-source charts, MIT licensed, built-in S3 backup — the free alternative to Bitnami.`,
+      description: `Production-ready Helm charts for Kubernetes. ${chartCount}+ open-source charts, Apache-2.0 licensed, built-in S3 backup — the free alternative to Bitnami.`,
       potentialAction: {
         '@type': 'SearchAction',
         target: {

--- a/src/pages/charts.astro
+++ b/src/pages/charts.astro
@@ -7,7 +7,7 @@ import Footer from '../components/Footer.astro';
 
 <BaseLayout
   title="Charts"
-  description="Browse all HelmForge Helm charts — production-ready, MIT licensed, built on official upstream images."
+  description="Browse all HelmForge Helm charts — production-ready, Apache-2.0 licensed, built on official upstream images."
 >
   <Header />
   <main id="main-content">

--- a/src/pages/community.astro
+++ b/src/pages/community.astro
@@ -80,7 +80,7 @@ const iconPaths: Record<string, string> = {
 };
 
 const governance = [
-  { label: 'License', value: 'MIT', description: 'All charts are open-source under the MIT license.' },
+  { label: 'License', value: 'Apache-2.0', description: 'All charts are open-source under the Apache-2.0 license.' },
   {
     label: 'Versioning',
     value: 'SemVer',

--- a/src/pages/docs/comparison.mdx
+++ b/src/pages/docs/comparison.mdx
@@ -1,7 +1,7 @@
 ---
 layout: ../../layouts/DocsLayout.astro
 title: HelmForge vs Bitnami — Open-Source Helm Chart Alternative
-description: HelmForge is the MIT-licensed Bitnami alternative for Kubernetes. Official upstream images, built-in S3 backup, pinned tags, and zero vendor lock-in. Full feature comparison with Bitnami and generic community charts.
+description: HelmForge is the Apache-2.0-licensed Bitnami alternative for Kubernetes. Official upstream images, built-in S3 backup, pinned tags, and zero vendor lock-in. Full feature comparison with Bitnami and generic community charts.
 ---
 
 import { chartCount, backupCount } from '../../data/charts';
@@ -76,7 +76,7 @@ This page compares HelmForge against two common alternatives: **Bitnami** (the l
               >
                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7" />
               </svg>{' '}
-              MIT — forever open source
+              Apache-2.0 — CNCF-aligned open source
             </span>
           </td>
           <td class="px-5 py-3.5 text-text-muted leading-relaxed !border-0">Apache 2.0 charts; images under EULA</td>
@@ -327,7 +327,7 @@ image:
 
 ## Licensing and Business Model
 
-HelmForge is MIT licensed — charts, CI, documentation, everything. This will not change.
+HelmForge is Apache-2.0 licensed — charts, CI, documentation, everything. This aligns HelmForge with CNCF project licensing expectations.
 
 Bitnami charts are Apache 2.0, but the **container images** are under a separate [Bitnami EULA](https://www.vmware.com/agreements/bitnami) that introduced usage limits. The free tier has restrictions on pulls and commercial use. Enterprise usage requires a paid subscription.
 
@@ -339,7 +339,7 @@ In practice, this means Bitnami's open-source image path is a dead end. Users wh
 
 Generic community charts have no consistent licensing. Some are MIT, some are unlicensed, some change terms without notice.
 
-**For operators:** MIT means no license audits, no usage tracking, no surprise terms changes. You use it, modify it, redistribute it — commercially or otherwise.
+**For operators:** Apache-2.0 means a permissive, well-understood open-source license with explicit patent terms and no usage tracking.
 
 ## Built-in S3 Backup
 
@@ -432,7 +432,7 @@ helm verify <chart-name>-<version>.tgz --keyring pgp-public-key.asc
 
 - You want official upstream images without proprietary layers
 - You need built-in backup without extra tooling
-- You prefer MIT licensing with no usage restrictions
+- You prefer Apache-2.0 licensing with no usage restrictions
 - You value supply chain signing and schema validation
 
 **Choose Bitnami when:**

--- a/src/pages/docs/faq.mdx
+++ b/src/pages/docs/faq.mdx
@@ -79,7 +79,7 @@ import Callout from '../../components/Callout.astro';
       "name": "What license are HelmForge charts under?",
       "acceptedAnswer": {
         "@type": "Answer",
-        "text": "All HelmForge charts are released under the MIT License. You can use them freely in personal and commercial projects with no usage restrictions, no license audits, and no surprise terms changes."
+        "text": "All HelmForge charts are released under the Apache License 2.0. You can use them freely in personal and commercial projects with no usage restrictions, no license audits, and no surprise terms changes."
       }
     },
     {
@@ -429,6 +429,6 @@ Yes. HelmForge uses dual signing: GPG provenance files for `helm verify` and [Si
 <details>
 <summary>What license are the charts under?</summary>
 
-All HelmForge charts are released under the **MIT License**. You can use them freely in personal and commercial projects.
+All HelmForge charts are released under the **Apache License 2.0**. You can use them freely in personal and commercial projects.
 
 </details>

--- a/src/pages/docs/index.mdx
+++ b/src/pages/docs/index.mdx
@@ -37,11 +37,11 @@ For years, the Kubernetes ecosystem relied heavily on tools like Bitnami for get
 
 However, following the Broadcom acquisition, the landscape drastically shifted. The open-source community discovered that Bitnami's free offerings were relegated to "legacy images" (with official warnings stating: _"This repository is no longer updated. Please note that this repository may be removed"_). For long-term enterprise support and production workloads, users are now gated behind proprietary "Bitnami Secure Images" that require you to _"Contact sales"_.
 
-HelmForge was born out of necessity to fill this gaping void. We believe DevOps engineers should not have their infrastructure held hostage by sudden paywalls or confusing licensing changes. HelmForge provides an alternative that is **100% Free Forever**, explicitly open-source under the MIT license, and built to 'just work' out of the box.
+HelmForge was born out of necessity to fill this gaping void. We believe DevOps engineers should not have their infrastructure held hostage by sudden paywalls or confusing licensing changes. HelmForge provides an alternative that is **100% Free Forever**, explicitly open-source under the Apache-2.0 license, and built to 'just work' out of the box.
 
 ## Core Philosophy
 
-- **Zero Lock-in:** 100% open-source (MIT License) and built on standard upstream images.
+- **Zero Lock-in:** 100% open-source (Apache License 2.0) and built on standard upstream images.
 - **Production Defaults:** TLS configurations, non-root constraints, ResourceQuotas, and metrics are ready inside every chart.
 - **Built-in S3 Backups:** We treat Day-2 operations as primary. Our charts contain integrated Kubernetes CronJobs that backup directly to any S3-compatible storage.
 

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -13,7 +13,7 @@ import { chartCount } from '../data/charts';
 
 <BaseLayout
   title="HelmForge — Open-Source Helm Charts for Kubernetes"
-  description={`HelmForge — ${chartCount}+ production-ready Helm charts for Kubernetes. The open-source, MIT-licensed alternative to Bitnami. Official images, built-in S3 backup, non-root security, zero vendor lock-in. Free forever.`}
+  description={`HelmForge — ${chartCount}+ production-ready Helm charts for Kubernetes. The open-source, Apache-2.0-licensed alternative to Bitnami. Official images, built-in S3 backup, non-root security, zero vendor lock-in. Free forever.`}
 >
   <Header />
   <main id="main-content">


### PR DESCRIPTION
## Summary
- Updates public HelmForge positioning and copy for CNCF Sandbox readiness.
- Aligns site metadata and license references with Apache-2.0.
- Refreshes community, docs, comparison, and homepage content around the project model.

## Validation
- [x] `npm run lint`
- [x] `npm run build`

## Context
Prepared as part of HelmForge CNCF Sandbox readiness work.