### PR TITLE
feat(blog): add editorial discovery strategy

### DIFF
--- a/e2e/blog.spec.ts
+++ b/e2e/blog.spec.ts
@@ -32,9 +32,14 @@ test.describe('Blog', () => {
   test('blog index exposes editorial sections, tags, and calendar', async ({ page }) => {
     await page.goto('/blog');
 
-    await expect(page.getByText('Editorial sections')).toBeVisible();
-    await expect(page.getByRole('link', { name: /Databases 1 posts/i })).toBeVisible();
-    await expect(page.getByRole('link', { name: /Kubernetes 0 posts/i })).toBeVisible();
+    const editorialSections = page.locator('section').filter({ hasText: 'Editorial sections' }).first();
+    await expect(editorialSections).toBeVisible();
+    await expect(editorialSections.locator('a[href="/blog/category/databases"]')).toContainText(
+      /Databases\s+\d+\s+posts/i,
+    );
+    await expect(editorialSections.locator('a[href="/blog/category/kubernetes"]')).toContainText(
+      /Kubernetes\s+\d+\s+posts/i,
+    );
     await expect(page.locator('a[href="/blog/tag/postgresql"]').first()).toBeVisible();
     await expect(page.locator('a[aria-label="Open editorial calendar"]')).toHaveAttribute(
       'href',

--- a/e2e/blog.spec.ts
+++ b/e2e/blog.spec.ts
@@ -29,6 +29,19 @@ test.describe('Blog', () => {
     await expect(actions.locator('a[aria-label="Subscribe via RSS"]')).toBeVisible();
   });
 
+  test('blog index exposes editorial sections, tags, and calendar', async ({ page }) => {
+    await page.goto('/blog');
+
+    await expect(page.getByText('Editorial sections')).toBeVisible();
+    await expect(page.getByRole('link', { name: /Databases 1 posts/i })).toBeVisible();
+    await expect(page.getByRole('link', { name: /Kubernetes 0 posts/i })).toBeVisible();
+    await expect(page.locator('a[href="/blog/tag/postgresql"]').first()).toBeVisible();
+    await expect(page.locator('a[aria-label="Open editorial calendar"]')).toHaveAttribute(
+      'href',
+      '/blog/editorial-calendar',
+    );
+  });
+
   test('blog cards expose title, description, author, and date', async ({ page }) => {
     await page.goto('/blog');
 
@@ -47,7 +60,7 @@ test.describe('Blog', () => {
     expect(href).toBeTruthy();
 
     await page.goto(href!);
-    await expect(page.locator('article')).toBeVisible();
+    await expect(page.locator('article[data-pagefind-body]')).toBeVisible();
     // Reading time should be visible
     await expect(page.locator('text=/\\d+ min read/')).toBeVisible();
   });
@@ -58,14 +71,19 @@ test.describe('Blog', () => {
     const href = await firstPost.getAttribute('href');
     await page.goto(href!);
 
-    // Should have a time element
-    await expect(page.locator('time')).toBeVisible();
-    // Should have at least one tag
-    expect(
-      await page
-        .locator('[class*="tag"], [class*="badge"], span:has-text("helm"), span:has-text("kubernetes")')
-        .count(),
-    ).toBeGreaterThan(0);
+    await expect(page.locator('header time').first()).toBeVisible();
+    await expect(page.locator('a[href^="/blog/category/"]').first()).toBeVisible();
+    await expect(page.locator('a[href^="/blog/tag/"]').first()).toBeVisible();
+  });
+
+  test('category and tag pages render grouped posts', async ({ page }) => {
+    await page.goto('/blog/category/databases');
+    await expect(page.locator('h1')).toContainText('Databases');
+    await expect(page.locator('a[href="/blog/production-postgresql-kubernetes"]:has(h2)')).toBeVisible();
+
+    await page.goto('/blog/tag/postgresql');
+    await expect(page.locator('h1')).toContainText('Postgresql');
+    await expect(page.locator('a[href="/blog/production-postgresql-kubernetes"]:has(h2)')).toBeVisible();
   });
 
   test('blog post has share links', async ({ page }) => {
@@ -126,6 +144,26 @@ test.describe('Blog', () => {
     await expect(ctaSection.locator('a[aria-label="Subscribe via RSS"]')).toHaveAttribute('href', '/blog/rss.xml');
   });
 
+  test('blog post includes discovery links to charts, related posts, latest posts, and read next', async ({ page }) => {
+    await page.goto('/blog/production-postgresql-kubernetes');
+
+    const relatedCharts = page.locator('aside section').filter({ hasText: 'Related chart docs' });
+    await expect(relatedCharts).toContainText('postgresql');
+    await expect(relatedCharts.locator('a[href="/docs/charts/postgresql"]')).toBeVisible();
+    await expect(page.getByText('Related analysis')).toBeVisible();
+    await expect(page.locator('aside section').filter({ hasText: 'Latest posts' })).toBeVisible();
+    await expect(page.getByRole('link', { name: /Read next/i })).toBeVisible();
+  });
+
+  test('editorial calendar publishes a 12 week content plan', async ({ page }) => {
+    await page.goto('/blog/editorial-calendar');
+
+    await expect(page.locator('h1')).toContainText('Consistent, useful Kubernetes and Helm coverage');
+    await expect(page.locator('section:has(time)')).toHaveCount(12);
+    await expect(page.getByText('Kubernetes release readiness')).toBeVisible();
+    await expect(page.getByText('CNCF ecosystem')).toBeVisible();
+  });
+
   test('newsletter page embeds listmonk form', async ({ page }) => {
     await page.goto('/newsletter');
     await expect(page).toHaveTitle(/Newsletter/i);
@@ -153,6 +191,7 @@ test.describe('Blog', () => {
     );
 
     expect(article).toBeTruthy();
+    expect(article.articleSection).toBe('Releases');
     expect(article.author).toMatchObject({
       '@type': 'Person',
       name: 'Maicon Berlofa',

--- a/scripts/validate-blog-standards.mjs
+++ b/scripts/validate-blog-standards.mjs
@@ -25,6 +25,7 @@ const OFFICIAL_REFERENCE_HOSTS = new Set([
   'prometheus.io',
   'grafana.com',
   'cncf.io',
+  'modelcontextprotocol.io',
 ]);
 
 const NON_OFFICIAL_BANNED_HOSTS = new Set(['replicated.com', 'knowledge.broadcom.com', 'medium.com']);
@@ -60,6 +61,44 @@ function getFrontmatterTags(frontmatter) {
         .toLowerCase(),
     )
     .filter(Boolean);
+}
+
+function validateCategory(frontmatter, filePath, errors) {
+  const allowedCategories = new Set([
+    'kubernetes',
+    'helm',
+    'cncf',
+    'security',
+    'databases',
+    'operations',
+    'releases',
+    'comparisons',
+  ]);
+  const category = getFrontmatterScalar(frontmatter, 'category');
+
+  if (!category) {
+    errors.push(`${filePath}: category is required for editorial discovery`);
+    return;
+  }
+  if (!allowedCategories.has(category)) {
+    errors.push(`${filePath}: category "${category}" is not an approved editorial section`);
+  }
+}
+
+function validateEditorialQuality(frontmatter, filePath, errors) {
+  const title = getFrontmatterScalar(frontmatter, 'title') ?? '';
+  const description = getFrontmatterScalar(frontmatter, 'description') ?? '';
+  const clickbaitPattern = /\b(shocking|secret|destroyed|panic|you won't believe|what happened next)\b/i;
+
+  if (clickbaitPattern.test(title) || clickbaitPattern.test(description)) {
+    errors.push(`${filePath}: title and description must avoid clickbait language`);
+  }
+  if (title.length < 24) {
+    errors.push(`${filePath}: title should capture the article angle clearly`);
+  }
+  if (description.length < 80) {
+    errors.push(`${filePath}: description should explain the practical value of the post`);
+  }
 }
 
 function getSignificantSlugTokens(filePath) {
@@ -129,6 +168,7 @@ function validateReferencesSection(body, filePath, errors) {
   const referencesHeading = /^##\s+References\s*$/im;
   const headingMatch = referencesHeading.exec(body);
   if (!headingMatch) {
+    errors.push(`${filePath}: technical posts must include a ## References section with official sources`);
     return;
   }
 
@@ -272,6 +312,8 @@ function main() {
     const tags = getFrontmatterTags(frontmatter);
 
     validateAuthorId(frontmatter, fullPath, allowedAuthorIds, errors);
+    validateCategory(frontmatter, fullPath, errors);
+    validateEditorialQuality(frontmatter, fullPath, errors);
     validateCoverImage(frontmatter, fullPath, errors, warnings, seenCoverImages);
     validateTechnicalVisual(tags, body, fullPath, errors);
     validateReferencesSection(body, fullPath, errors);

--- a/scripts/validate-blog-standards.mjs
+++ b/scripts/validate-blog-standards.mjs
@@ -205,6 +205,11 @@ function validateReferencesSection(body, filePath, errors, required) {
   const section = nextHeading === -1 ? remaining : remaining.slice(0, nextHeading);
 
   const urls = [...section.matchAll(/\[[^\]]+\]\((https?:\/\/[^)\s]+)\)/g)].map((m) => m[1]);
+  if (required && urls.length === 0) {
+    errors.push(`${filePath}: technical posts must include at least one official source link in ## References`);
+    return;
+  }
+
   for (const rawUrl of urls) {
     try {
       const hostname = new URL(rawUrl).hostname;

--- a/scripts/validate-blog-standards.mjs
+++ b/scripts/validate-blog-standards.mjs
@@ -101,6 +101,31 @@ function validateEditorialQuality(frontmatter, filePath, errors) {
   }
 }
 
+function isTechnicalPost(frontmatter, tags) {
+  const category = getFrontmatterScalar(frontmatter, 'category');
+  const isAnnouncement = tags.includes('announcement');
+  const technicalCategories = new Set(['kubernetes', 'helm', 'security', 'databases', 'operations', 'releases']);
+  const technicalTags = new Set([
+    'cri-o',
+    'database',
+    'docker',
+    'generic-chart',
+    'helm',
+    'images',
+    'kubernetes',
+    'migration',
+    'operations',
+    'postgresql',
+    'tutorial',
+  ]);
+
+  if (isAnnouncement) {
+    return false;
+  }
+
+  return technicalCategories.has(category) || tags.some((tag) => technicalTags.has(tag));
+}
+
 function getSignificantSlugTokens(filePath) {
   const stopWords = new Set(['a', 'an', 'and', 'for', 'in', 'on', 'the', 'to', 'vs', 'with']);
   return path
@@ -164,11 +189,13 @@ function hostIsBanned(hostname) {
   return false;
 }
 
-function validateReferencesSection(body, filePath, errors) {
+function validateReferencesSection(body, filePath, errors, required) {
   const referencesHeading = /^##\s+References\s*$/im;
   const headingMatch = referencesHeading.exec(body);
   if (!headingMatch) {
-    errors.push(`${filePath}: technical posts must include a ## References section with official sources`);
+    if (required) {
+      errors.push(`${filePath}: technical posts must include a ## References section with official sources`);
+    }
     return;
   }
 
@@ -316,7 +343,7 @@ function main() {
     validateEditorialQuality(frontmatter, fullPath, errors);
     validateCoverImage(frontmatter, fullPath, errors, warnings, seenCoverImages);
     validateTechnicalVisual(tags, body, fullPath, errors);
-    validateReferencesSection(body, fullPath, errors);
+    validateReferencesSection(body, fullPath, errors, isTechnicalPost(frontmatter, tags));
   }
 
   if (errors.length > 0) {

--- a/src/components/BlogPostCard.astro
+++ b/src/components/BlogPostCard.astro
@@ -1,0 +1,80 @@
+---
+import type { CollectionEntry } from 'astro:content';
+import { AUTHORS, DEFAULT_AUTHOR_ID, getAuthorUrl } from '../data/authors';
+import { getBlogCategory } from '../data/blog';
+import { getCategoryUrl, getTagUrl } from '../lib/blogDiscovery';
+import { getPublishedDate } from '../lib/blogFeed';
+
+type BlogPost = CollectionEntry<'blog'>;
+
+interface Props {
+  post: BlogPost;
+  compact?: boolean;
+}
+
+const { post, compact = false } = Astro.props;
+const author = AUTHORS[post.data.authorId] ?? AUTHORS[DEFAULT_AUTHOR_ID];
+const publishedDate = getPublishedDate(post);
+const category = getBlogCategory(post.data.category);
+---
+
+<article
+  class:list={[
+    'group glass-panel overflow-hidden transition-all hover:border-primary/40 hover:-translate-y-1 hover:shadow-xl hover:shadow-primary/10 flex flex-col',
+    compact ? 'rounded-xl' : 'rounded-2xl',
+  ]}
+>
+  <div class:list={['flex flex-col flex-grow', compact ? 'p-5' : 'p-6']}>
+    <div class="mb-3 flex flex-wrap items-center gap-2">
+      <a
+        href={getCategoryUrl(category.slug)}
+        class="rounded-full bg-primary/10 px-2.5 py-0.5 text-[10px] font-bold uppercase tracking-wider text-primary hover:bg-primary/20 transition-colors"
+      >
+        {category.label}
+      </a>
+      {
+        post.data.tags.slice(0, compact ? 1 : 2).map((tag) => (
+          <a
+            href={getTagUrl(tag)}
+            class="rounded-full border border-border px-2.5 py-0.5 text-[10px] font-bold uppercase tracking-wider text-text-muted hover:border-primary/40 hover:text-primary-light transition-colors"
+          >
+            {tag}
+          </a>
+        ))
+      }
+    </div>
+    <a href={`/blog/${post.id}`} class="group/title">
+      <h2
+        class:list={[
+          'font-bold text-text-base heading-font group-hover/title:text-primary-light transition-colors leading-snug',
+          compact ? 'text-base' : 'text-lg',
+        ]}
+      >
+        {post.data.title}
+      </h2>
+    </a>
+    <p
+      class:list={['mt-2 text-sm text-text-muted leading-relaxed flex-grow', compact ? 'line-clamp-2' : 'line-clamp-3']}
+    >
+      {post.data.description}
+    </p>
+    <div class="mt-4 flex items-center justify-between gap-3 text-xs text-text-muted">
+      <div class="flex min-w-0 flex-wrap items-center gap-2">
+        <a href={getAuthorUrl(author)} class="font-semibold text-text-base hover:text-primary-light transition-colors">
+          {author.name}
+        </a>
+        <span class="text-border">|</span>
+        <time datetime={publishedDate.toISOString()}>
+          {
+            publishedDate.toLocaleDateString('en-US', {
+              month: 'short',
+              day: 'numeric',
+              year: 'numeric',
+            })
+          }
+        </time>
+      </div>
+      <span class="shrink-0 text-primary-light opacity-0 transition-opacity group-hover:opacity-100">Read</span>
+    </div>
+  </div>
+</article>

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -1,6 +1,7 @@
 import { defineCollection, z } from 'astro:content';
 import { glob } from 'astro/loaders';
 import { AUTHORS } from './data/authors';
+import { BLOG_CATEGORIES } from './data/blog';
 
 const AUTHOR_IDS = Object.keys(AUTHORS) as [string, ...string[]];
 
@@ -13,7 +14,9 @@ const blog = defineCollection({
     publishDate: z.coerce.date().optional(),
     updatedAt: z.coerce.date().optional(),
     authorId: z.enum(AUTHOR_IDS),
+    category: z.enum(BLOG_CATEGORIES),
     tags: z.array(z.string()).default([]),
+    relatedCharts: z.array(z.string()).default([]),
     image: z.string().optional(),
     coverImage: z.string().min(1),
     coverAlt: z.string().min(24),

--- a/src/content/blog/fastmcp-server-deploy-mcp-anywhere.mdx
+++ b/src/content/blog/fastmcp-server-deploy-mcp-anywhere.mdx
@@ -4,7 +4,9 @@ description: 'Introducing FastMCP Server — a standalone Docker image that dyna
 date: 2026-04-05
 publishDate: 2026-04-05
 authorId: 'maicon-berlofa'
+category: 'operations'
 tags: ['mcp', 'ai', 'docker', 'fastmcp', 'knowledge-base']
+relatedCharts: ['fastmcp-server', 'generic']
 coverImage: '/blog/2026-04-05-fastmcp-server-deploy-mcp-anywhere-hero.webp'
 coverAlt: 'FastMCP Server deployment model for dynamic tools resources prompts and knowledge bases'
 ---
@@ -93,3 +95,8 @@ The server starts with no tools (that is fine) and the healthcheck endpoint resp
 - [Docker image on Docker Hub](https://hub.docker.com/r/helmforge/fastmcp-server)
 - [Source code](https://github.com/helmforgedev/fastmcp-server)
 - [Helm chart documentation](https://helmforge.dev/docs/charts/fastmcp-server)
+
+## References
+
+- [Model Context Protocol documentation](https://modelcontextprotocol.io/)
+- [Docker bind mounts documentation](https://docs.docker.com/engine/storage/bind-mounts/)

--- a/src/content/blog/helmforge-vs-bitnami.mdx
+++ b/src/content/blog/helmforge-vs-bitnami.mdx
@@ -4,7 +4,9 @@ description: 'An honest look at how HelmForge charts compare to Bitnami — imag
 date: 2026-04-01
 publishDate: 2026-04-01
 authorId: 'maicon-berlofa'
+category: 'comparisons'
 tags: ['comparison', 'bitnami', 'kubernetes']
+relatedCharts: ['postgresql', 'redis', 'mysql', 'keycloak', 'velero']
 coverImage: '/blog/2026-04-01-helmforge-vs-bitnami-hero.webp'
 coverAlt: 'HelmForge versus Bitnami practical comparison for Kubernetes Helm charts'
 ---
@@ -72,3 +74,8 @@ Bitnami charts do not include backup functionality. You need to build your own b
 Both projects serve the Kubernetes community well. HelmForge is not trying to replace Bitnami — it is offering an alternative for teams that want official images, built-in backup, and a more opinionated approach to production readiness.
 
 Explore the [full comparison table](/docs/comparison) for a detailed feature-by-feature breakdown.
+
+## References
+
+- [Helm chart documentation](https://helm.sh/docs/topics/charts/)
+- [Docker Official Images documentation](https://docs.docker.com/docker-hub/image-library/trusted-content/)

--- a/src/content/blog/introducing-helmforge.mdx
+++ b/src/content/blog/introducing-helmforge.mdx
@@ -4,7 +4,9 @@ description: 'The story behind HelmForge — production-ready Helm charts built 
 date: 2026-04-01
 publishDate: 2026-04-01
 authorId: 'maicon-berlofa'
+category: 'cncf'
 tags: ['announcement', 'open-source', 'kubernetes']
+relatedCharts: ['postgresql', 'redis', 'generic', 'velero']
 coverImage: '/blog/2026-04-01-introducing-helmforge-hero.webp'
 coverAlt: 'Introducing HelmForge production-ready Helm charts for Kubernetes'
 ---
@@ -55,3 +57,9 @@ Since our first release, HelmForge has grown to over 30 stable charts covering d
 We are actively building more charts based on community requests. If there is an application you want to see in HelmForge, [request it](/request) and the community votes on priorities.
 
 HelmForge is Apache-2.0 licensed and always will be. Check out the [getting started guide](/docs/getting-started) or browse the [chart catalog](/) to find what you need.
+
+## References
+
+- [Helm project documentation](https://helm.sh/docs/)
+- [Kubernetes documentation](https://kubernetes.io/docs/home/)
+- [CNCF project landscape](https://www.cncf.io/projects/)

--- a/src/content/blog/kubernetes-1-34-image-short-names.mdx
+++ b/src/content/blog/kubernetes-1-34-image-short-names.mdx
@@ -4,7 +4,9 @@ description: 'A practical guide to the short-image-name failures seen with Kuber
 date: 2026-04-03
 publishDate: 2026-04-03
 authorId: 'maicon-berlofa'
+category: 'releases'
 tags: ['kubernetes', 'cri-o', 'images', 'operations']
+relatedCharts: ['generic']
 coverImage: '/blog/2026-04-03-kubernetes-1-34-short-name-enforcement-hero.webp'
 coverAlt: 'Kubernetes 1.34 and CRI-O 1.34 short-name enforcement overview'
 ---

--- a/src/content/blog/migration-generic-breaking-platform-contract.mdx
+++ b/src/content/blog/migration-generic-breaking-platform-contract.mdx
@@ -4,7 +4,9 @@ description: 'A focused migration guide for the Generic chart breaking feature r
 date: 2026-04-27
 publishDate: 2026-04-27
 authorId: 'maicon-berlofa'
+category: 'helm'
 tags: ['helm', 'generic-chart', 'migration', 'kubernetes']
+relatedCharts: ['generic']
 coverImage: '/blog/2026-04-27-generic-breaking-platform-contract-hero.webp'
 coverAlt: 'HelmForge Generic chart migration guide'
 ---
@@ -50,3 +52,8 @@ pass only after the platform operators are present.
 The chart now prefers deterministic, explicit behavior over permissive defaults. The result is a safer generic chart,
 but some previous values that rendered loosely will now fail fast so teams can fix the contract before the manifests
 reach a cluster.
+
+## References
+
+- [Helm chart template guide](https://helm.sh/docs/chart_template_guide/)
+- [Kubernetes workloads documentation](https://kubernetes.io/docs/concepts/workloads/)

--- a/src/content/blog/production-postgresql-kubernetes.mdx
+++ b/src/content/blog/production-postgresql-kubernetes.mdx
@@ -4,7 +4,9 @@ description: 'Run PostgreSQL with replication, backups, and real monitoring usin
 date: 2026-04-02
 publishDate: 2026-04-02
 authorId: 'maicon-berlofa'
+category: 'databases'
 tags: ['tutorial', 'postgresql', 'database', 'kubernetes']
+relatedCharts: ['postgresql', 'mysql', 'mariadb', 'mongodb']
 coverImage: '/blog/2026-04-02-production-postgresql-kubernetes-hero.webp'
 coverAlt: 'Production PostgreSQL on Kubernetes with replication, backup, and monitoring'
 ---
@@ -173,3 +175,9 @@ Confirm the artifact appears in your S3 bucket/prefix.
 
 - Full chart reference: [/docs/charts/postgresql](/docs/charts/postgresql)
 - Related guides: [/docs/charts/mysql](/docs/charts/mysql), [/docs/charts/mariadb](/docs/charts/mariadb), [/docs/charts/mongodb](/docs/charts/mongodb)
+
+## References
+
+- [PostgreSQL documentation](https://www.postgresql.org/docs/)
+- [Kubernetes StatefulSet documentation](https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/)
+- [Prometheus documentation](https://prometheus.io/docs/introduction/overview/)

--- a/src/data/blog.ts
+++ b/src/data/blog.ts
@@ -1,0 +1,81 @@
+export const BLOG_CATEGORIES = [
+  'kubernetes',
+  'helm',
+  'cncf',
+  'security',
+  'databases',
+  'operations',
+  'releases',
+  'comparisons',
+] as const;
+
+export type BlogCategorySlug = (typeof BLOG_CATEGORIES)[number];
+
+export type BlogCategory = {
+  slug: BlogCategorySlug;
+  label: string;
+  description: string;
+};
+
+export const BLOG_CATEGORY_DETAILS: Record<BlogCategorySlug, BlogCategory> = {
+  kubernetes: {
+    slug: 'kubernetes',
+    label: 'Kubernetes',
+    description: 'Cluster behavior, workloads, APIs, and operational changes that affect application teams.',
+  },
+  helm: {
+    slug: 'helm',
+    label: 'Helm',
+    description: 'Packaging patterns, chart design, values contracts, and Helm repository operations.',
+  },
+  cncf: {
+    slug: 'cncf',
+    label: 'CNCF',
+    description: 'Cloud native ecosystem work, project maturity, governance, and standards relevant to operators.',
+  },
+  security: {
+    slug: 'security',
+    label: 'Security',
+    description: 'Supply-chain, image provenance, CVEs, policy, and secure-by-default Kubernetes deployments.',
+  },
+  databases: {
+    slug: 'databases',
+    label: 'Databases',
+    description: 'PostgreSQL, Redis, MySQL, backups, replication, recovery, and stateful application operations.',
+  },
+  operations: {
+    slug: 'operations',
+    label: 'Operations',
+    description: 'Practical production workflows for backups, observability, upgrades, and incident prevention.',
+  },
+  releases: {
+    slug: 'releases',
+    label: 'Releases',
+    description: 'Release notes, breaking changes, migration windows, and upgrade guidance.',
+  },
+  comparisons: {
+    slug: 'comparisons',
+    label: 'Comparisons',
+    description: 'Practical trade-off analysis across charts, images, platforms, and deployment patterns.',
+  },
+};
+
+export function getBlogCategory(slug: BlogCategorySlug) {
+  return BLOG_CATEGORY_DETAILS[slug];
+}
+
+export function slugifyBlogTag(tag: string) {
+  return tag
+    .toLowerCase()
+    .trim()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+}
+
+export function formatBlogTag(tag: string) {
+  return tag
+    .split(/[-\s]+/)
+    .filter(Boolean)
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(' ');
+}

--- a/src/layouts/BlogLayout.astro
+++ b/src/layouts/BlogLayout.astro
@@ -4,7 +4,10 @@ import Header from '../components/Header.astro';
 import Footer from '../components/Footer.astro';
 import Container from '../components/Container.astro';
 import BlogHero from '../components/BlogHero.astro';
+import BlogPostCard from '../components/BlogPostCard.astro';
 import { getAuthorUrl, type AuthorProfile } from '../data/authors';
+import { getBlogCategory, type BlogCategorySlug } from '../data/blog';
+import { getCategoryUrl, getTagUrl, getBlogPostUrl, type BlogPost } from '../lib/blogDiscovery';
 
 type ArticleSchemaType = 'Article' | 'BlogPosting' | 'NewsArticle';
 
@@ -15,12 +18,18 @@ interface Props {
   publishDate?: Date;
   updatedAt?: Date;
   author: AuthorProfile;
+  category: BlogCategorySlug;
   tags: string[];
+  relatedCharts: string[];
   readingTime: number;
   postSlug: string;
   coverImage: string;
   coverAlt: string;
   schemaType?: ArticleSchemaType;
+  relatedPosts?: BlogPost[];
+  latestPosts?: BlogPost[];
+  newerPost?: BlogPost;
+  olderPost?: BlogPost;
 }
 
 const {
@@ -30,12 +39,18 @@ const {
   publishDate,
   updatedAt,
   author,
+  category,
   tags,
+  relatedCharts,
   readingTime,
   postSlug,
   coverImage,
   coverAlt,
   schemaType = 'BlogPosting',
+  relatedPosts = [],
+  latestPosts = [],
+  newerPost,
+  olderPost,
 } = Astro.props;
 
 const publishedDate = publishDate ?? date;
@@ -51,7 +66,8 @@ const formattedModifiedDate = modifiedDate.toLocaleDateString('en-US', {
   day: 'numeric',
 });
 const canonicalUrl = `https://helmforge.dev/blog/${postSlug}`;
-const articleSection = tags[0] ?? 'Blog';
+const categoryDetails = getBlogCategory(category);
+const articleSection = categoryDetails.label;
 const articleImage = new URL(coverImage, Astro.site).href;
 const authorUrl = new URL(getAuthorUrl(author), Astro.site).href;
 const showUpdatedDate = modifiedDate.valueOf() !== publishedDate.valueOf();
@@ -65,6 +81,7 @@ const articleJsonLd = {
   dateModified: modifiedDate.toISOString(),
   inLanguage: 'en',
   isAccessibleForFree: true,
+  articleSection,
   author: {
     '@type': 'Person',
     name: author.name,
@@ -125,11 +142,20 @@ const articleJsonLd = {
       <div class="lg:col-span-8 xl:col-span-9">
         <header class="mb-8">
           <div class="flex flex-wrap items-center gap-2 mb-4">
+            <a
+              href={getCategoryUrl(category)}
+              class="text-[10px] font-bold uppercase tracking-wider text-primary bg-primary/10 rounded-full px-2.5 py-0.5 hover:bg-primary/20 transition-colors"
+            >
+              {categoryDetails.label}
+            </a>
             {
               tags.map((tag) => (
-                <span class="text-[10px] font-bold uppercase tracking-wider text-primary bg-primary/10 rounded-full px-2.5 py-0.5">
+                <a
+                  href={getTagUrl(tag)}
+                  class="text-[10px] font-bold uppercase tracking-wider text-text-muted border border-border rounded-full px-2.5 py-0.5 hover:border-primary/40 hover:text-primary-light transition-colors"
+                >
                   {tag}
-                </span>
+                </a>
               ))
             }
           </div>
@@ -199,10 +225,95 @@ const articleJsonLd = {
             </div>
           </section>
         </article>
+
+        {
+          relatedPosts.length > 0 && (
+            <section class="mt-8">
+              <div class="mb-4 flex items-center justify-between gap-4">
+                <h2 class="text-xl font-bold text-text-base heading-font">Related analysis</h2>
+                <a href={getCategoryUrl(category)} class="text-sm font-semibold text-primary-light hover:text-primary">
+                  More in {categoryDetails.label}
+                </a>
+              </div>
+              <div class="grid grid-cols-1 gap-4 md:grid-cols-3">
+                {relatedPosts.map((post) => (
+                  <BlogPostCard post={post} compact />
+                ))}
+              </div>
+            </section>
+          )
+        }
+
+        <section class="mt-8 grid grid-cols-1 gap-4 md:grid-cols-2">
+          {
+            newerPost && (
+              <a
+                href={getBlogPostUrl(newerPost)}
+                class="rounded-xl border border-border bg-bg-surface/40 p-5 transition-colors hover:border-primary/40"
+              >
+                <p class="text-xs uppercase tracking-wider text-text-muted">Newer post</p>
+                <h2 class="mt-2 text-base font-bold text-text-base heading-font">{newerPost.data.title}</h2>
+              </a>
+            )
+          }
+          {
+            olderPost && (
+              <a
+                href={getBlogPostUrl(olderPost)}
+                class="rounded-xl border border-border bg-bg-surface/40 p-5 transition-colors hover:border-primary/40"
+              >
+                <p class="text-xs uppercase tracking-wider text-text-muted">Read next</p>
+                <h2 class="mt-2 text-base font-bold text-text-base heading-font">{olderPost.data.title}</h2>
+              </a>
+            )
+          }
+        </section>
       </div>
 
       <aside class="lg:col-span-4 xl:col-span-3">
         <div class="sticky top-24 space-y-4">
+          <section class="glass-panel rounded-2xl p-5">
+            <p class="text-xs uppercase tracking-wider text-text-muted mb-2">Section</p>
+            <a href={getCategoryUrl(category)} class="text-lg font-semibold text-text-base hover:text-primary-light">
+              {categoryDetails.label}
+            </a>
+            <p class="mt-2 text-sm leading-relaxed text-text-muted">{categoryDetails.description}</p>
+          </section>
+
+          {
+            relatedCharts.length > 0 && (
+              <section class="glass-panel rounded-2xl p-5">
+                <p class="text-xs uppercase tracking-wider text-text-muted mb-2">Related chart docs</p>
+                <div class="flex flex-wrap gap-2">
+                  {relatedCharts.map((chart) => (
+                    <a
+                      href={`/docs/charts/${chart}`}
+                      class="rounded-md border border-border px-2.5 py-1.5 text-xs font-semibold text-text-base hover:border-primary/40 hover:text-primary-light transition-colors"
+                    >
+                      {chart}
+                    </a>
+                  ))}
+                </div>
+              </section>
+            )
+          }
+
+          <section class="glass-panel rounded-2xl p-5">
+            <p class="text-xs uppercase tracking-wider text-text-muted mb-2">Latest posts</p>
+            <div class="space-y-3">
+              {
+                latestPosts.map((post) => (
+                  <a
+                    href={getBlogPostUrl(post)}
+                    class="block rounded-lg border border-border/70 p-3 hover:border-primary/40"
+                  >
+                    <p class="text-sm font-semibold leading-snug text-text-base">{post.data.title}</p>
+                  </a>
+                ))
+              }
+            </div>
+          </section>
+
           <section class="glass-panel rounded-2xl p-5">
             <p class="text-xs uppercase tracking-wider text-text-muted mb-2">Written by</p>
             <a

--- a/src/lib/blogDiscovery.ts
+++ b/src/lib/blogDiscovery.ts
@@ -1,0 +1,91 @@
+import type { CollectionEntry } from 'astro:content';
+import { BLOG_CATEGORY_DETAILS, slugifyBlogTag, type BlogCategorySlug } from '../data/blog';
+import { getPublishedDate } from './blogFeed';
+
+export type BlogPost = CollectionEntry<'blog'>;
+
+export function getBlogPostUrl(post: BlogPost) {
+  return `/blog/${post.id}`;
+}
+
+export function getCategoryUrl(category: BlogCategorySlug) {
+  return `/blog/category/${category}`;
+}
+
+export function getTagUrl(tag: string) {
+  return `/blog/tag/${slugifyBlogTag(tag)}`;
+}
+
+export function getSortedPosts(posts: BlogPost[]) {
+  return [...posts].sort((a, b) => getPublishedDate(b).valueOf() - getPublishedDate(a).valueOf());
+}
+
+export function getAllTags(posts: BlogPost[]) {
+  const tagMap = new Map<string, { tag: string; slug: string; count: number }>();
+
+  for (const post of posts) {
+    for (const tag of post.data.tags) {
+      const slug = slugifyBlogTag(tag);
+      const existing = tagMap.get(slug);
+      if (existing) {
+        existing.count += 1;
+      } else {
+        tagMap.set(slug, { tag, slug, count: 1 });
+      }
+    }
+  }
+
+  return [...tagMap.values()].sort((a, b) => b.count - a.count || a.tag.localeCompare(b.tag));
+}
+
+export function getPostsByCategory(posts: BlogPost[], category: BlogCategorySlug) {
+  return getSortedPosts(posts).filter((post) => post.data.category === category);
+}
+
+export function getPostsByTag(posts: BlogPost[], tagSlug: string) {
+  return getSortedPosts(posts).filter((post) => post.data.tags.some((tag) => slugifyBlogTag(tag) === tagSlug));
+}
+
+export function getCategoryCounts(posts: BlogPost[]) {
+  return Object.fromEntries(
+    Object.keys(BLOG_CATEGORY_DETAILS).map((category) => [
+      category,
+      posts.filter((post) => post.data.category === category).length,
+    ]),
+  ) as Record<BlogCategorySlug, number>;
+}
+
+export function getRelatedPosts(currentPost: BlogPost, posts: BlogPost[], limit = 3) {
+  const currentTags = new Set(currentPost.data.tags.map(slugifyBlogTag));
+  const currentCharts = new Set(currentPost.data.relatedCharts);
+
+  return posts
+    .filter((post) => post.id !== currentPost.id)
+    .map((post) => {
+      const sharedTags = post.data.tags.filter((tag) => currentTags.has(slugifyBlogTag(tag))).length;
+      const sharedCharts = post.data.relatedCharts.filter((chart) => currentCharts.has(chart)).length;
+      const categoryScore = post.data.category === currentPost.data.category ? 4 : 0;
+      const score = categoryScore + sharedTags * 2 + sharedCharts * 3;
+      return { post, score };
+    })
+    .filter(({ score }) => score > 0)
+    .sort((a, b) => b.score - a.score || getPublishedDate(b.post).valueOf() - getPublishedDate(a.post).valueOf())
+    .slice(0, limit)
+    .map(({ post }) => post);
+}
+
+export function getLatestPosts(posts: BlogPost[], currentPost?: BlogPost, limit = 3) {
+  return getSortedPosts(posts)
+    .filter((post) => post.id !== currentPost?.id)
+    .slice(0, limit);
+}
+
+export function getAdjacentPosts(currentPost: BlogPost, posts: BlogPost[]) {
+  const sorted = getSortedPosts(posts);
+  const index = sorted.findIndex((post) => post.id === currentPost.id);
+
+  return {
+    newerPost: index > 0 ? sorted[index - 1] : undefined,
+    olderPost: index >= 0 && index < sorted.length - 1 ? sorted[index + 1] : undefined,
+  };
+}

--- a/src/lib/blogFeed.ts
+++ b/src/lib/blogFeed.ts
@@ -3,6 +3,7 @@ import path from 'node:path';
 import type { CollectionEntry } from 'astro:content';
 import type { RSSFeedItem } from '@astrojs/rss';
 import { AUTHORS, DEFAULT_AUTHOR_ID } from '../data/authors';
+import { getBlogCategory } from '../data/blog';
 
 type BlogPost = CollectionEntry<'blog'>;
 
@@ -45,7 +46,7 @@ export function getBlogRssItems(posts: BlogPost[], site: URL): RSSFeedItem[] {
       description: post.data.description,
       link: canonicalUrl,
       pubDate: getPublishedDate(post),
-      categories: post.data.tags,
+      categories: [getBlogCategory(post.data.category).label, ...post.data.tags],
       author: author.name,
       enclosure: {
         url: imageUrl,

--- a/src/pages/blog/[...slug].astro
+++ b/src/pages/blog/[...slug].astro
@@ -2,6 +2,7 @@
 import { getCollection, render } from 'astro:content';
 import BlogLayout from '../../layouts/BlogLayout.astro';
 import { AUTHORS, DEFAULT_AUTHOR_ID } from '../../data/authors';
+import { getAdjacentPosts, getLatestPosts, getRelatedPosts } from '../../lib/blogDiscovery';
 
 export async function getStaticPaths() {
   const posts = await getCollection('blog');
@@ -12,10 +13,14 @@ export async function getStaticPaths() {
 }
 
 const { post } = Astro.props;
+const posts = await getCollection('blog');
 const { Content } = await render(post);
 const author = AUTHORS[post.data.authorId] ?? AUTHORS[DEFAULT_AUTHOR_ID];
 const words = post.body.trim().split(/\s+/).filter(Boolean).length;
 const readingTime = Math.max(1, Math.ceil(words / 220));
+const relatedPosts = getRelatedPosts(post, posts);
+const latestPosts = getLatestPosts(posts, post);
+const { newerPost, olderPost } = getAdjacentPosts(post, posts);
 ---
 
 <BlogLayout
@@ -25,12 +30,18 @@ const readingTime = Math.max(1, Math.ceil(words / 220));
   publishDate={post.data.publishDate}
   updatedAt={post.data.updatedAt}
   author={author}
+  category={post.data.category}
   tags={post.data.tags}
+  relatedCharts={post.data.relatedCharts}
   readingTime={readingTime}
   postSlug={post.id}
   coverImage={post.data.coverImage}
   coverAlt={post.data.coverAlt}
   schemaType={post.data.schemaType}
+  relatedPosts={relatedPosts}
+  latestPosts={latestPosts}
+  newerPost={newerPost}
+  olderPost={olderPost}
 >
   <Content />
 </BlogLayout>

--- a/src/pages/blog/category/[category].astro
+++ b/src/pages/blog/category/[category].astro
@@ -1,0 +1,48 @@
+---
+import { getCollection } from 'astro:content';
+import BaseLayout from '../../../layouts/BaseLayout.astro';
+import Header from '../../../components/Header.astro';
+import Footer from '../../../components/Footer.astro';
+import Container from '../../../components/Container.astro';
+import SectionHeader from '../../../components/SectionHeader.astro';
+import BlogPostCard from '../../../components/BlogPostCard.astro';
+import { BLOG_CATEGORIES, BLOG_CATEGORY_DETAILS, type BlogCategorySlug } from '../../../data/blog';
+import { getPostsByCategory } from '../../../lib/blogDiscovery';
+
+export async function getStaticPaths() {
+  const posts = await getCollection('blog');
+  return BLOG_CATEGORIES.map((category) => ({
+    params: { category },
+    props: {
+      category,
+      posts: getPostsByCategory(posts, category),
+    },
+  }));
+}
+
+const { category, posts } = Astro.props as {
+  category: BlogCategorySlug;
+  posts: Awaited<ReturnType<typeof getCollection<'blog'>>>;
+};
+const categoryDetails = BLOG_CATEGORY_DETAILS[category];
+---
+
+<BaseLayout
+  title={`${categoryDetails.label} Blog Posts`}
+  description={`${categoryDetails.description} Browse HelmForge articles in the ${categoryDetails.label} editorial section.`}
+>
+  <Header />
+  <main id="main-content" class="py-16 sm:py-20" data-pagefind-body>
+    <Container>
+      <a href="/blog" class="mb-8 inline-flex text-sm text-text-muted transition-colors hover:text-primary-light">
+        Back to blog
+      </a>
+      <SectionHeader label="Category" as="h1" title={categoryDetails.label} description={categoryDetails.description} />
+
+      <div class="mt-12 grid grid-cols-1 gap-6 md:grid-cols-2 lg:grid-cols-3">
+        {posts.map((post) => <BlogPostCard post={post} />)}
+      </div>
+    </Container>
+  </main>
+  <Footer />
+</BaseLayout>

--- a/src/pages/blog/editorial-calendar.astro
+++ b/src/pages/blog/editorial-calendar.astro
@@ -1,0 +1,159 @@
+---
+import BaseLayout from '../../layouts/BaseLayout.astro';
+import Header from '../../components/Header.astro';
+import Footer from '../../components/Footer.astro';
+import Container from '../../components/Container.astro';
+import SectionHeader from '../../components/SectionHeader.astro';
+
+const weeks = [
+  {
+    week: '2026-05-04',
+    theme: 'Kubernetes release readiness',
+    posts: [
+      'Kubernetes upgrade preflight checks for Helm users',
+      'What operators should test before moving CRI runtimes',
+      'Short image names cleanup checklist for platform teams',
+    ],
+  },
+  {
+    week: '2026-05-11',
+    theme: 'PostgreSQL and recovery',
+    posts: [
+      'PostgreSQL restore drills on Kubernetes',
+      'Replica lag signals that matter before production traffic',
+      'S3-compatible backup design for database charts',
+    ],
+  },
+  {
+    week: '2026-05-18',
+    theme: 'Helm chart contracts',
+    posts: [
+      'Values schema as a platform contract',
+      'Designing safe defaults without hiding trade-offs',
+      'Generic chart migration patterns from real workloads',
+    ],
+  },
+  {
+    week: '2026-05-25',
+    theme: 'Supply chain security',
+    posts: [
+      'Cosign and chart provenance for small platform teams',
+      'SBOM expectations for Kubernetes application delivery',
+      'When official images simplify incident response',
+    ],
+  },
+  {
+    week: '2026-06-01',
+    theme: 'Redis, RabbitMQ, and queues',
+    posts: [
+      'Redis persistence choices on Kubernetes',
+      'RabbitMQ health checks that catch real failures',
+      'Operational differences between cache and queue workloads',
+    ],
+  },
+  {
+    week: '2026-06-08',
+    theme: 'GitOps delivery',
+    posts: [
+      'Argo CD sync waves for stateful applications',
+      'Flux image automation with explicit registries',
+      'Keeping generated values reviewable in pull requests',
+    ],
+  },
+  {
+    week: '2026-06-15',
+    theme: 'Identity and access',
+    posts: [
+      'Keycloak chart hardening for production realms',
+      'Secret rotation patterns for Helm-managed applications',
+      'Ingress TLS and identity provider failure modes',
+    ],
+  },
+  {
+    week: '2026-06-22',
+    theme: 'Bitnami and migration strategy',
+    posts: [
+      'Bitnami migration inventory for platform teams',
+      'Replacing image assumptions without rewriting every chart',
+      'How to phase chart migration by operational risk',
+    ],
+  },
+  {
+    week: '2026-06-29',
+    theme: 'Observability and incidents',
+    posts: [
+      'Prometheus alerts for HelmForge database charts',
+      'Reading pod events during failed chart upgrades',
+      'Metrics that should block a production rollout',
+    ],
+  },
+  {
+    week: '2026-07-06',
+    theme: 'CNCF ecosystem',
+    posts: [
+      'Artifact Hub metadata that helps operators trust a chart',
+      'CNCF sandbox expectations from a maintainer perspective',
+      'How small projects can document governance early',
+    ],
+  },
+  {
+    week: '2026-07-13',
+    theme: 'MySQL and MariaDB',
+    posts: [
+      'MySQL backup validation on Kubernetes',
+      'MariaDB upgrade windows and rollback planning',
+      'Choosing PostgreSQL, MySQL, or MariaDB for self-hosted apps',
+    ],
+  },
+  {
+    week: '2026-07-20',
+    theme: 'Release operations',
+    posts: [
+      'Writing release notes that operators can act on',
+      'Chart deprecation policy without surprising users',
+      'Post-release validation after Helm repository publishing',
+    ],
+  },
+];
+---
+
+<BaseLayout
+  title="HelmForge Editorial Calendar"
+  description="A 12-week HelmForge blog editorial calendar for Kubernetes, Helm, databases, security, CNCF, and operations discovery."
+>
+  <Header />
+  <main id="main-content" class="py-16 sm:py-20" data-pagefind-body>
+    <Container>
+      <a href="/blog" class="mb-8 inline-flex text-sm text-text-muted transition-colors hover:text-primary-light">
+        Back to blog
+      </a>
+      <SectionHeader
+        label="Editorial Calendar"
+        as="h1"
+        title="Consistent, useful Kubernetes and Helm coverage."
+        description="A 12-week publishing plan focused on timely operator problems, original analysis, practical value, and official references."
+      />
+
+      <div class="mt-12 space-y-4">
+        {
+          weeks.map((week) => (
+            <section class="rounded-xl border border-border bg-bg-surface/40 p-5">
+              <div class="flex flex-col gap-1 sm:flex-row sm:items-center sm:justify-between">
+                <h2 class="text-lg font-bold text-text-base heading-font">{week.theme}</h2>
+                <time class="text-sm text-text-muted" datetime={week.week}>
+                  Week of {week.week}
+                </time>
+              </div>
+              <ul class="mt-4 grid grid-cols-1 gap-3 md:grid-cols-3">
+                {week.posts.map((post) => (
+                  <li class="rounded-lg border border-border/70 px-3 py-2 text-sm text-text-muted">{post}</li>
+                ))}
+              </ul>
+            </section>
+          ))
+        }
+      </div>
+    </Container>
+  </main>
+  <Footer />
+</BaseLayout>

--- a/src/pages/blog/index.astro
+++ b/src/pages/blog/index.astro
@@ -4,13 +4,16 @@ import Header from '../../components/Header.astro';
 import Footer from '../../components/Footer.astro';
 import Container from '../../components/Container.astro';
 import SectionHeader from '../../components/SectionHeader.astro';
+import BlogPostCard from '../../components/BlogPostCard.astro';
 import { getCollection } from 'astro:content';
-import { AUTHORS, DEFAULT_AUTHOR_ID, getAuthorUrl } from '../../data/authors';
+import { BLOG_CATEGORIES, BLOG_CATEGORY_DETAILS } from '../../data/blog';
+import { getAllTags, getCategoryCounts } from '../../lib/blogDiscovery';
+import { getSortedBlogPosts } from '../../lib/blogFeed';
 
 const allPosts = await getCollection('blog');
-const getPublishedDate = (post: (typeof allPosts)[number]) => post.data.publishDate ?? post.data.date;
-const posts = allPosts.sort((a, b) => getPublishedDate(b).valueOf() - getPublishedDate(a).valueOf());
-const getAuthor = (authorId: string) => AUTHORS[authorId] ?? AUTHORS[DEFAULT_AUTHOR_ID];
+const posts = getSortedBlogPosts(allPosts);
+const categoryCounts = getCategoryCounts(posts);
+const tags = getAllTags(posts).slice(0, 12);
 ---
 
 <BaseLayout
@@ -54,59 +57,58 @@ const getAuthor = (authorId: string) => AUTHORS[authorId] ?? AUTHORS[DEFAULT_AUT
               d="M4 11a9 9 0 019 9m-9-5a5 5 0 015 5m-5-9a13 13 0 0113 13M5 19h.01"></path>
           </svg>
         </a>
+        <a
+          href="/blog/editorial-calendar"
+          class="inline-flex items-center gap-2 rounded-lg border border-border px-4 py-2 text-sm font-semibold text-text-base hover:border-primary/40 hover:text-primary-light transition-colors"
+          aria-label="Open editorial calendar"
+        >
+          Editorial Calendar
+        </a>
       </div>
 
-      <div class="mt-12 grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
-        {
-          posts.map((post) => {
-            const author = getAuthor(post.data.authorId);
-            return (
-              <article class="group glass-panel rounded-2xl overflow-hidden transition-all hover:border-primary/40 hover:-translate-y-1 hover:shadow-xl hover:shadow-primary/10 flex flex-col">
-                <div class="p-6 flex flex-col flex-grow">
-                  <div class="flex flex-wrap gap-2 mb-3">
-                    {post.data.tags.slice(0, 2).map((tag) => (
-                      <span class="text-[10px] font-bold uppercase tracking-wider text-primary bg-primary/10 rounded-full px-2 py-0.5">
-                        {tag}
-                      </span>
-                    ))}
-                  </div>
-                  <a href={`/blog/${post.id}`} class="group">
-                    <h2 class="text-lg font-bold text-text-base heading-font group-hover:text-primary-light transition-colors leading-snug">
-                      {post.data.title}
-                    </h2>
-                  </a>
-                  <p class="mt-2 text-sm text-text-muted leading-relaxed line-clamp-3 flex-grow">
-                    {post.data.description}
-                  </p>
-                  <div class="mt-4 flex items-center justify-between text-xs text-text-muted">
-                    <div class="flex items-center gap-2">
-                      <a
-                        href={getAuthorUrl(author)}
-                        class="font-semibold text-text-base hover:text-primary-light transition-colors"
-                      >
-                        {author.name}
-                      </a>
-                      <span class="text-border">|</span>
-                      <time datetime={getPublishedDate(post).toISOString()}>
-                        {getPublishedDate(post).toLocaleDateString('en-US', {
-                          month: 'short',
-                          day: 'numeric',
-                          year: 'numeric',
-                        })}
-                      </time>
+      <section class="mt-10 grid grid-cols-1 gap-6 lg:grid-cols-[minmax(0,1.35fr)_minmax(0,0.65fr)]">
+        <div>
+          <h2 class="text-sm font-bold uppercase tracking-[0.18em] text-text-base">Editorial sections</h2>
+          <div class="mt-4 grid grid-cols-1 gap-3 sm:grid-cols-2">
+            {
+              BLOG_CATEGORIES.map((slug) => {
+                const category = BLOG_CATEGORY_DETAILS[slug];
+                return (
+                  <a
+                    href={`/blog/category/${category.slug}`}
+                    class="rounded-xl border border-border bg-bg-surface/40 p-4 transition-colors hover:border-primary/40"
+                  >
+                    <div class="flex items-center justify-between gap-3">
+                      <span class="text-sm font-semibold text-text-base">{category.label}</span>
+                      <span class="text-xs text-text-muted">{categoryCounts[slug]} posts</span>
                     </div>
-                    <span class="flex items-center gap-1 text-primary-light opacity-0 group-hover:opacity-100 transition-opacity">
-                      Read
-                      <svg class="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" />
-                      </svg>
-                    </span>
-                  </div>
-                </div>
-              </article>
-            );
-          })
-        }
+                    <p class="mt-2 line-clamp-2 text-xs leading-relaxed text-text-muted">{category.description}</p>
+                  </a>
+                );
+              })
+            }
+          </div>
+        </div>
+
+        <div>
+          <h2 class="text-sm font-bold uppercase tracking-[0.18em] text-text-base">Popular tags</h2>
+          <div class="mt-4 flex flex-wrap gap-2">
+            {
+              tags.map((tag) => (
+                <a
+                  href={`/blog/tag/${tag.slug}`}
+                  class="rounded-full border border-border px-3 py-1 text-xs font-semibold text-text-muted transition-colors hover:border-primary/40 hover:text-primary-light"
+                >
+                  {tag.tag}
+                </a>
+              ))
+            }
+          </div>
+        </div>
+      </section>
+
+      <div class="mt-12 grid grid-cols-1 gap-6 md:grid-cols-2 lg:grid-cols-3">
+        {posts.map((post) => <BlogPostCard post={post} />)}
       </div>
     </Container>
   </main>

--- a/src/pages/blog/tag/[tag].astro
+++ b/src/pages/blog/tag/[tag].astro
@@ -1,0 +1,55 @@
+---
+import { getCollection } from 'astro:content';
+import BaseLayout from '../../../layouts/BaseLayout.astro';
+import Header from '../../../components/Header.astro';
+import Footer from '../../../components/Footer.astro';
+import Container from '../../../components/Container.astro';
+import SectionHeader from '../../../components/SectionHeader.astro';
+import BlogPostCard from '../../../components/BlogPostCard.astro';
+import { formatBlogTag } from '../../../data/blog';
+import { getAllTags, getPostsByTag } from '../../../lib/blogDiscovery';
+
+export async function getStaticPaths() {
+  const posts = await getCollection('blog');
+  return getAllTags(posts).map(({ tag, slug }) => ({
+    params: { tag: slug },
+    props: {
+      tag,
+      slug,
+      posts: getPostsByTag(posts, slug),
+    },
+  }));
+}
+
+const { tag, posts } = Astro.props as {
+  tag: string;
+  slug: string;
+  posts: Awaited<ReturnType<typeof getCollection<'blog'>>>;
+};
+const label = formatBlogTag(tag);
+---
+
+<BaseLayout
+  title={`${label} Blog Posts`}
+  description={`HelmForge articles tagged ${label}, with practical Kubernetes and Helm operations guidance.`}
+>
+  <Header />
+  <main id="main-content" class="py-16 sm:py-20" data-pagefind-body>
+    <Container>
+      <a href="/blog" class="mb-8 inline-flex text-sm text-text-muted transition-colors hover:text-primary-light">
+        Back to blog
+      </a>
+      <SectionHeader
+        label="Tag"
+        as="h1"
+        title={label}
+        description={`Articles tagged ${label}, grouped for deeper topical discovery.`}
+      />
+
+      <div class="mt-12 grid grid-cols-1 gap-6 md:grid-cols-2 lg:grid-cols-3">
+        {posts.map((post) => <BlogPostCard post={post} />)}
+      </div>
+    </Container>
+  </main>
+  <Footer />
+</BaseLayout>

--- a/src/pages/docs/charts/fastmcp-server.mdx
+++ b/src/pages/docs/charts/fastmcp-server.mdx
@@ -432,6 +432,7 @@ pdb:
 
 ## More Information
 
+- [Blog guide: Deploy MCP Servers Anywhere with FastMCP Server](/blog/fastmcp-server-deploy-mcp-anywhere)
 - [FastMCP Server source](https://github.com/helmforgedev/fastmcp-server)
 - [FastMCP upstream project](https://github.com/jlowin/fastmcp)
 - [Chart source and full values reference](https://github.com/helmforgedev/charts/tree/main/charts/fastmcp-server)

--- a/src/pages/docs/charts/generic.mdx
+++ b/src/pages/docs/charts/generic.mdx
@@ -378,5 +378,7 @@ Deployment and StatefulSet HPA resources use the Kubernetes `autoscaling/v2` API
 
 ## More Information
 
+- [Blog guide: Migrating to the Generic Chart Breaking Platform Contract](/blog/migration-generic-breaking-platform-contract)
+- [Blog guide: Kubernetes 1.34 and Short Image Names](/blog/kubernetes-1-34-image-short-names)
 - [HelmForge Generic Chart Source](https://github.com/helmforgedev/charts/tree/main/charts/generic)
 - [Kubernetes Documentation](https://kubernetes.io/docs/home/)

--- a/src/pages/docs/charts/postgresql.mdx
+++ b/src/pages/docs/charts/postgresql.mdx
@@ -459,6 +459,7 @@ This reference covers the complete `values.yaml` surface for the PostgreSQL char
 
 ## More Information
 
+- [Blog guide: Deploy Production-Ready PostgreSQL on Kubernetes](/blog/production-postgresql-kubernetes)
 - [PostgreSQL Official Website](https://www.postgresql.org)
 - [PostgreSQL Official Documentation](https://www.postgresql.org/docs/current/)
 - [PostgreSQL Docker Official Image](https://hub.docker.com/_/postgres)

--- a/src/pages/docs/comparison.mdx
+++ b/src/pages/docs/comparison.mdx
@@ -518,3 +518,8 @@ helm uninstall <old-bitnami-release-name>
 ```
 
 > **Tip:** Use `helm diff` (helm-diff plugin) to compare rendered templates before committing to the migration.
+
+## Related Blog Analysis
+
+- [HelmForge vs Bitnami: A Practical Comparison](/blog/helmforge-vs-bitnami)
+- [Kubernetes 1.34 and Short Image Names: What Broke, Why, and How to Fix It Fast](/blog/kubernetes-1-34-image-short-names)


### PR DESCRIPTION
Related to #172

## Summary

- adds explicit blog editorial categories and tag/category archive pages
- refactors blog cards into a reusable component and links category/tag chips
- adds related posts, latest posts, related chart docs, and read-next navigation to article pages
- adds a 12-week editorial calendar for timely Kubernetes, Helm, CNCF, database, security, and operations coverage
- adds category/related chart frontmatter to all existing posts and official References sections for technical posts
- adds crosslinks from relevant chart/docs pages back to blog analysis
- strengthens blog standards validation for category metadata, official references, and non-clickbait titles/descriptions

## Validation

- [x] npm run lint
- [x] npm run format:check
- [x] npx prettier --check e2e/blog.spec.ts scripts/validate-blog-standards.mjs src/content/blog/*.mdx src/pages/docs/charts/fastmcp-server.mdx src/pages/docs/charts/generic.mdx src/pages/docs/charts/postgresql.mdx src/pages/docs/comparison.mdx
- [x] npm run build - 120 pages built
- [x] local internal link check after build - Checked 120 HTML files. Internal links OK.
- [x] npx playwright test e2e/blog.spec.ts e2e/footer.spec.ts e2e/editorial-trust.spec.ts - 120 passed

## MCP HelmForge

- validate_compliance: PASS, 28/28 guardrails
- check_pr_validity: allowed
- check_release_readiness: PASS

## Chart Docs Evidence

Changed chart docs only append related blog links. Existing complete values coverage and official/upstream product links were reviewed and left intact.