### PR TITLE
feat(blog): add editorial trust signals

### DIFF
--- a/e2e/blog.spec.ts
+++ b/e2e/blog.spec.ts
@@ -4,7 +4,7 @@ test.describe('Blog', () => {
   test('blog index renders post cards', async ({ page }) => {
     await page.goto('/blog');
     await expect(page).toHaveTitle(/Blog/i);
-    const cards = page.locator('a[href^="/blog/"]:has(h2)');
+    const cards = page.locator('article:has(a[href^="/blog/"]:has(h2))');
     expect(await cards.count()).toBeGreaterThanOrEqual(3);
   });
 
@@ -32,11 +32,12 @@ test.describe('Blog', () => {
   test('blog cards expose title, description, author, and date', async ({ page }) => {
     await page.goto('/blog');
 
-    const firstCard = page.locator('a[href^="/blog/"]:has(h2)').first();
+    const firstCard = page.locator('article:has(a[href^="/blog/"]:has(h2))').first();
     await expect(firstCard.locator('h2')).toBeVisible();
     await expect(firstCard.locator('p')).toBeVisible();
     await expect(firstCard.locator('time')).toBeVisible();
     await expect(firstCard.locator('time')).toHaveAttribute('datetime', /\d{4}-\d{2}-\d{2}T/);
+    await expect(firstCard.locator('a[href="/authors/maicon-berlofa"]')).toBeVisible();
   });
 
   test('blog post renders with content', async ({ page }) => {
@@ -95,7 +96,8 @@ test.describe('Blog', () => {
 
     const authorCard = page.locator('aside section').filter({ hasText: 'Written by' }).first();
     await expect(authorCard).toBeVisible();
-    await expect(authorCard.getByText('Maicon Berlofa')).toBeVisible();
+    await expect(authorCard.locator('a[href="/authors/maicon-berlofa"]')).toContainText('Maicon Berlofa');
+    await expect(authorCard.getByText(/founder and maintainer of HelmForge/i)).toBeVisible();
     await expect(authorCard.locator('a[aria-label*="GitHub"]')).toBeVisible();
     await expect(authorCard.locator('a[aria-label*="LinkedIn"]')).toBeVisible();
   });
@@ -154,6 +156,12 @@ test.describe('Blog', () => {
     expect(article.author).toMatchObject({
       '@type': 'Person',
       name: 'Maicon Berlofa',
+      url: 'https://helmforge.dev/authors/maicon-berlofa',
+      jobTitle: 'Founder and Maintainer',
+      affiliation: {
+        '@type': 'Organization',
+        name: 'HelmForge',
+      },
     });
   });
 

--- a/e2e/editorial-trust.spec.ts
+++ b/e2e/editorial-trust.spec.ts
@@ -1,0 +1,81 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('Editorial trust signals', () => {
+  test('author profile identifies maintainer and exposes Person structured data', async ({ page }) => {
+    await page.goto('/authors/maicon-berlofa');
+
+    await expect(page).toHaveTitle(/Maicon Berlofa/i);
+    await expect(page.locator('h1')).toContainText('Maicon Berlofa');
+    await expect(page.getByText(/founder and maintainer of HelmForge/i)).toBeVisible();
+    await expect(page.getByText('Kubernetes operations', { exact: true })).toBeVisible();
+    await expect(page.locator('a[href="https://github.com/mberlofa"]')).toBeVisible();
+    await expect(page.locator('a[href="https://www.linkedin.com/in/berlofa"]')).toBeVisible();
+    await expect(page.locator('a[href="mailto:maicon.berloffa@gmail.com"]')).toBeVisible();
+
+    const structuredData = (await page.locator('script[type="application/ld+json"]').allTextContents()).map((content) =>
+      JSON.parse(content),
+    );
+    const person = structuredData.find((schema) => schema['@type'] === 'Person');
+
+    expect(person).toMatchObject({
+      '@type': 'Person',
+      name: 'Maicon Berlofa',
+      url: 'https://helmforge.dev/authors/maicon-berlofa',
+      jobTitle: 'Founder and Maintainer',
+      affiliation: {
+        '@type': 'Organization',
+        name: 'HelmForge',
+        url: 'https://helmforge.dev',
+      },
+    });
+    expect(person.knowsAbout).toContain('Helm chart engineering');
+  });
+
+  test('about page explains the project and is backed by AboutPage schema', async ({ page }) => {
+    await page.goto('/about');
+
+    await expect(page.locator('h1')).toContainText('Production-ready Helm charts');
+    await expect(page.getByText(/Apache-2\.0 Helm charts/i)).toBeVisible();
+    await expect(page.getByText(/official upstream container images/i)).toBeVisible();
+
+    const structuredData = (await page.locator('script[type="application/ld+json"]').allTextContents()).map((content) =>
+      JSON.parse(content),
+    );
+    expect(structuredData.some((schema) => schema['@type'] === 'AboutPage')).toBeTruthy();
+  });
+
+  test('contact and corrections pages expose clear reporting channels', async ({ page }) => {
+    await page.goto('/contact');
+
+    await expect(page.locator('h1')).toContainText('Reach the right channel');
+    await expect(page.locator('a[href="mailto:berlofa@helmforge.dev"]')).toBeVisible();
+    await expect(page.locator('a[href="https://github.com/helmforgedev/charts/issues"]')).toBeVisible();
+    await expect(page.getByRole('link', { name: /Corrections Report an article/i })).toBeVisible();
+
+    await page.goto('/corrections');
+    await expect(page.locator('h1')).toContainText('Help keep HelmForge content accurate');
+    await expect(page.locator('a[href="mailto:berlofa@helmforge.dev"]')).toBeVisible();
+    await expect(page.locator('a[href="https://github.com/helmforgedev/site/issues/new"]')).toBeVisible();
+  });
+
+  test('editorial policy documents review, sources, updates, and AI assistance', async ({ page }) => {
+    await page.goto('/editorial-policy');
+
+    await expect(page.locator('h1')).toContainText('How HelmForge publishes technical content');
+    await expect(page.getByText('Technical review')).toBeVisible();
+    await expect(page.getByText('Source selection')).toBeVisible();
+    await expect(page.getByText('AI and editorial assistance')).toBeVisible();
+    await expect(page.getByText('Update policy')).toBeVisible();
+  });
+
+  test('footer links to project trust pages', async ({ page }) => {
+    await page.goto('/');
+
+    const footer = page.locator('footer');
+    await expect(footer.locator('a[href="/about"]')).toBeVisible();
+    await expect(footer.locator('a[href="/contact"]')).toBeVisible();
+    await expect(footer.locator('a[href="/authors/maicon-berlofa"]')).toBeVisible();
+    await expect(footer.locator('a[href="/editorial-policy"]')).toBeVisible();
+    await expect(footer.locator('a[href="/corrections"]')).toBeVisible();
+  });
+});

--- a/e2e/footer.spec.ts
+++ b/e2e/footer.spec.ts
@@ -1,6 +1,21 @@
 import { test, expect } from '@playwright/test';
 
-const pages = ['/', '/stack', '/blog', '/docs', '/playground', '/roadmap', '/community', '/changelog', '/request'];
+const pages = [
+  '/',
+  '/stack',
+  '/blog',
+  '/docs',
+  '/playground',
+  '/roadmap',
+  '/community',
+  '/changelog',
+  '/request',
+  '/about',
+  '/contact',
+  '/authors/maicon-berlofa',
+  '/editorial-policy',
+  '/corrections',
+];
 
 test.describe('Footer', () => {
   for (const path of pages) {

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -7,7 +7,7 @@ const year = new Date().getFullYear();
 
 <footer class="mt-auto border-t border-border bg-bg-surface/50">
   <Container class="py-10">
-    <div class="grid grid-cols-1 gap-8 md:grid-cols-[minmax(0,1.25fr)_1fr_1fr]">
+    <div class="grid grid-cols-1 gap-8 md:grid-cols-[minmax(0,1.25fr)_1fr_1fr_1fr]">
       <!-- Brand -->
       <div>
         <a
@@ -39,6 +39,28 @@ const year = new Date().getFullYear();
           </li>
           <li><a href="/changelog" class="text-text-muted transition-colors hover:text-text-base">Changelog</a></li>
           <li><a href="/blog" class="text-text-muted transition-colors hover:text-text-base">Blog</a></li>
+        </ul>
+      </div>
+
+      <!-- Project -->
+      <div>
+        <div class="mb-3 text-[11px] font-bold uppercase tracking-[0.18em] text-text-base">Project</div>
+        <ul class="space-y-2 text-sm">
+          <li><a href="/about" class="text-text-muted transition-colors hover:text-text-base">About</a></li>
+          <li><a href="/contact" class="text-text-muted transition-colors hover:text-text-base">Contact</a></li>
+          <li>
+            <a href="/authors/maicon-berlofa" class="text-text-muted transition-colors hover:text-text-base"
+              >Author Profile</a
+            >
+          </li>
+          <li>
+            <a href="/editorial-policy" class="text-text-muted transition-colors hover:text-text-base"
+              >Editorial Policy</a
+            >
+          </li>
+          <li>
+            <a href="/corrections" class="text-text-muted transition-colors hover:text-text-base">Corrections</a>
+          </li>
         </ul>
       </div>
 

--- a/src/components/SectionHeader.astro
+++ b/src/components/SectionHeader.astro
@@ -4,18 +4,22 @@ interface Props {
   title: string;
   description?: string;
   align?: 'left' | 'center';
+  as?: 'h1' | 'h2';
   class?: string;
 }
 
-const { label, title, description, align = 'left', class: className = '' } = Astro.props;
+const { label, title, description, align = 'left', as = 'h2', class: className = '' } = Astro.props;
 
 const alignClass = align === 'center' ? 'text-center mx-auto' : '';
+const HeadingTag = as;
 ---
 
 <div class:list={['max-w-2xl', alignClass, className]}>
   {label && <p class="text-sm font-semibold uppercase tracking-[0.18em] text-primary">{label}</p>}
-  <h2 class:list={['text-3xl sm:text-4xl font-bold tracking-tight text-text-base heading-font', label && 'mt-3']}>
+  <HeadingTag
+    class:list={['text-3xl sm:text-4xl font-bold tracking-tight text-text-base heading-font', label && 'mt-3']}
+  >
     <Fragment set:html={title} />
-  </h2>
+  </HeadingTag>
   {description && <p class="mt-4 text-base sm:text-lg text-text-muted leading-relaxed">{description}</p>}
 </div>

--- a/src/data/authors.ts
+++ b/src/data/authors.ts
@@ -2,9 +2,15 @@ export type AuthorProfile = {
   id: string;
   name: string;
   role: string;
+  location?: string;
+  email?: string;
+  bio: string;
+  expertise: string[];
+  affiliation: string;
   avatar?: string;
   github?: string;
   linkedin?: string;
+  website?: string;
 };
 
 export const AUTHORS: Record<string, AuthorProfile> = {
@@ -12,9 +18,25 @@ export const AUTHORS: Record<string, AuthorProfile> = {
     id: 'maicon-berlofa',
     name: 'Maicon Berlofa',
     role: 'Founder and Maintainer',
+    location: 'Brazil',
+    email: 'maicon.berloffa@gmail.com',
+    bio: 'Maicon Berlofa is the founder and maintainer of HelmForge, focused on production-ready Helm charts, Kubernetes operations, supply-chain hygiene, and open-source infrastructure automation.',
+    expertise: [
+      'Kubernetes operations',
+      'Helm chart engineering',
+      'Database platforms on Kubernetes',
+      'Backup and recovery automation',
+      'Open-source project governance',
+    ],
+    affiliation: 'HelmForge',
     github: 'https://github.com/mberlofa',
     linkedin: 'https://www.linkedin.com/in/berlofa',
+    website: 'https://helmforge.dev',
   },
 };
 
 export const DEFAULT_AUTHOR_ID = 'maicon-berlofa';
+
+export function getAuthorUrl(author: AuthorProfile) {
+  return `/authors/${author.id}`;
+}

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -82,6 +82,30 @@ const breadcrumbJsonLd = {
   })),
 };
 
+const organizationJsonLd = {
+  '@context': 'https://schema.org',
+  '@type': 'Organization',
+  name: 'HelmForge',
+  url: 'https://helmforge.dev',
+  logo: 'https://helmforge.dev/helmforge-logo-horizontal.svg',
+  description: 'Production-ready Helm charts, forged for Kubernetes. The modern open-source alternative to Bitnami.',
+  sameAs: [
+    'https://github.com/helmforgedev',
+    'https://github.com/helmforgedev/charts',
+    'https://artifacthub.io/packages/search?repo=helmforge',
+    'https://repo.helmforge.dev',
+    'https://github.com/cncf/sandbox',
+  ],
+  contactPoint: [
+    {
+      '@type': 'ContactPoint',
+      contactType: 'maintainer',
+      email: 'berlofa@helmforge.dev',
+      url: 'https://helmforge.dev/contact',
+    },
+  ],
+};
+
 // WebSite + SiteLinksSearchBox JSON-LD (homepage only)
 const websiteJsonLd = isHomepage
   ? {
@@ -173,19 +197,7 @@ const websiteJsonLd = isHomepage
     </script>
 
     <!-- JSON-LD Structured Data for Organization -->
-    <script
-      type="application/ld+json"
-      set:html={JSON.stringify({
-        '@context': 'https://schema.org',
-        '@type': 'Organization',
-        name: 'HelmForge',
-        url: 'https://helmforge.dev',
-        logo: 'https://helmforge.dev/helmforge-logo-horizontal.svg',
-        description:
-          'Production-ready Helm charts, forged for Kubernetes. The modern open-source alternative to Bitnami.',
-        sameAs: ['https://github.com/helmforgedev/charts'],
-      })}
-    />
+    <script type="application/ld+json" set:html={JSON.stringify(organizationJsonLd)} />
 
     <!-- JSON-LD Structured Data for SoftwareApplication Collection -->
     <script

--- a/src/layouts/BlogLayout.astro
+++ b/src/layouts/BlogLayout.astro
@@ -4,7 +4,7 @@ import Header from '../components/Header.astro';
 import Footer from '../components/Footer.astro';
 import Container from '../components/Container.astro';
 import BlogHero from '../components/BlogHero.astro';
-import type { AuthorProfile } from '../data/authors';
+import { getAuthorUrl, type AuthorProfile } from '../data/authors';
 
 type ArticleSchemaType = 'Article' | 'BlogPosting' | 'NewsArticle';
 
@@ -44,10 +44,17 @@ const formattedDate = publishedDate.toLocaleDateString('en-US', {
   month: 'long',
   day: 'numeric',
 });
-const canonicalUrl = `https://helmforge.dev/blog/${postSlug}`;
 const modifiedDate = updatedAt ?? publishedDate;
+const formattedModifiedDate = modifiedDate.toLocaleDateString('en-US', {
+  year: 'numeric',
+  month: 'long',
+  day: 'numeric',
+});
+const canonicalUrl = `https://helmforge.dev/blog/${postSlug}`;
 const articleSection = tags[0] ?? 'Blog';
 const articleImage = new URL(coverImage, Astro.site).href;
+const authorUrl = new URL(getAuthorUrl(author), Astro.site).href;
+const showUpdatedDate = modifiedDate.valueOf() !== publishedDate.valueOf();
 
 const articleJsonLd = {
   '@context': 'https://schema.org',
@@ -61,8 +68,14 @@ const articleJsonLd = {
   author: {
     '@type': 'Person',
     name: author.name,
-    url: author.linkedin || author.github || 'https://helmforge.dev',
+    url: authorUrl,
     sameAs: [author.github, author.linkedin].filter(Boolean),
+    jobTitle: author.role,
+    affiliation: {
+      '@type': 'Organization',
+      name: author.affiliation,
+      url: 'https://helmforge.dev',
+    },
   },
   image: [articleImage],
   mainEntityOfPage: canonicalUrl,
@@ -127,9 +140,22 @@ const articleJsonLd = {
           </h1>
           <p class="mt-4 text-lg text-text-muted leading-relaxed">{description}</p>
           <div class="mt-6 flex flex-wrap items-center gap-3 text-sm text-text-muted">
-            <span>{author.name}</span>
+            <a
+              href={getAuthorUrl(author)}
+              class="font-semibold text-text-base hover:text-primary-light transition-colors">{author.name}</a
+            >
             <span class="text-border">|</span>
-            <time datetime={publishedDate.toISOString()}>{formattedDate}</time>
+            <span>Published <time datetime={publishedDate.toISOString()}>{formattedDate}</time></span>
+            {
+              showUpdatedDate && (
+                <>
+                  <span class="text-border">|</span>
+                  <span>
+                    Updated <time datetime={modifiedDate.toISOString()}>{formattedModifiedDate}</time>
+                  </span>
+                </>
+              )
+            }
             <span class="text-border">|</span>
             <span>{readingTime} min read</span>
           </div>
@@ -179,8 +205,12 @@ const articleJsonLd = {
         <div class="sticky top-24 space-y-4">
           <section class="glass-panel rounded-2xl p-5">
             <p class="text-xs uppercase tracking-wider text-text-muted mb-2">Written by</p>
-            <p class="text-lg font-semibold text-text-base">{author.name}</p>
+            <a
+              href={getAuthorUrl(author)}
+              class="text-lg font-semibold text-text-base hover:text-primary-light transition-colors">{author.name}</a
+            >
             <p class="text-sm text-text-muted mt-1">{author.role}</p>
+            <p class="text-sm text-text-muted mt-3 leading-relaxed">{author.bio}</p>
             <p class="text-sm text-text-muted mt-3">Follow the author:</p>
             <div class="mt-4 flex items-center gap-3">
               {

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -1,0 +1,78 @@
+---
+import BaseLayout from '../layouts/BaseLayout.astro';
+import Header from '../components/Header.astro';
+import Footer from '../components/Footer.astro';
+import Container from '../components/Container.astro';
+import SectionHeader from '../components/SectionHeader.astro';
+
+const aboutJsonLd = {
+  '@context': 'https://schema.org',
+  '@type': 'AboutPage',
+  name: 'About HelmForge',
+  url: 'https://helmforge.dev/about',
+  mainEntity: {
+    '@type': 'Organization',
+    name: 'HelmForge',
+    url: 'https://helmforge.dev',
+    sameAs: [
+      'https://github.com/helmforgedev',
+      'https://github.com/helmforgedev/charts',
+      'https://artifacthub.io/packages/search?repo=helmforge',
+      'https://repo.helmforge.dev',
+    ],
+  },
+};
+
+const principles = [
+  'Use official upstream images instead of rebuilding application containers.',
+  'Keep Helm chart defaults practical for production Kubernetes operations.',
+  'Treat backups, upgrade paths, security context, and observability as first-class chart behavior.',
+  'Document operational trade-offs clearly so users can make informed decisions.',
+];
+---
+
+<BaseLayout
+  title="About HelmForge"
+  description="Learn about HelmForge as an open-source Helm chart project and technical publication for Kubernetes operations."
+>
+  <Header />
+  <script type="application/ld+json" set:html={JSON.stringify(aboutJsonLd)} />
+
+  <main id="main-content" class="py-16 sm:py-20" data-pagefind-body>
+    <Container>
+      <SectionHeader
+        label="About"
+        as="h1"
+        title="Production-ready Helm charts, documented in the open."
+        description="HelmForge publishes Apache-2.0 Helm charts and practical Kubernetes operations content for teams that want transparent, reproducible infrastructure."
+      />
+
+      <div class="mt-12 grid grid-cols-1 gap-8 lg:grid-cols-[minmax(0,1.1fr)_minmax(0,0.9fr)]">
+        <section class="space-y-5 text-sm leading-relaxed text-text-muted">
+          <p>
+            HelmForge exists to keep Kubernetes application deployment accessible, secure, and independently
+            maintainable. The project focuses on charts that use official upstream container images, clear operational
+            defaults, and automation around release quality.
+          </p>
+          <p>
+            The site is both project documentation and a technical publication. Blog posts explain Kubernetes behavior,
+            chart migration paths, production trade-offs, and lessons learned from operating self-hosted applications.
+          </p>
+          <p>
+            HelmForge is maintained in public repositories under the HelmForge GitHub organization, with charts
+            published through the Helm repository, OCI registry, and Artifact Hub.
+          </p>
+        </section>
+
+        <section class="glass-panel rounded-2xl p-6">
+          <h2 class="text-lg font-bold text-text-base heading-font">Editorial and project principles</h2>
+          <ul class="mt-4 space-y-3 text-sm text-text-muted">
+            {principles.map((principle) => <li class="leading-relaxed">{principle}</li>)}
+          </ul>
+        </section>
+      </div>
+    </Container>
+  </main>
+
+  <Footer />
+</BaseLayout>

--- a/src/pages/authors/[id].astro
+++ b/src/pages/authors/[id].astro
@@ -1,0 +1,144 @@
+---
+import BaseLayout from '../../layouts/BaseLayout.astro';
+import Header from '../../components/Header.astro';
+import Footer from '../../components/Footer.astro';
+import Container from '../../components/Container.astro';
+import SectionHeader from '../../components/SectionHeader.astro';
+import { AUTHORS, getAuthorUrl, type AuthorProfile } from '../../data/authors';
+
+export function getStaticPaths() {
+  return Object.values(AUTHORS).map((author) => ({
+    params: { id: author.id },
+    props: { author },
+  }));
+}
+
+const { author } = Astro.props as { author: AuthorProfile };
+const authorUrl = `https://helmforge.dev${getAuthorUrl(author)}`;
+const sameAs = [author.github, author.linkedin, author.website].filter(Boolean);
+
+const personJsonLd = {
+  '@context': 'https://schema.org',
+  '@type': 'Person',
+  name: author.name,
+  url: authorUrl,
+  jobTitle: author.role,
+  email: author.email ? `mailto:${author.email}` : undefined,
+  address: author.location
+    ? {
+        '@type': 'PostalAddress',
+        addressCountry: author.location,
+      }
+    : undefined,
+  affiliation: {
+    '@type': 'Organization',
+    name: author.affiliation,
+    url: 'https://helmforge.dev',
+  },
+  knowsAbout: author.expertise,
+  sameAs,
+};
+
+const profilePageJsonLd = {
+  '@context': 'https://schema.org',
+  '@type': 'ProfilePage',
+  mainEntity: personJsonLd,
+  url: authorUrl,
+  name: `${author.name} - HelmForge Author Profile`,
+};
+---
+
+<BaseLayout
+  title={`${author.name} - Author Profile`}
+  description={`${author.name} is ${author.role} at HelmForge, focused on ${author.expertise.slice(0, 3).join(', ')}.`}
+>
+  <Header />
+  <script type="application/ld+json" set:html={JSON.stringify(personJsonLd)} />
+  <script type="application/ld+json" set:html={JSON.stringify(profilePageJsonLd)} />
+
+  <main id="main-content" class="py-16 sm:py-20" data-pagefind-body>
+    <Container>
+      <SectionHeader label="Author" title={author.name} description={author.bio} />
+
+      <div class="mt-12 grid grid-cols-1 gap-8 lg:grid-cols-[minmax(0,0.8fr)_minmax(0,1.2fr)]">
+        <section class="glass-panel rounded-2xl p-6 sm:p-8">
+          <div class="flex items-start gap-5">
+            <div
+              class="flex h-16 w-16 shrink-0 items-center justify-center rounded-2xl bg-primary/10 text-xl font-bold text-primary-light"
+              aria-hidden="true"
+            >
+              {
+                author.name
+                  .split(' ')
+                  .map((part) => part[0])
+                  .join('')
+                  .slice(0, 2)
+              }
+            </div>
+            <div>
+              <h1 class="text-2xl font-bold text-text-base heading-font">{author.name}</h1>
+              <p class="mt-1 text-sm text-text-muted">{author.role}</p>
+              {author.location && <p class="mt-2 text-sm text-text-muted">{author.location}</p>}
+            </div>
+          </div>
+
+          <div class="mt-6 flex flex-wrap gap-3 text-sm">
+            {
+              author.github && (
+                <a
+                  href={author.github}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  class="inline-flex rounded-lg border border-border px-3 py-2 font-semibold text-text-base hover:border-primary/40 hover:text-primary-light transition-colors"
+                >
+                  GitHub
+                </a>
+              )
+            }
+            {
+              author.linkedin && (
+                <a
+                  href={author.linkedin}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  class="inline-flex rounded-lg border border-border px-3 py-2 font-semibold text-text-base hover:border-primary/40 hover:text-primary-light transition-colors"
+                >
+                  LinkedIn
+                </a>
+              )
+            }
+            {
+              author.email && (
+                <a
+                  href={`mailto:${author.email}`}
+                  class="inline-flex rounded-lg border border-border px-3 py-2 font-semibold text-text-base hover:border-primary/40 hover:text-primary-light transition-colors"
+                >
+                  Email
+                </a>
+              )
+            }
+          </div>
+        </section>
+
+        <section class="glass-panel rounded-2xl p-6 sm:p-8">
+          <h2 class="text-lg font-bold text-text-base heading-font">Expertise</h2>
+          <div class="mt-4 flex flex-wrap gap-2">
+            {
+              author.expertise.map((item) => (
+                <span class="rounded-full bg-primary/10 px-3 py-1 text-xs font-bold uppercase tracking-wider text-primary-light">
+                  {item}
+                </span>
+              ))
+            }
+          </div>
+          <p class="mt-6 text-sm leading-relaxed text-text-muted">
+            HelmForge author profiles identify who writes and reviews technical material, what they work on, and where
+            readers can verify their open-source activity.
+          </p>
+        </section>
+      </div>
+    </Container>
+  </main>
+
+  <Footer />
+</BaseLayout>

--- a/src/pages/blog/index.astro
+++ b/src/pages/blog/index.astro
@@ -5,12 +5,12 @@ import Footer from '../../components/Footer.astro';
 import Container from '../../components/Container.astro';
 import SectionHeader from '../../components/SectionHeader.astro';
 import { getCollection } from 'astro:content';
-import { AUTHORS, DEFAULT_AUTHOR_ID } from '../../data/authors';
+import { AUTHORS, DEFAULT_AUTHOR_ID, getAuthorUrl } from '../../data/authors';
 
 const allPosts = await getCollection('blog');
 const getPublishedDate = (post: (typeof allPosts)[number]) => post.data.publishDate ?? post.data.date;
 const posts = allPosts.sort((a, b) => getPublishedDate(b).valueOf() - getPublishedDate(a).valueOf());
-const getAuthorName = (authorId: string) => (AUTHORS[authorId] ?? AUTHORS[DEFAULT_AUTHOR_ID]).name;
+const getAuthor = (authorId: string) => AUTHORS[authorId] ?? AUTHORS[DEFAULT_AUTHOR_ID];
 ---
 
 <BaseLayout
@@ -58,47 +58,54 @@ const getAuthorName = (authorId: string) => (AUTHORS[authorId] ?? AUTHORS[DEFAUL
 
       <div class="mt-12 grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
         {
-          posts.map((post) => (
-            <a
-              href={`/blog/${post.id}`}
-              class="group glass-panel rounded-2xl overflow-hidden transition-all hover:border-primary/40 hover:-translate-y-1 hover:shadow-xl hover:shadow-primary/10 flex flex-col"
-            >
-              <div class="p-6 flex flex-col flex-grow">
-                <div class="flex flex-wrap gap-2 mb-3">
-                  {post.data.tags.slice(0, 2).map((tag) => (
-                    <span class="text-[10px] font-bold uppercase tracking-wider text-primary bg-primary/10 rounded-full px-2 py-0.5">
-                      {tag}
-                    </span>
-                  ))}
-                </div>
-                <h2 class="text-lg font-bold text-text-base heading-font group-hover:text-primary-light transition-colors leading-snug">
-                  {post.data.title}
-                </h2>
-                <p class="mt-2 text-sm text-text-muted leading-relaxed line-clamp-3 flex-grow">
-                  {post.data.description}
-                </p>
-                <div class="mt-4 flex items-center justify-between text-xs text-text-muted">
-                  <div class="flex items-center gap-2">
-                    <span>{getAuthorName(post.data.authorId)}</span>
-                    <span class="text-border">|</span>
-                    <time datetime={getPublishedDate(post).toISOString()}>
-                      {getPublishedDate(post).toLocaleDateString('en-US', {
-                        month: 'short',
-                        day: 'numeric',
-                        year: 'numeric',
-                      })}
-                    </time>
+          posts.map((post) => {
+            const author = getAuthor(post.data.authorId);
+            return (
+              <article class="group glass-panel rounded-2xl overflow-hidden transition-all hover:border-primary/40 hover:-translate-y-1 hover:shadow-xl hover:shadow-primary/10 flex flex-col">
+                <div class="p-6 flex flex-col flex-grow">
+                  <div class="flex flex-wrap gap-2 mb-3">
+                    {post.data.tags.slice(0, 2).map((tag) => (
+                      <span class="text-[10px] font-bold uppercase tracking-wider text-primary bg-primary/10 rounded-full px-2 py-0.5">
+                        {tag}
+                      </span>
+                    ))}
                   </div>
-                  <span class="flex items-center gap-1 text-primary-light opacity-0 group-hover:opacity-100 transition-opacity">
-                    Read
-                    <svg class="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" />
-                    </svg>
-                  </span>
+                  <a href={`/blog/${post.id}`} class="group">
+                    <h2 class="text-lg font-bold text-text-base heading-font group-hover:text-primary-light transition-colors leading-snug">
+                      {post.data.title}
+                    </h2>
+                  </a>
+                  <p class="mt-2 text-sm text-text-muted leading-relaxed line-clamp-3 flex-grow">
+                    {post.data.description}
+                  </p>
+                  <div class="mt-4 flex items-center justify-between text-xs text-text-muted">
+                    <div class="flex items-center gap-2">
+                      <a
+                        href={getAuthorUrl(author)}
+                        class="font-semibold text-text-base hover:text-primary-light transition-colors"
+                      >
+                        {author.name}
+                      </a>
+                      <span class="text-border">|</span>
+                      <time datetime={getPublishedDate(post).toISOString()}>
+                        {getPublishedDate(post).toLocaleDateString('en-US', {
+                          month: 'short',
+                          day: 'numeric',
+                          year: 'numeric',
+                        })}
+                      </time>
+                    </div>
+                    <span class="flex items-center gap-1 text-primary-light opacity-0 group-hover:opacity-100 transition-opacity">
+                      Read
+                      <svg class="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" />
+                      </svg>
+                    </span>
+                  </div>
                 </div>
-              </div>
-            </a>
-          ))
+              </article>
+            );
+          })
         }
       </div>
     </Container>

--- a/src/pages/contact.astro
+++ b/src/pages/contact.astro
@@ -1,0 +1,78 @@
+---
+import BaseLayout from '../layouts/BaseLayout.astro';
+import Header from '../components/Header.astro';
+import Footer from '../components/Footer.astro';
+import Container from '../components/Container.astro';
+import SectionHeader from '../components/SectionHeader.astro';
+
+const contactJsonLd = {
+  '@context': 'https://schema.org',
+  '@type': 'ContactPage',
+  name: 'Contact HelmForge',
+  url: 'https://helmforge.dev/contact',
+  mainEntity: {
+    '@type': 'Organization',
+    name: 'HelmForge',
+    url: 'https://helmforge.dev',
+    contactPoint: [
+      {
+        '@type': 'ContactPoint',
+        contactType: 'maintainer',
+        email: 'berlofa@helmforge.dev',
+      },
+    ],
+  },
+};
+---
+
+<BaseLayout
+  title="Contact HelmForge"
+  description="Contact HelmForge maintainers, report chart issues, request charts, or send editorial corrections."
+>
+  <Header />
+  <script type="application/ld+json" set:html={JSON.stringify(contactJsonLd)} />
+
+  <main id="main-content" class="py-16 sm:py-20" data-pagefind-body>
+    <Container>
+      <SectionHeader
+        label="Contact"
+        as="h1"
+        title="Reach the right channel."
+        description="Use GitHub for project work, email for maintainer contact, and the correction policy for article updates."
+      />
+
+      <div class="mt-12 grid grid-cols-1 gap-4 md:grid-cols-2">
+        <a
+          href="mailto:berlofa@helmforge.dev"
+          class="glass-panel rounded-2xl p-6 hover:border-primary/40 transition-colors"
+        >
+          <h2 class="text-lg font-bold text-text-base heading-font">Maintainer email</h2>
+          <p class="mt-2 text-sm text-text-muted">berlofa@helmforge.dev</p>
+        </a>
+        <a
+          href="https://github.com/helmforgedev/charts/issues"
+          target="_blank"
+          rel="noopener noreferrer"
+          class="glass-panel rounded-2xl p-6 hover:border-primary/40 transition-colors"
+        >
+          <h2 class="text-lg font-bold text-text-base heading-font">Chart issues</h2>
+          <p class="mt-2 text-sm text-text-muted">
+            Open bug reports, feature requests, and chart discussions on GitHub.
+          </p>
+        </a>
+        <a href="/request" class="glass-panel rounded-2xl p-6 hover:border-primary/40 transition-colors">
+          <h2 class="text-lg font-bold text-text-base heading-font">Chart requests</h2>
+          <p class="mt-2 text-sm text-text-muted">Request a new application chart for the HelmForge catalog.</p>
+        </a>
+        <a href="/corrections" class="glass-panel rounded-2xl p-6 hover:border-primary/40 transition-colors">
+          <h2 class="text-lg font-bold text-text-base heading-font">Corrections</h2>
+          <p class="mt-2 text-sm text-text-muted">
+            Report an article error, outdated command, or unclear technical claim.
+          </p>
+        </a>
+      </div>
+    </Container>
+  </main>
+
+  <Footer />
+</BaseLayout>

--- a/src/pages/corrections.astro
+++ b/src/pages/corrections.astro
@@ -1,0 +1,70 @@
+---
+import BaseLayout from '../layouts/BaseLayout.astro';
+import Header from '../components/Header.astro';
+import Footer from '../components/Footer.astro';
+import Container from '../components/Container.astro';
+import SectionHeader from '../components/SectionHeader.astro';
+
+const correctionsJsonLd = {
+  '@context': 'https://schema.org',
+  '@type': 'WebPage',
+  name: 'HelmForge Corrections Policy',
+  url: 'https://helmforge.dev/corrections',
+  about: 'Corrections and update process for HelmForge content',
+};
+---
+
+<BaseLayout
+  title="Corrections Policy"
+  description="How to report corrections for HelmForge articles and how meaningful updates are handled."
+>
+  <Header />
+  <script type="application/ld+json" set:html={JSON.stringify(correctionsJsonLd)} />
+
+  <main id="main-content" class="py-16 sm:py-20" data-pagefind-body>
+    <Container>
+      <SectionHeader
+        label="Corrections"
+        as="h1"
+        title="Help keep HelmForge content accurate."
+        description="Technical content ages quickly. Corrections are welcome when commands, versions, links, or operational guidance need attention."
+      />
+
+      <div class="mt-12 grid grid-cols-1 gap-8 lg:grid-cols-[minmax(0,1fr)_minmax(0,1fr)]">
+        <section class="space-y-4 text-sm leading-relaxed text-text-muted">
+          <h2 class="text-lg font-bold text-text-base heading-font">What to send</h2>
+          <p>
+            Include the article URL, the section or quote that needs attention, the corrected information, and a source
+            or reproduction step when available.
+          </p>
+          <p>
+            For chart behavior, include the chart name, version, Kubernetes version, and relevant values or logs when
+            they help confirm the issue.
+          </p>
+        </section>
+
+        <section class="glass-panel rounded-2xl p-6">
+          <h2 class="text-lg font-bold text-text-base heading-font">Where to report</h2>
+          <div class="mt-4 flex flex-wrap gap-3 text-sm">
+            <a
+              href="https://github.com/helmforgedev/site/issues/new"
+              target="_blank"
+              rel="noopener noreferrer"
+              class="inline-flex rounded-lg border border-primary/40 bg-primary/10 px-4 py-2 font-semibold text-primary-light hover:bg-primary/20 transition-colors"
+            >
+              Open a site issue
+            </a>
+            <a
+              href="mailto:berlofa@helmforge.dev"
+              class="inline-flex rounded-lg border border-border px-4 py-2 font-semibold text-text-base hover:border-primary/40 hover:text-primary-light transition-colors"
+            >
+              Email maintainers
+            </a>
+          </div>
+        </section>
+      </div>
+    </Container>
+  </main>
+
+  <Footer />
+</BaseLayout>

--- a/src/pages/editorial-policy.astro
+++ b/src/pages/editorial-policy.astro
@@ -1,0 +1,70 @@
+---
+import BaseLayout from '../layouts/BaseLayout.astro';
+import Header from '../components/Header.astro';
+import Footer from '../components/Footer.astro';
+import Container from '../components/Container.astro';
+import SectionHeader from '../components/SectionHeader.astro';
+
+const policyJsonLd = {
+  '@context': 'https://schema.org',
+  '@type': 'WebPage',
+  name: 'HelmForge Editorial Policy',
+  url: 'https://helmforge.dev/editorial-policy',
+  about: 'Editorial standards for HelmForge technical content',
+};
+
+const sections = [
+  {
+    title: 'Technical review',
+    body: 'Articles should be grounded in working Helm, Kubernetes, or project repository behavior. Commands, paths, and configuration examples are reviewed against the current HelmForge codebase when possible.',
+  },
+  {
+    title: 'Source selection',
+    body: 'Posts favor primary sources such as upstream documentation, release notes, project repositories, and official specifications. When a claim depends on current behavior, the source should be linked or reproducible.',
+  },
+  {
+    title: 'AI and editorial assistance',
+    body: 'Automation and AI tools may assist with drafts, checks, and formatting. Maintainers remain responsible for factual review, final wording, and publication decisions.',
+  },
+  {
+    title: 'Corrections',
+    body: 'Material errors are corrected when discovered. Meaningful updates should preserve or add visible updated dates so readers can understand when guidance changed.',
+  },
+  {
+    title: 'Update policy',
+    body: 'Dates are not changed for cosmetic edits. Updated dates are reserved for meaningful technical changes, migration guidance, corrected behavior, or refreshed references.',
+  },
+];
+---
+
+<BaseLayout
+  title="Editorial Policy"
+  description="HelmForge editorial standards for technical review, source selection, AI assistance, corrections, and update policy."
+>
+  <Header />
+  <script type="application/ld+json" set:html={JSON.stringify(policyJsonLd)} />
+
+  <main id="main-content" class="py-16 sm:py-20" data-pagefind-body>
+    <Container>
+      <SectionHeader
+        label="Editorial Policy"
+        as="h1"
+        title="How HelmForge publishes technical content."
+        description="These standards keep articles useful, verifiable, and honest about operational trade-offs."
+      />
+
+      <div class="mt-12 grid grid-cols-1 gap-4 md:grid-cols-2">
+        {
+          sections.map((section) => (
+            <section class="glass-panel rounded-2xl p-6">
+              <h2 class="text-lg font-bold text-text-base heading-font">{section.title}</h2>
+              <p class="mt-3 text-sm leading-relaxed text-text-muted">{section.body}</p>
+            </section>
+          ))
+        }
+      </div>
+    </Container>
+  </main>
+
+  <Footer />
+</BaseLayout>


### PR DESCRIPTION
Related to #170

## Summary

- adds the public Maicon Berlofa author profile with Person and ProfilePage JSON-LD
- links blog index cards, post bylines, and author sidebar cards to the author profile
- adds About, Contact, Editorial Policy, and Corrections pages for ownership and editorial trust signals
- enriches site Organization metadata and article author structured data with affiliation, sameAs, and author URL
- exposes trust pages in the footer and adds focused E2E coverage

## Validation

- [x] npm run lint
- [x] npm run format:check
- [x] npx prettier --check e2e/editorial-trust.spec.ts e2e/blog.spec.ts e2e/footer.spec.ts
- [x] npm run build
- [x] local internal link check after build: Checked 92 HTML files. Internal links OK.
- [x] npx playwright test e2e/blog.spec.ts e2e/footer.spec.ts e2e/editorial-trust.spec.ts - 108 passed

## MCP HelmForge

- validate_compliance: PASS, 28/28 guardrails
- check_pr_validity: allowed
- check_release_readiness: PASS