### PR TITLE
docs(postgresql): document dual-stack networking values

### DIFF
--- a/src/pages/docs/charts/postgresql.mdx
+++ b/src/pages/docs/charts/postgresql.mdx
@@ -174,6 +174,20 @@ tls:
 - `auth.database` remains the application bootstrap database. It is created only on first initialization of a fresh data directory.
 - `docker-entrypoint-initdb.d` scripts only run when the data directory is empty. Existing PVCs keep their current roles and databases during upgrades.
 
+## Dual-stack Networking
+
+PostgreSQL Services accept Kubernetes [dual-stack](https://kubernetes.io/docs/concepts/services-networking/dual-stack/) configuration. By default, both `service.ipFamilyPolicy` and `service.ipFamilies` are unset and the chart inherits whatever the cluster advertises (matching prior behavior). Setting them propagates to every chart-managed Service: client, primary, replicas, metrics, and the headless StatefulSet services.
+
+```yaml
+service:
+  ipFamilyPolicy: PreferDualStack
+  ipFamilies:
+    - IPv4
+    - IPv6
+```
+
+`PreferDualStack` is the safer choice for clusters that may be single- or dual-stack: omit `ipFamilies` and the cluster auto-populates whatever it supports. Set `ipFamilies` explicitly only when the cluster is configured for both families — the Kubernetes API rejects an explicit family the cluster does not advertise. `RequireDualStack` enforces both.
+
 ## Configuration Reference
 
 This reference covers the complete `values.yaml` surface for the PostgreSQL chart.
@@ -292,14 +306,16 @@ This reference covers the complete `values.yaml` surface for the PostgreSQL char
 
 ### Service
 
-| Parameter                     | Type    | Default     | Description                                            |
-| ----------------------------- | ------- | ----------- | ------------------------------------------------------ |
-| `service.type`                | string  | `ClusterIP` | Service type for PostgreSQL client access.             |
-| `service.annotations`         | object  | `{}`        | Annotations applied to the client Service.             |
-| `service.primaryAnnotations`  | object  | `{}`        | Annotations applied to the dedicated primary Service.  |
-| `service.replicasAnnotations` | object  | `{}`        | Annotations applied to the dedicated replicas Service. |
-| `service.port`                | integer | `5432`      | PostgreSQL listener port.                              |
-| `service.metricsPort`         | integer | `9187`      | Metrics port exposed when metrics are enabled.         |
+| Parameter                     | Type    | Default     | Description                                                                                                  |
+| ----------------------------- | ------- | ----------- | ------------------------------------------------------------------------------------------------------------ |
+| `service.type`                | string  | `ClusterIP` | Service type for PostgreSQL client access.                                                                   |
+| `service.annotations`         | object  | `{}`        | Annotations applied to the client Service.                                                                   |
+| `service.primaryAnnotations`  | object  | `{}`        | Annotations applied to the dedicated primary Service.                                                        |
+| `service.replicasAnnotations` | object  | `{}`        | Annotations applied to the dedicated replicas Service.                                                       |
+| `service.port`                | integer | `5432`      | PostgreSQL listener port.                                                                                    |
+| `service.metricsPort`         | integer | `9187`      | Metrics port exposed when metrics are enabled.                                                               |
+| `service.ipFamilyPolicy`      | string  | _omitted_   | Service IP family policy: `SingleStack`, `PreferDualStack`, or `RequireDualStack`. Omit for cluster default. |
+| `service.ipFamilies`          | array   | _omitted_   | Ordered list of IP families (`IPv4`, `IPv6`). Omit for cluster default.                                      |
 
 ### Metrics
 


### PR DESCRIPTION
## Summary

Documents the new dual-stack networking values (`service.ipFamilyPolicy` and `service.ipFamilies`) that the postgresql chart will expose. Adds a "Dual-stack Networking" section under Operational Notes and two rows in the Service configuration reference table.

## Notes

- Defaults remain unset; existing deployments are unaffected and inherit cluster defaults.
- Explains the difference between `PreferDualStack` (cluster auto-picks families) and the explicit-families variant (which requires the cluster to advertise both IPv4 and IPv6).

## Test plan

- [x] `npm run lint` passes
- [x] `npm run format:check` passes
- [x] `npm run build` succeeds (121 pages indexed)

Chart PR: helmforgedev/charts#127
Related to helmforgedev/charts#125