### PR TITLE
fix(blog): compact editorial sections

### DIFF
--- a/e2e/blog.spec.ts
+++ b/e2e/blog.spec.ts
@@ -35,11 +35,9 @@ test.describe('Blog', () => {
     const editorialSections = page.locator('section').filter({ hasText: 'Editorial sections' }).first();
     await expect(editorialSections).toBeVisible();
     await expect(editorialSections.locator('a[href="/blog/category/databases"]')).toContainText(
-      /Databases\s+\d+\s+posts/i,
+      /Databases\s+1/i,
     );
-    await expect(editorialSections.locator('a[href="/blog/category/kubernetes"]')).toContainText(
-      /Kubernetes\s+\d+\s+posts/i,
-    );
+    await expect(editorialSections.locator('a[href="/blog/category/kubernetes"]')).toContainText(/Kubernetes\s+1/i);
     await expect(page.locator('a[href="/blog/tag/postgresql"]').first()).toBeVisible();
     await expect(page.locator('a[aria-label="Open editorial calendar"]')).toHaveAttribute(
       'href',
@@ -82,6 +80,10 @@ test.describe('Blog', () => {
   });
 
   test('category and tag pages render grouped posts', async ({ page }) => {
+    await page.goto('/blog/category/kubernetes');
+    await expect(page.locator('h1')).toContainText('Kubernetes');
+    await expect(page.locator('a[href="/blog/kubernetes-1-34-image-short-names"]:has(h2)')).toBeVisible();
+
     await page.goto('/blog/category/databases');
     await expect(page.locator('h1')).toContainText('Databases');
     await expect(page.locator('a[href="/blog/production-postgresql-kubernetes"]:has(h2)')).toBeVisible();
@@ -196,7 +198,7 @@ test.describe('Blog', () => {
     );
 
     expect(article).toBeTruthy();
-    expect(article.articleSection).toBe('Releases');
+    expect(article.articleSection).toBe('Kubernetes');
     expect(article.author).toMatchObject({
       '@type': 'Person',
       name: 'Maicon Berlofa',

--- a/reports/blog-performance-report.md
+++ b/reports/blog-performance-report.md
@@ -31,12 +31,12 @@ Use this report as the recurring Phase 7 review artifact after Search Console, B
 
 | URL | Title | Category | Published | Updated | Google clicks | Impressions | CTR | Avg position | Discover clicks | Bing clicks | CWV notes |
 | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
-[/blog/migration-generic-breaking-platform-contract](https://helmforge.dev/blog/migration-generic-breaking-platform-contract) | Migrating to the Generic Chart Breaking Platform Contract | helm | 2026-04-27 | - |  |  |  |  |  |  | 
-[/blog/fastmcp-server-deploy-mcp-anywhere](https://helmforge.dev/blog/fastmcp-server-deploy-mcp-anywhere) | Deploy MCP Servers Anywhere with FastMCP Server | operations | 2026-04-05 | - |  |  |  |  |  |  | 
-[/blog/kubernetes-1-34-image-short-names](https://helmforge.dev/blog/kubernetes-1-34-image-short-names) | Kubernetes 1.34 and Short Image Names: What Broke, Why, and How to Fix It Fast | releases | 2026-04-03 | - |  |  |  |  |  |  | 
-[/blog/production-postgresql-kubernetes](https://helmforge.dev/blog/production-postgresql-kubernetes) | Deploy Production-Ready PostgreSQL on Kubernetes | databases | 2026-04-02 | - |  |  |  |  |  |  | 
-[/blog/helmforge-vs-bitnami](https://helmforge.dev/blog/helmforge-vs-bitnami) | HelmForge vs Bitnami: A Practical Comparison | comparisons | 2026-04-01 | - |  |  |  |  |  |  | 
-[/blog/introducing-helmforge](https://helmforge.dev/blog/introducing-helmforge) | Introducing HelmForge: Why We Built It | cncf | 2026-04-01 | - |  |  |  |  |  |  | 
+[/blog/migration-generic-breaking-platform-contract](https://helmforge.dev/blog/migration-generic-breaking-platform-contract) | Migrating to the Generic Chart Breaking Platform Contract | helm | 2026-04-27 | - |  |  |  |  |  |  |
+[/blog/fastmcp-server-deploy-mcp-anywhere](https://helmforge.dev/blog/fastmcp-server-deploy-mcp-anywhere) | Deploy MCP Servers Anywhere with FastMCP Server | operations | 2026-04-05 | - |  |  |  |  |  |  |
+[/blog/kubernetes-1-34-image-short-names](https://helmforge.dev/blog/kubernetes-1-34-image-short-names) | Kubernetes 1.34 and Short Image Names: What Broke, Why, and How to Fix It Fast | kubernetes | 2026-04-03 | 2026-04-03 |  |  |  |  |  |  |
+[/blog/production-postgresql-kubernetes](https://helmforge.dev/blog/production-postgresql-kubernetes) | Deploy Production-Ready PostgreSQL on Kubernetes | databases | 2026-04-02 | - |  |  |  |  |  |  |
+[/blog/helmforge-vs-bitnami](https://helmforge.dev/blog/helmforge-vs-bitnami) | HelmForge vs Bitnami: A Practical Comparison | comparisons | 2026-04-01 | - |  |  |  |  |  |  |
+[/blog/introducing-helmforge](https://helmforge.dev/blog/introducing-helmforge) | Introducing HelmForge: Why We Built It | cncf | 2026-04-01 | - |  |  |  |  |  |  |
 
 <!-- prettier-ignore-end -->
 

--- a/scripts/generate-blog-performance-report.mjs
+++ b/scripts/generate-blog-performance-report.mjs
@@ -93,7 +93,9 @@ function buildReport(posts) {
         '',
         '',
         '',
-      ].join(' | '),
+      ]
+        .join(' | ')
+        .trimEnd(),
     )
     .join('\n');
 

--- a/src/content/blog/kubernetes-1-34-image-short-names.mdx
+++ b/src/content/blog/kubernetes-1-34-image-short-names.mdx
@@ -3,12 +3,14 @@ title: 'Kubernetes 1.34 and Short Image Names: What Broke, Why, and How to Fix I
 description: 'A practical guide to the short-image-name failures seen with Kubernetes 1.34 + CRI-O, with mitigation playbooks and a pre-upgrade checklist.'
 date: 2026-04-03
 publishDate: 2026-04-03
+updatedAt: 2026-04-03
 authorId: 'maicon-berlofa'
-category: 'releases'
+category: 'kubernetes'
 tags: ['kubernetes', 'cri-o', 'images', 'operations']
 relatedCharts: ['generic']
 coverImage: '/blog/2026-04-03-kubernetes-1-34-short-name-enforcement-hero.webp'
 coverAlt: 'Kubernetes 1.34 and CRI-O 1.34 short-name enforcement overview'
+schemaType: 'BlogPosting'
 ---
 
 If you upgraded to Kubernetes 1.34 and suddenly saw pod failures like `short name mode is enforcing`, you are not alone.

--- a/src/pages/blog/index.astro
+++ b/src/pages/blog/index.astro
@@ -13,6 +13,7 @@ import { getSortedBlogPosts } from '../../lib/blogFeed';
 const allPosts = await getCollection('blog');
 const posts = getSortedBlogPosts(allPosts);
 const categoryCounts = getCategoryCounts(posts);
+const activeCategories = BLOG_CATEGORIES.filter((slug) => categoryCounts[slug] > 0);
 const tags = getAllTags(posts).slice(0, 12);
 ---
 
@@ -69,20 +70,19 @@ const tags = getAllTags(posts).slice(0, 12);
       <section class="mt-10 grid grid-cols-1 gap-6 lg:grid-cols-[minmax(0,1.35fr)_minmax(0,0.65fr)]">
         <div>
           <h2 class="text-sm font-bold uppercase tracking-[0.18em] text-text-base">Editorial sections</h2>
-          <div class="mt-4 grid grid-cols-1 gap-3 sm:grid-cols-2">
+          <div class="mt-4 flex flex-wrap gap-2">
             {
-              BLOG_CATEGORIES.map((slug) => {
+              activeCategories.map((slug) => {
                 const category = BLOG_CATEGORY_DETAILS[slug];
                 return (
                   <a
                     href={`/blog/category/${category.slug}`}
-                    class="rounded-xl border border-border bg-bg-surface/40 p-4 transition-colors hover:border-primary/40"
+                    class="inline-flex items-center gap-2 rounded-full border border-border px-3 py-1.5 text-xs font-semibold text-text-muted transition-colors hover:border-primary/40 hover:text-primary-light"
                   >
-                    <div class="flex items-center justify-between gap-3">
-                      <span class="text-sm font-semibold text-text-base">{category.label}</span>
-                      <span class="text-xs text-text-muted">{categoryCounts[slug]} posts</span>
-                    </div>
-                    <p class="mt-2 line-clamp-2 text-xs leading-relaxed text-text-muted">{category.description}</p>
+                    <span>{category.label}</span>
+                    <span class="rounded-full bg-bg-muted px-2 py-0.5 text-[11px] text-text-muted">
+                      {categoryCounts[slug]}
+                    </span>
                   </a>
                 );
               })


### PR DESCRIPTION
Related to #172

## Summary
- Compact the Blog index Editorial sections block into active category pills, rendering only categories with posts.
- Move the Kubernetes 1.34 short image names post from `releases` to `kubernetes`, fixing the category count and category page grouping.
- Keep blog discovery metadata explicit with `updatedAt` and `schemaType`.
- Refresh the blog performance report and trim generated report row whitespace.

## Validation
- `npm run format:check`
- `npm run lint`
- `npm run build`
- `npx playwright test e2e/blog.spec.ts --project=chromium`
- `npm run blog:performance-report -- --check`
- `npx prettier --check scripts/generate-blog-performance-report.mjs`
- `git diff --check`
- Internal `dist` link check
- HelmForge MCP release readiness: PASS
- HelmForge MCP compliance evidence: 40/41 pass. Remaining `GR-039` is a known false positive from scanning the full generated `reports/blog-performance-report.md`, which contains the existing post title `HelmForge vs Bitnami`; this PR does not introduce or change that post.