### PR TITLE
docs(drupal): document dual-stack networking values

### DIFF
--- a/src/pages/docs/charts/drupal.mdx
+++ b/src/pages/docs/charts/drupal.mdx
@@ -272,42 +272,58 @@ The chart still has an installer-oriented surface, but it now covers production 
 
 ### Service, Ingress, Probes, And Platform Values
 
-| Key                             | Default     | Description                                                 |
-| ------------------------------- | ----------- | ----------------------------------------------------------- |
-| `service.type`                  | `ClusterIP` | Drupal service type                                         |
-| `service.port`                  | `80`        | Drupal service port                                         |
-| `service.annotations`           | `{}`        | Annotations applied to the service                          |
-| `ingress.enabled`               | `false`     | Enable ingress resources                                    |
-| `ingress.ingressClassName`      | `""`        | Ingress class name                                          |
-| `ingress.annotations`           | `{}`        | Ingress annotations                                         |
-| `ingress.hosts`                 | `[]`        | Ingress host and path definitions                           |
-| `ingress.tls`                   | `[]`        | TLS secret mappings for ingress                             |
-| `startupProbe.enabled`          | `true`      | Enable the startup probe                                    |
-| `startupProbe.path`             | `/`         | Startup probe HTTP path                                     |
-| `livenessProbe.enabled`         | `true`      | Enable the liveness probe                                   |
-| `livenessProbe.path`            | `/`         | Liveness probe HTTP path                                    |
-| `readinessProbe.enabled`        | `true`      | Enable the readiness probe                                  |
-| `readinessProbe.path`           | `/`         | Readiness probe HTTP path                                   |
-| `resources.requests.cpu`        | `250m`      | Default CPU request for the Drupal container                |
-| `resources.requests.memory`     | `512Mi`     | Default memory request for the Drupal container             |
-| `resources.limits.cpu`          | `1`         | Default CPU limit for the Drupal container                  |
-| `resources.limits.memory`       | `1Gi`       | Default memory limit for the Drupal container               |
-| `podSecurityContext.fsGroup`    | `33`        | Group ownership applied to the mounted Drupal files volume  |
-| `securityContext`               | `{}`        | Container-level security context                            |
-| `serviceAccount.create`         | `false`     | Create a dedicated service account                          |
-| `serviceAccount.name`           | `""`        | Existing or custom service account name                     |
-| `serviceAccount.annotations`    | `{}`        | Service account annotations                                 |
-| `nodeSelector`                  | `{}`        | Node selector rules                                         |
-| `tolerations`                   | `[]`        | Pod tolerations                                             |
-| `affinity`                      | `{}`        | Pod affinity and anti-affinity                              |
-| `topologySpreadConstraints`     | `[]`        | Topology spread constraints                                 |
-| `priorityClassName`             | `""`        | Priority class for the pod                                  |
-| `terminationGracePeriodSeconds` | `30`        | Pod termination grace period                                |
-| `podLabels`                     | `{}`        | Extra pod labels                                            |
-| `podAnnotations`                | `{}`        | Extra pod annotations                                       |
-| `extraVolumes`                  | `[]`        | Additional volumes injected into the pod                    |
-| `extraVolumeMounts`             | `[]`        | Additional volume mounts injected into the Drupal container |
-| `extraManifests`                | `[]`        | Extra Kubernetes manifests rendered by the chart            |
+| Key                             | Default     | Description                                                                                                  |
+| ------------------------------- | ----------- | ------------------------------------------------------------------------------------------------------------ |
+| `service.type`                  | `ClusterIP` | Drupal service type                                                                                          |
+| `service.port`                  | `80`        | Drupal service port                                                                                          |
+| `service.annotations`           | `{}`        | Annotations applied to the service                                                                           |
+| `service.ipFamilyPolicy`        | _omitted_   | Service IP family policy: `SingleStack`, `PreferDualStack`, or `RequireDualStack`. Omit for cluster default. |
+| `service.ipFamilies`            | _omitted_   | Ordered list of IP families (`IPv4`, `IPv6`). Omit for cluster default.                                      |
+| `ingress.enabled`               | `false`     | Enable ingress resources                                                                                     |
+| `ingress.ingressClassName`      | `""`        | Ingress class name                                                                                           |
+| `ingress.annotations`           | `{}`        | Ingress annotations                                                                                          |
+| `ingress.hosts`                 | `[]`        | Ingress host and path definitions                                                                            |
+| `ingress.tls`                   | `[]`        | TLS secret mappings for ingress                                                                              |
+| `startupProbe.enabled`          | `true`      | Enable the startup probe                                                                                     |
+| `startupProbe.path`             | `/`         | Startup probe HTTP path                                                                                      |
+| `livenessProbe.enabled`         | `true`      | Enable the liveness probe                                                                                    |
+| `livenessProbe.path`            | `/`         | Liveness probe HTTP path                                                                                     |
+| `readinessProbe.enabled`        | `true`      | Enable the readiness probe                                                                                   |
+| `readinessProbe.path`           | `/`         | Readiness probe HTTP path                                                                                    |
+| `resources.requests.cpu`        | `250m`      | Default CPU request for the Drupal container                                                                 |
+| `resources.requests.memory`     | `512Mi`     | Default memory request for the Drupal container                                                              |
+| `resources.limits.cpu`          | `1`         | Default CPU limit for the Drupal container                                                                   |
+| `resources.limits.memory`       | `1Gi`       | Default memory limit for the Drupal container                                                                |
+| `podSecurityContext.fsGroup`    | `33`        | Group ownership applied to the mounted Drupal files volume                                                   |
+| `securityContext`               | `{}`        | Container-level security context                                                                             |
+| `serviceAccount.create`         | `false`     | Create a dedicated service account                                                                           |
+| `serviceAccount.name`           | `""`        | Existing or custom service account name                                                                      |
+| `serviceAccount.annotations`    | `{}`        | Service account annotations                                                                                  |
+| `nodeSelector`                  | `{}`        | Node selector rules                                                                                          |
+| `tolerations`                   | `[]`        | Pod tolerations                                                                                              |
+| `affinity`                      | `{}`        | Pod affinity and anti-affinity                                                                               |
+| `topologySpreadConstraints`     | `[]`        | Topology spread constraints                                                                                  |
+| `priorityClassName`             | `""`        | Priority class for the pod                                                                                   |
+| `terminationGracePeriodSeconds` | `30`        | Pod termination grace period                                                                                 |
+| `podLabels`                     | `{}`        | Extra pod labels                                                                                             |
+| `podAnnotations`                | `{}`        | Extra pod annotations                                                                                        |
+| `extraVolumes`                  | `[]`        | Additional volumes injected into the pod                                                                     |
+| `extraVolumeMounts`             | `[]`        | Additional volume mounts injected into the Drupal container                                                  |
+| `extraManifests`                | `[]`        | Extra Kubernetes manifests rendered by the chart                                                             |
+
+## Dual-stack Networking
+
+The Drupal Service accepts Kubernetes [dual-stack](https://kubernetes.io/docs/concepts/services-networking/dual-stack/) configuration. By default, both `service.ipFamilyPolicy` and `service.ipFamilies` are unset and the chart inherits whatever the cluster advertises (matching prior behavior).
+
+```yaml
+service:
+  ipFamilyPolicy: PreferDualStack
+  ipFamilies:
+    - IPv4
+    - IPv6
+```
+
+`PreferDualStack` is the safer choice for clusters that may be single- or dual-stack: omit `ipFamilies` and the cluster auto-populates whatever it supports. Set `ipFamilies` explicitly only when the cluster is configured for both families — the Kubernetes API rejects an explicit family the cluster does not advertise. `RequireDualStack` enforces both.
 
 ## More Information
 


### PR DESCRIPTION
## Summary

Documents the new dual-stack networking values (`service.ipFamilyPolicy` and `service.ipFamilies`) that the drupal chart will expose. Adds a "Dual-stack Networking" section and two rows in the Service values table.

## Notes

- Defaults remain unset; existing deployments are unaffected and inherit cluster defaults.
- Mirrors the postgresql and mysql doc structure delivered in helmforgedev/site#177 and helmforgedev/site#178.

## Test plan

- [x] `npm run lint` passes
- [x] `npm run format:check` passes
- [x] `npm run build` succeeds

Chart PR: helmforgedev/charts#129
Related to helmforgedev/charts#125