### PR TITLE
docs: rename Statistics for Strava title

### DIFF
--- a/src/data/charts.ts
+++ b/src/data/charts.ts
@@ -337,7 +337,7 @@ export const charts: Chart[] = [
     backup: true,
   },
   {
-    name: 'Strava Statistics',
+    name: 'Statistics for Strava',
     slug: 'strava-statistics',
     description: 'Self-hosted fitness dashboard with SQLite and Strava OAuth integration.',
     maturity: 'stable',

--- a/src/data/navigation.ts
+++ b/src/data/navigation.ts
@@ -143,7 +143,7 @@ export const chartCategories: ChartCategory[] = [
     label: 'Archiving & Fitness',
     charts: [
       { label: 'Wallabag', href: '/docs/charts/wallabag', maturity: 'stable' },
-      { label: 'Strava Statistics', href: '/docs/charts/strava-statistics', maturity: 'stable' },
+      { label: 'Statistics for Strava', href: '/docs/charts/strava-statistics', maturity: 'stable' },
       { label: 'ArchiveBox', href: '/docs/charts/archivebox', maturity: 'stable' },
       { label: 'Karakeep', href: '/docs/charts/karakeep', maturity: 'stable' },
       { label: 'Middleware', href: '/docs/charts/middleware', maturity: 'stable' },

--- a/src/pages/docs/charts/index.mdx
+++ b/src/pages/docs/charts/index.mdx
@@ -129,12 +129,12 @@ HelmForge provides production-ready Helm charts for common Kubernetes workloads.
 
 ## Archiving & Fitness
 
-| Chart                                               | Description                                                               |
-| --------------------------------------------------- | ------------------------------------------------------------------------- |
-| [Wallabag](/docs/charts/wallabag)                   | Self-hosted read-it-later with PostgreSQL, optional Redis                 |
-| [Strava Statistics](/docs/charts/strava-statistics) | Self-hosted fitness dashboard with SQLite and Strava OAuth integration    |
-| [ArchiveBox](/docs/charts/archivebox)               | Self-hosted web archiving with Chromium headless and multi-format capture |
-| [Karakeep](/docs/charts/karakeep)                   | AI-powered bookmark manager with Meilisearch and Chromium sidecars        |
+| Chart                                                   | Description                                                               |
+| ------------------------------------------------------- | ------------------------------------------------------------------------- |
+| [Wallabag](/docs/charts/wallabag)                       | Self-hosted read-it-later with PostgreSQL, optional Redis                 |
+| [Statistics for Strava](/docs/charts/strava-statistics) | Self-hosted fitness dashboard with SQLite and Strava OAuth integration    |
+| [ArchiveBox](/docs/charts/archivebox)                   | Self-hosted web archiving with Chromium headless and multi-format capture |
+| [Karakeep](/docs/charts/karakeep)                       | AI-powered bookmark manager with Meilisearch and Chromium sidecars        |
 
 ## DevOps & Metrics
 

--- a/src/pages/docs/charts/strava-statistics.mdx
+++ b/src/pages/docs/charts/strava-statistics.mdx
@@ -1,13 +1,13 @@
 ---
 layout: ../../../layouts/DocsLayout.astro
-title: Strava Statistics Chart
-description: HelmForge Strava Statistics chart — self-hosted fitness dashboard for Strava athletes with SQLite storage, OAuth integration, and detailed activity visualizations for Kubernetes.
+title: Statistics for Strava Chart
+description: HelmForge Statistics for Strava chart — self-hosted fitness dashboard for Strava athletes with SQLite storage, OAuth integration, and detailed activity visualizations for Kubernetes.
 ---
 
 import DocsTabs from '../../../components/DocsTabs.astro';
 import Callout from '../../../components/Callout.astro';
 
-# Strava Statistics
+# Statistics for Strava
 
 Self-hosted fitness dashboard for [Statistics for Strava](https://github.com/robiningelbrecht/strava-statistics).
 Pulls your complete activity history from the Strava API using OAuth and presents it as a rich, personal dashboard
@@ -88,7 +88,7 @@ helm install strava-statistics oci://ghcr.io/helmforgedev/helm/strava-statistics
 <div data-tab-panel="basic">
 
 ```yaml
-# values.yaml — Strava Statistics with inline credentials
+# values.yaml — Statistics for Strava with inline credentials
 strava:
   clientId: '12345'
   clientSecret: 'your-strava-client-secret'
@@ -145,7 +145,7 @@ ingress:
 <div data-tab-panel="tls">
 
 ```yaml
-# values.yaml — Strava Statistics with TLS via cert-manager
+# values.yaml — Statistics for Strava with TLS via cert-manager
 strava:
   clientId: '12345'
   clientSecret: 'your-strava-client-secret'
@@ -334,4 +334,4 @@ ingress:
 
 - [Statistics for Strava GitHub Repository](https://github.com/robiningelbrecht/strava-statistics)
 - [Strava Developers Portal](https://developers.strava.com)
-- [HelmForge Strava Statistics Chart Source](https://github.com/helmforgedev/charts/tree/main/charts/strava-statistics)
+- [HelmForge Statistics for Strava Chart Source](https://github.com/helmforgedev/charts/tree/main/charts/strava-statistics)


### PR DESCRIPTION
## Summary
- Rename the displayed chart title from Strava Statistics to Statistics for Strava.
- Update the chart listing, navigation label, page title, examples, and source reference text.
- Keep the existing `/docs/charts/strava-statistics/` path and chart slug unchanged for compatibility.

## Validation
- npm run format:check
- npm run lint
- npm run build
