### PR TITLE
feat(blog): enforce mandatory hero images

### DIFF
--- a/e2e/blog.spec.ts
+++ b/e2e/blog.spec.ts
@@ -86,6 +86,8 @@ test.describe('Blog', () => {
     const hero = page.locator('figure img[src*="/blog/"][src$=".webp"]').first();
     await expect(hero).toBeVisible();
     await expect(hero).toHaveAttribute('alt', /Kubernetes 1\.34/i);
+    await expect(hero).toHaveAttribute('width', '1600');
+    await expect(hero).toHaveAttribute('height', '900');
   });
 
   test('blog post renders author card with social links', async ({ page }) => {

--- a/scripts/validate-blog-standards.mjs
+++ b/scripts/validate-blog-standards.mjs
@@ -53,8 +53,22 @@ function getFrontmatterTags(frontmatter) {
   }
   return match[1]
     .split(',')
-    .map((t) => t.trim().replace(/^['"]|['"]$/g, '').toLowerCase())
+    .map((t) =>
+      t
+        .trim()
+        .replace(/^['"]|['"]$/g, '')
+        .toLowerCase(),
+    )
     .filter(Boolean);
+}
+
+function getSignificantSlugTokens(filePath) {
+  const stopWords = new Set(['a', 'an', 'and', 'for', 'in', 'on', 'the', 'to', 'vs', 'with']);
+  return path
+    .basename(filePath, path.extname(filePath))
+    .toLowerCase()
+    .split(/[^a-z0-9]+/)
+    .filter((token) => token.length >= 3 && !stopWords.has(token));
 }
 
 function getAllowedAuthorIds() {
@@ -138,22 +152,50 @@ function validateReferencesSection(body, filePath, errors) {
   }
 }
 
-function validateCoverImage(frontmatter, filePath, errors) {
+function validateCoverImage(frontmatter, filePath, errors, warnings, seenCoverImages) {
   const coverImage = getFrontmatterScalar(frontmatter, 'coverImage');
   const coverAlt = getFrontmatterScalar(frontmatter, 'coverAlt');
+  const publishDate = getFrontmatterScalar(frontmatter, 'publishDate') ?? getFrontmatterScalar(frontmatter, 'date');
 
   if (!coverImage) {
+    errors.push(`${filePath}: coverImage is required for discovery-ready blog posts`);
+  }
+  if (!coverAlt) {
+    errors.push(`${filePath}: coverAlt is required for discovery-ready blog posts`);
+  }
+  if (!coverImage || !coverAlt) {
     return;
   }
 
+  if (coverImage === '/og-default.png') {
+    errors.push(`${filePath}: coverImage must be a post-specific hero image, not /og-default.png`);
+  }
   if (!coverImage.startsWith('/blog/')) {
     errors.push(`${filePath}: coverImage must be under /blog/`);
   }
   if (!coverImage.endsWith('-hero.webp')) {
     errors.push(`${filePath}: coverImage must end with -hero.webp`);
   }
-  if (!coverAlt || coverAlt.length < 12) {
-    errors.push(`${filePath}: coverAlt is required and must be descriptive`);
+  if (coverAlt.length < 24) {
+    errors.push(`${filePath}: coverAlt must be descriptive and at least 24 characters`);
+  }
+  if (/^(hero|image|preview|blog image|cover image|thumbnail)$/i.test(coverAlt.trim())) {
+    errors.push(`${filePath}: coverAlt is too generic`);
+  }
+  if (seenCoverImages.has(coverImage)) {
+    errors.push(`${filePath}: coverImage duplicates ${seenCoverImages.get(coverImage)}`);
+  } else {
+    seenCoverImages.set(coverImage, filePath);
+  }
+
+  const coverFileName = path.basename(coverImage).toLowerCase();
+  if (publishDate && !coverFileName.includes(publishDate.slice(0, 10))) {
+    errors.push(`${filePath}: coverImage filename must include the publish date (${publishDate.slice(0, 10)})`);
+  }
+
+  const slugTokenMatches = getSignificantSlugTokens(filePath).filter((token) => coverFileName.includes(token));
+  if (slugTokenMatches.length < 2) {
+    errors.push(`${filePath}: coverImage filename must be descriptive and include at least two post topic tokens`);
   }
 
   const imagePath = path.join(PUBLIC_DIR, coverImage.replace(/^\//, ''));
@@ -167,6 +209,16 @@ function validateCoverImage(frontmatter, filePath, errors) {
     const ratio = dimensions.width / dimensions.height;
     const expected = 16 / 9;
     const delta = Math.abs(ratio - expected);
+    if (dimensions.width < 1200) {
+      errors.push(
+        `${filePath}: coverImage must be at least 1200px wide. Current ${dimensions.width}x${dimensions.height}`,
+      );
+    }
+    if (dimensions.width !== 1600 || dimensions.height !== 900) {
+      warnings.push(
+        `${filePath}: recommended coverImage size is 1600x900. Current ${dimensions.width}x${dimensions.height}`,
+      );
+    }
     if (delta > 0.03) {
       errors.push(
         `${filePath}: coverImage must be near 16:9. Current ${dimensions.width}x${dimensions.height} (${ratio.toFixed(3)})`,
@@ -198,9 +250,8 @@ function validateTechnicalVisual(tags, body, filePath, errors) {
   }
 
   const hasImage = /!\[[^\]]*\]\([^)]+\)/.test(body);
-  const hasDiagramComponent = /<ArchitectureDiagram\b|<PostgresqlDiagram\b|<MysqlDiagram\b|<RedisDiagram\b|<KeycloakDiagram\b/.test(
-    body,
-  );
+  const hasDiagramComponent =
+    /<ArchitectureDiagram\b|<PostgresqlDiagram\b|<MysqlDiagram\b|<RedisDiagram\b|<KeycloakDiagram\b/.test(body);
 
   if (!hasImage && !hasDiagramComponent) {
     errors.push(`${filePath}: technical tutorial/incident post must include at least one explanatory image or diagram`);
@@ -211,6 +262,8 @@ function main() {
   const allowedAuthorIds = getAllowedAuthorIds();
   const files = fs.readdirSync(BLOG_DIR).filter((file) => file.endsWith('.md') || file.endsWith('.mdx'));
   const errors = [];
+  const warnings = [];
+  const seenCoverImages = new Map();
 
   for (const fileName of files) {
     const fullPath = path.join(BLOG_DIR, fileName);
@@ -219,7 +272,7 @@ function main() {
     const tags = getFrontmatterTags(frontmatter);
 
     validateAuthorId(frontmatter, fullPath, allowedAuthorIds, errors);
-    validateCoverImage(frontmatter, fullPath, errors);
+    validateCoverImage(frontmatter, fullPath, errors, warnings, seenCoverImages);
     validateTechnicalVisual(tags, body, fullPath, errors);
     validateReferencesSection(body, fullPath, errors);
   }
@@ -230,6 +283,13 @@ function main() {
       console.error(`- ${error}`);
     }
     process.exit(1);
+  }
+
+  if (warnings.length > 0) {
+    console.warn('Blog standards validation warnings:\n');
+    for (const warning of warnings) {
+      console.warn(`- ${warning}`);
+    }
   }
 
   console.log(`Blog standards validation passed for ${files.length} post(s).`);

--- a/src/components/BlogHero.astro
+++ b/src/components/BlogHero.astro
@@ -2,13 +2,22 @@
 interface Props {
   src: string;
   alt: string;
+  width?: number;
+  height?: number;
   caption?: string;
 }
 
-const { src, alt, caption } = Astro.props;
+const { src, alt, width = 1600, height = 900, caption } = Astro.props;
 ---
 
 <figure class="mb-8">
-  <img src={src} alt={alt} loading="eager" class="w-full rounded-2xl border border-border object-cover aspect-[16/9]" />
+  <img
+    src={src}
+    alt={alt}
+    width={width}
+    height={height}
+    loading="eager"
+    class="w-full rounded-2xl border border-border object-cover aspect-[16/9]"
+  />
   {caption && <figcaption class="mt-2 text-sm text-text-muted">{caption}</figcaption>}
 </figure>

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -15,8 +15,8 @@ const blog = defineCollection({
     authorId: z.enum(AUTHOR_IDS),
     tags: z.array(z.string()).default([]),
     image: z.string().optional(),
-    coverImage: z.string().optional(),
-    coverAlt: z.string().optional(),
+    coverImage: z.string().min(1),
+    coverAlt: z.string().min(24),
     schemaType: z.enum(['Article', 'BlogPosting', 'NewsArticle']).default('BlogPosting'),
   }),
 });

--- a/src/layouts/BlogLayout.astro
+++ b/src/layouts/BlogLayout.astro
@@ -18,8 +18,8 @@ interface Props {
   tags: string[];
   readingTime: number;
   postSlug: string;
-  coverImage?: string;
-  coverAlt?: string;
+  coverImage: string;
+  coverAlt: string;
   schemaType?: ArticleSchemaType;
 }
 
@@ -47,7 +47,7 @@ const formattedDate = publishedDate.toLocaleDateString('en-US', {
 const canonicalUrl = `https://helmforge.dev/blog/${postSlug}`;
 const modifiedDate = updatedAt ?? publishedDate;
 const articleSection = tags[0] ?? 'Blog';
-const articleImage = coverImage ? new URL(coverImage, Astro.site).href : undefined;
+const articleImage = new URL(coverImage, Astro.site).href;
 
 const articleJsonLd = {
   '@context': 'https://schema.org',
@@ -64,7 +64,7 @@ const articleJsonLd = {
     url: author.linkedin || author.github || 'https://helmforge.dev',
     sameAs: [author.github, author.linkedin].filter(Boolean),
   },
-  image: articleImage ? [articleImage] : undefined,
+  image: [articleImage],
   mainEntityOfPage: canonicalUrl,
   publisher: {
     '@type': 'Organization',
@@ -84,9 +84,9 @@ const articleJsonLd = {
   title={title}
   description={description}
   image={coverImage}
-  imageAlt={coverAlt ?? title}
-  imageWidth={coverImage ? 1600 : undefined}
-  imageHeight={coverImage ? 900 : undefined}
+  imageAlt={coverAlt}
+  imageWidth={1600}
+  imageHeight={900}
   ogType="article"
   articlePublishedTime={publishedDate.toISOString()}
   articleModifiedTime={modifiedDate.toISOString()}
@@ -135,7 +135,7 @@ const articleJsonLd = {
           </div>
         </header>
 
-        {coverImage && <BlogHero src={coverImage} alt={coverAlt ?? title} />}
+        <BlogHero src={coverImage} alt={coverAlt} width={1600} height={900} />
 
         <article class="glass-panel rounded-2xl px-6 py-8 sm:px-8 lg:px-10" data-pagefind-body>
           <div class="prose prose-docs max-w-none">


### PR DESCRIPTION
## Summary
- Makes `coverImage` and `coverAlt` mandatory for blog posts in the Astro content schema.
- Strengthens `npm run lint:blog` so discovery-ready posts fail on missing, duplicate, generic, incorrectly named, incorrectly located, undersized, non-16:9, or default social preview images.
- Keeps `/blog/*-hero.webp` as the required hero-image convention and warns when the preferred `1600x900` size is not used.
- Ensures blog hero media renders as a standard HTML `<img>` with explicit `width="1600"` and `height="900"`.
- Adds E2E coverage for hero image dimensions.

## Validation
- [x] HelmForge MCP `validate_blog` passed for representative FastMCP post
- [x] HelmForge MCP `validate_compliance` passed: 28/28 guardrails
- [x] `npm run lint`
- [x] `npm run format:check`
- [x] `npx prettier --check scripts/validate-blog-standards.mjs e2e/blog.spec.ts`
- [x] `npm run build`
- [x] `npx playwright test e2e/blog.spec.ts` — 48 passed
- [x] All blog hero images validate as 1600x900 WebP
- [x] Built blog posts render standard hero `<img>` elements with `width=1600` and `height=900`

Related to #164