### PR TITLE
feat(blog): add dedicated blog feed discovery

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -1,13 +1,63 @@
 // @ts-check
+import fs from 'node:fs';
+import path from 'node:path';
 import { defineConfig, fontProviders } from 'astro/config';
 
 import tailwindcss from '@tailwindcss/vite';
 import mdx from '@astrojs/mdx';
 import sitemap from '@astrojs/sitemap';
 
+const SITE_URL = 'https://helmforge.dev';
+const BLOG_DIR = path.join(process.cwd(), 'src', 'content', 'blog');
+
+function getFrontmatterScalar(frontmatter, key) {
+  const regex = new RegExp(`^${key}:\\s*(.+)$`, 'm');
+  const match = frontmatter.match(regex);
+  if (!match) return undefined;
+  return match[1].trim().replace(/^['"]|['"]$/g, '');
+}
+
+function getBlogSitemapMetadata() {
+  if (!fs.existsSync(BLOG_DIR)) return new Map();
+
+  return new Map(
+    fs
+      .readdirSync(BLOG_DIR)
+      .filter((file) => file.endsWith('.md') || file.endsWith('.mdx'))
+      .map((file) => {
+        const slug = path.basename(file, path.extname(file));
+        const content = fs.readFileSync(path.join(BLOG_DIR, file), 'utf8');
+        const frontmatter = content.match(/^---\r?\n([\s\S]*?)\r?\n---/)?.[1] ?? '';
+        const coverImage = getFrontmatterScalar(frontmatter, 'coverImage');
+        const coverAlt = getFrontmatterScalar(frontmatter, 'coverAlt');
+        const date =
+          getFrontmatterScalar(frontmatter, 'updatedAt') ??
+          getFrontmatterScalar(frontmatter, 'publishDate') ??
+          getFrontmatterScalar(frontmatter, 'date');
+
+        return [
+          `${SITE_URL}/blog/${slug}`,
+          {
+            coverImage,
+            coverAlt,
+            lastmod: date ? new Date(date) : undefined,
+          },
+        ];
+      }),
+  );
+}
+
+/** @type {Map<string, { coverImage?: string, coverAlt?: string, lastmod?: Date }> | undefined} */
+let blogSitemapMetadata;
+
+function getCachedBlogSitemapMetadata() {
+  blogSitemapMetadata ??= getBlogSitemapMetadata();
+  return blogSitemapMetadata;
+}
+
 // https://astro.build/config
 export default defineConfig({
-  site: 'https://helmforge.dev',
+  site: SITE_URL,
   trailingSlash: 'never',
 
   vite: {
@@ -26,6 +76,9 @@ export default defineConfig({
   integrations: [
     mdx(),
     sitemap({
+      namespaces: {
+        image: true,
+      },
       serialize(item) {
         const url = item.url;
 
@@ -59,7 +112,16 @@ export default defineConfig({
 
         // Blog posts
         if (url.match(/\/blog\/[a-z0-9-]+$/)) {
-          return { ...item, priority: 0.7, changefreq: 'never' };
+          const metadata = getCachedBlogSitemapMetadata().get(url.replace(/\/$/, ''));
+          if (metadata?.coverImage) {
+            /** @type {any} */ (item).img = [
+              {
+                url: `${SITE_URL}${metadata.coverImage}`,
+                title: metadata.coverAlt,
+              },
+            ];
+          }
+          return { ...item, lastmod: metadata?.lastmod, priority: 0.7, changefreq: 'never' };
         }
 
         // Blog index, changelog, roadmap

--- a/e2e/blog.spec.ts
+++ b/e2e/blog.spec.ts
@@ -4,7 +4,7 @@ test.describe('Blog', () => {
   test('blog index renders post cards', async ({ page }) => {
     await page.goto('/blog');
     await expect(page).toHaveTitle(/Blog/i);
-    const cards = page.locator('a[href^="/blog/"]');
+    const cards = page.locator('a[href^="/blog/"]:has(h2)');
     expect(await cards.count()).toBeGreaterThanOrEqual(3);
   });
 
@@ -17,7 +17,7 @@ test.describe('Blog', () => {
 
     const subscribe = page.locator('a[aria-label="Subscribe via RSS"]').first();
     await expect(subscribe).toBeVisible();
-    await expect(subscribe).toHaveAttribute('href', '/rss.xml');
+    await expect(subscribe).toHaveAttribute('href', '/blog/rss.xml');
   });
 
   test('blog index keeps subscription actions near header', async ({ page }) => {
@@ -32,7 +32,7 @@ test.describe('Blog', () => {
   test('blog cards expose title, description, author, and date', async ({ page }) => {
     await page.goto('/blog');
 
-    const firstCard = page.locator('a[href^="/blog/"]').first();
+    const firstCard = page.locator('a[href^="/blog/"]:has(h2)').first();
     await expect(firstCard.locator('h2')).toBeVisible();
     await expect(firstCard.locator('p')).toBeVisible();
     await expect(firstCard.locator('time')).toBeVisible();
@@ -41,7 +41,7 @@ test.describe('Blog', () => {
 
   test('blog post renders with content', async ({ page }) => {
     await page.goto('/blog');
-    const firstPost = page.locator('a[href^="/blog/"]').first();
+    const firstPost = page.locator('a[href^="/blog/"]:has(h2)').first();
     const href = await firstPost.getAttribute('href');
     expect(href).toBeTruthy();
 
@@ -53,7 +53,7 @@ test.describe('Blog', () => {
 
   test('blog post has date and tags', async ({ page }) => {
     await page.goto('/blog');
-    const firstPost = page.locator('a[href^="/blog/"]').first();
+    const firstPost = page.locator('a[href^="/blog/"]:has(h2)').first();
     const href = await firstPost.getAttribute('href');
     await page.goto(href!);
 
@@ -69,7 +69,7 @@ test.describe('Blog', () => {
 
   test('blog post has share links', async ({ page }) => {
     await page.goto('/blog');
-    const firstPost = page.locator('a[href^="/blog/"]').first();
+    const firstPost = page.locator('a[href^="/blog/"]:has(h2)').first();
     const href = await firstPost.getAttribute('href');
     await page.goto(href!);
 
@@ -109,7 +109,10 @@ test.describe('Blog', () => {
       'href',
       '/newsletter',
     );
-    await expect(subscribeSection.locator('a[aria-label="Subscribe via RSS"]')).toHaveAttribute('href', '/rss.xml');
+    await expect(subscribeSection.locator('a[aria-label="Subscribe via RSS"]')).toHaveAttribute(
+      'href',
+      '/blog/rss.xml',
+    );
   });
 
   test('blog post has end-of-article newsletter cta', async ({ page }) => {
@@ -118,7 +121,7 @@ test.describe('Blog', () => {
     const ctaSection = page.locator('article section').filter({ hasText: 'Get the next post in your inbox' }).first();
     await expect(ctaSection).toBeVisible();
     await expect(ctaSection.locator('a[aria-label="Open newsletter page"]')).toHaveAttribute('href', '/newsletter');
-    await expect(ctaSection.locator('a[aria-label="Subscribe via RSS"]')).toHaveAttribute('href', '/rss.xml');
+    await expect(ctaSection.locator('a[aria-label="Subscribe via RSS"]')).toHaveAttribute('href', '/blog/rss.xml');
   });
 
   test('newsletter page embeds listmonk form', async ({ page }) => {
@@ -160,8 +163,10 @@ test.describe('Blog', () => {
     const canonical = page.locator('link[rel="canonical"]');
     await expect(canonical).toHaveAttribute('href', /\/blog\/kubernetes-1-34-image-short-names\/?$/);
 
-    const rssAlternate = page.locator('link[rel="alternate"][type="application/rss+xml"]');
-    await expect(rssAlternate).toHaveAttribute('href', '/rss.xml');
+    await expect(page.locator('link[rel="alternate"][type="application/rss+xml"][href="/rss.xml"]')).toHaveCount(1);
+    await expect(page.locator('link[rel="alternate"][type="application/rss+xml"][href="/blog/rss.xml"]')).toHaveCount(
+      1,
+    );
 
     await expect(page.locator('meta[name="robots"][content*="noindex" i]')).toHaveCount(0);
   });
@@ -178,6 +183,25 @@ test.describe('Blog', () => {
     expect(body).toContain('<language>en</language>');
   });
 
+  test('blog rss endpoint contains only blog posts with media metadata', async ({ page }) => {
+    const response = await page.request.get('/blog/rss.xml');
+    expect(response.ok()).toBeTruthy();
+    expect(response.headers()['content-type']).toContain('xml');
+
+    const body = await response.text();
+    expect(body).toContain('<rss');
+    expect(body).toContain('xmlns:atom="http://www.w3.org/2005/Atom"');
+    expect(body).toContain('xmlns:media="http://search.yahoo.com/mrss/"');
+    expect(body).toContain(
+      '<atom:link href="https://helmforge.dev/blog/rss.xml" rel="self" type="application/rss+xml"',
+    );
+    expect(body).toContain('https://helmforge.dev/blog/kubernetes-1-34-image-short-names');
+    expect(body).toContain('<dc:creator>Maicon Berlofa</dc:creator>');
+    expect(body).toContain('<media:content url="https://helmforge.dev/blog/');
+    expect(body).toContain('<enclosure url="https://helmforge.dev/blog/');
+    expect(body).not.toContain('https://helmforge.dev/docs/charts/');
+  });
+
   test('sitemap includes blog urls', async ({ page }) => {
     const response = await page.request.get('/sitemap-index.xml');
     expect(response.ok()).toBeTruthy();
@@ -186,11 +210,16 @@ test.describe('Blog', () => {
     const sitemapMatch = indexBody.match(/<loc>([^<]*sitemap-0\.xml)<\/loc>/);
     expect(sitemapMatch).toBeTruthy();
 
-    const sitemapResponse = await page.request.get(sitemapMatch![1]);
+    const sitemapResponse = await page.request.get(new URL(sitemapMatch![1]).pathname);
     expect(sitemapResponse.ok()).toBeTruthy();
     const sitemapBody = await sitemapResponse.text();
 
     expect(sitemapBody).toContain('https://helmforge.dev/blog/');
     expect(sitemapBody).toContain('https://helmforge.dev/blog/kubernetes-1-34-image-short-names');
+    expect(sitemapBody).toContain('<image:image>');
+    expect(sitemapBody).toContain(
+      'https://helmforge.dev/blog/2026-04-03-kubernetes-1-34-short-name-enforcement-hero.webp',
+    );
+    expect(sitemapBody).toContain('<lastmod>2026-04-03');
   });
 });

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,4 +1,6 @@
 User-agent: *
 Allow: /
+Allow: /rss.xml
+Allow: /blog/rss.xml
 
 Sitemap: https://helmforge.dev/sitemap-index.xml

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -42,6 +42,7 @@ const pathname = Astro.url.pathname;
 const pathSegments = pathname.split('/').filter(Boolean);
 const isHomepage = pathname === '/' || pathname === '';
 const isChartPage = pathSegments[0] === 'docs' && pathSegments[1] === 'charts' && !!pathSegments[2];
+const isBlogPage = pathSegments[0] === 'blog';
 const isBlogPost = pathSegments[0] === 'blog' && !!pathSegments[1];
 const chartSlug = isChartPage ? pathSegments[2] : null;
 const chartDisplay = chartSlug ? chartSlug.replace(/-/g, ' ') : null;
@@ -130,7 +131,8 @@ const websiteJsonLd = isHomepage
     <link rel="manifest" href="/site.webmanifest" />
     <meta name="theme-color" content="#7c3aed" />
     <link rel="canonical" href={url} />
-    <link rel="alternate" type="application/rss+xml" title="HelmForge Charts" href="/rss.xml" />
+    <link rel="alternate" type="application/rss+xml" title="HelmForge Feed" href="/rss.xml" />
+    {isBlogPage && <link rel="alternate" type="application/rss+xml" title="HelmForge Blog" href="/blog/rss.xml" />}
 
     <!-- Open Graph -->
     <meta property="og:type" content={resolvedOgType} />

--- a/src/layouts/BlogLayout.astro
+++ b/src/layouts/BlogLayout.astro
@@ -162,7 +162,7 @@ const articleJsonLd = {
                 </svg>
               </a>
               <a
-                href="/rss.xml"
+                href="/blog/rss.xml"
                 target="_blank"
                 rel="noopener noreferrer"
                 class="inline-flex items-center gap-2 rounded-lg border border-border px-4 py-2 text-sm font-semibold text-text-base hover:border-primary/40 hover:text-primary-light transition-colors"
@@ -261,7 +261,7 @@ const articleJsonLd = {
               </svg>
             </a>
             <a
-              href="/rss.xml"
+              href="/blog/rss.xml"
               target="_blank"
               rel="noopener noreferrer"
               class="mt-3 inline-flex items-center gap-2 rounded-lg border border-border px-3 py-2 text-sm font-semibold text-text-base hover:border-primary/40 hover:text-primary-light transition-colors"

--- a/src/lib/blogFeed.ts
+++ b/src/lib/blogFeed.ts
@@ -1,0 +1,62 @@
+import { statSync } from 'node:fs';
+import path from 'node:path';
+import type { CollectionEntry } from 'astro:content';
+import type { RSSFeedItem } from '@astrojs/rss';
+import { AUTHORS, DEFAULT_AUTHOR_ID } from '../data/authors';
+
+type BlogPost = CollectionEntry<'blog'>;
+
+const BLOG_IMAGE_WIDTH = 1600;
+const BLOG_IMAGE_HEIGHT = 900;
+
+export function getPublishedDate(post: BlogPost) {
+  return post.data.publishDate ?? post.data.date;
+}
+
+export function getModifiedDate(post: BlogPost) {
+  return post.data.updatedAt ?? getPublishedDate(post);
+}
+
+function escapeXml(value: string) {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&apos;');
+}
+
+function getPublicAssetSize(publicPath: string) {
+  return statSync(path.join(process.cwd(), 'public', publicPath.replace(/^\//, ''))).size;
+}
+
+export function getSortedBlogPosts(posts: BlogPost[]) {
+  return [...posts].sort((a, b) => getPublishedDate(b).valueOf() - getPublishedDate(a).valueOf());
+}
+
+export function getBlogRssItems(posts: BlogPost[], site: URL): RSSFeedItem[] {
+  return getSortedBlogPosts(posts).map((post) => {
+    const author = AUTHORS[post.data.authorId] ?? AUTHORS[DEFAULT_AUTHOR_ID];
+    const canonicalUrl = new URL(`/blog/${post.id}`, site).toString();
+    const imageUrl = new URL(post.data.coverImage, site).toString();
+
+    return {
+      title: post.data.title,
+      description: post.data.description,
+      link: canonicalUrl,
+      pubDate: getPublishedDate(post),
+      categories: post.data.tags,
+      author: author.name,
+      enclosure: {
+        url: imageUrl,
+        length: getPublicAssetSize(post.data.coverImage),
+        type: 'image/webp',
+      },
+      customData:
+        `<dc:creator>${escapeXml(author.name)}</dc:creator>` +
+        `<media:content url="${escapeXml(imageUrl)}" medium="image" type="image/webp" width="${BLOG_IMAGE_WIDTH}" height="${BLOG_IMAGE_HEIGHT}" />` +
+        `<media:thumbnail url="${escapeXml(imageUrl)}" width="${BLOG_IMAGE_WIDTH}" height="${BLOG_IMAGE_HEIGHT}" />` +
+        `<guid isPermaLink="true">${escapeXml(canonicalUrl)}</guid>`,
+    };
+  });
+}

--- a/src/pages/blog/index.astro
+++ b/src/pages/blog/index.astro
@@ -39,7 +39,7 @@ const getAuthorName = (authorId: string) => (AUTHORS[authorId] ?? AUTHORS[DEFAUL
           </svg>
         </a>
         <a
-          href="/rss.xml"
+          href="/blog/rss.xml"
           target="_blank"
           rel="noopener noreferrer"
           class="inline-flex items-center gap-2 rounded-lg border border-border px-4 py-2 text-sm font-semibold text-text-base hover:border-primary/40 hover:text-primary-light transition-colors"

--- a/src/pages/blog/rss.xml.ts
+++ b/src/pages/blog/rss.xml.ts
@@ -1,26 +1,17 @@
 import rss from '@astrojs/rss';
 import type { APIContext } from 'astro';
 import { getCollection } from 'astro:content';
-import { charts } from '../data/charts';
-import { getBlogRssItems } from '../lib/blogFeed';
+import { getBlogRssItems } from '../../lib/blogFeed';
 
 export async function GET(context: APIContext) {
   const posts = await getCollection('blog');
-  const blogItems = getBlogRssItems(posts, context.site!);
-
-  const chartItems = charts.map((chart) => ({
-    title: `${chart.name} — ${chart.maturity}`,
-    description: chart.description,
-    link: `/docs/charts/${chart.slug}`,
-  }));
-
-  const feedUrl = new URL('/rss.xml', context.site).toString();
+  const feedUrl = new URL('/blog/rss.xml', context.site).toString();
 
   return rss({
-    title: 'HelmForge',
-    description: 'Production-ready Helm charts for Kubernetes. The open-source alternative to Bitnami.',
-    site: context.site!,
-    items: [...blogItems, ...chartItems],
+    title: 'HelmForge Blog',
+    description: 'Kubernetes, Helm, and HelmForge operations guides, announcements, and technical analysis.',
+    site: new URL('/blog', context.site!),
+    items: getBlogRssItems(posts, context.site!),
     trailingSlash: false,
     xmlns: {
       atom: 'http://www.w3.org/2005/Atom',
@@ -33,8 +24,8 @@ export async function GET(context: APIContext) {
       <atom:link href="${feedUrl}" rel="self" type="application/rss+xml" />
       <image>
         <url>https://helmforge.dev/favicon-512.png</url>
-        <title>HelmForge</title>
-        <link>https://helmforge.dev/</link>
+        <title>HelmForge Blog</title>
+        <link>https://helmforge.dev/blog</link>
       </image>
     `,
   });


### PR DESCRIPTION
## Summary

- Adds a dedicated `/blog/rss.xml` feed for blog-only discovery with author, category, cover image enclosure, Media RSS, and Atom self-link metadata.
- Keeps `/rss.xml` as the global HelmForge feed while adding blog RSS discovery links on blog pages and blog CTAs.
- Adds blog cover images and `lastmod` metadata to sitemap entries and exposes feeds in `robots.txt`.
- Extends E2E coverage for RSS discovery, blog feed media metadata, and sitemap images/lastmod.

## Validation

- [x] `npm run lint`
- [x] `npm run format:check`
- [x] `npm run build`
- [x] Local equivalent of CI `Check links` after build: All internal links valid
- [x] `npx playwright test e2e/blog.spec.ts` (51 passed)
- [x] MCP `validate_blog` PASS
- [x] MCP `validate_compliance` PASS
- [x] MCP `check_release_readiness` PASS

Related to #164