### PR TITLE
fix(seo): normalize canonical metadata and sitemap coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,8 +59,7 @@ jobs:
             echo "ERROR: sitemap-index.xml not generated"
             exit 1
           fi
-          echo "Sitemap URLs:"
-          grep -o '<loc>[^<]*</loc>' dist/sitemap-0.xml | sed 's/<[^>]*>//g'
+          npm run seo:verify-sitemap
 
       - name: Verify pages
         run: |

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -31,6 +31,9 @@ jobs:
 
       - run: npm run build
 
+      - name: Verify sitemap coverage
+        run: npm run seo:verify-sitemap
+
       - name: Deploy to Cloudflare Pages
         uses: cloudflare/wrangler-action@v3
         with:

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   "scripts": {
     "dev": "astro dev",
     "build": "astro build && pagefind --site dist",
+    "seo:verify-sitemap": "node scripts/verify-sitemap.mjs",
     "preview": "astro preview",
     "lint": "npm run lint:code && npm run lint:blog",
     "lint:code": "eslint src/",

--- a/public/_redirects
+++ b/public/_redirects
@@ -1,0 +1,4 @@
+/blog/category /blog 301
+/blog/tag /blog 301
+/mcp /docs/charts/fastmcp-server 301
+https://www.helmforge.dev/* https://helmforge.dev/:splat 301

--- a/scripts/verify-sitemap.mjs
+++ b/scripts/verify-sitemap.mjs
@@ -1,0 +1,47 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+const SITE_URL = 'https://helmforge.dev';
+const distDir = path.join(process.cwd(), 'dist');
+const sitemapPath = path.join(distDir, 'sitemap-0.xml');
+
+function walkHtml(dir) {
+  return fs.readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
+    const fullPath = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      if (entry.name === 'pagefind' || entry.name === '_astro') return [];
+      return walkHtml(fullPath);
+    }
+    return entry.isFile() && entry.name.endsWith('.html') ? [fullPath] : [];
+  });
+}
+
+function pageUrl(filePath) {
+  const relative = path.relative(distDir, filePath).replaceAll(path.sep, '/');
+  if (relative === '404.html') return null;
+  if (relative === 'index.html') return SITE_URL;
+  return `${SITE_URL}/${relative.replace(/\/index\.html$/, '')}`;
+}
+
+if (!fs.existsSync(sitemapPath)) {
+  console.error('ERROR: dist/sitemap-0.xml was not generated.');
+  process.exit(1);
+}
+
+const sitemap = fs.readFileSync(sitemapPath, 'utf8');
+const sitemapUrls = new Set([...sitemap.matchAll(/<loc>(.*?)<\/loc>/g)].map((match) => match[1]));
+const pageUrls = new Set(walkHtml(distDir).map(pageUrl).filter(Boolean));
+
+const missing = [...pageUrls].filter((url) => !sitemapUrls.has(url)).sort();
+const extra = [...sitemapUrls].filter((url) => !pageUrls.has(url)).sort();
+
+console.log(`Sitemap URLs: ${sitemapUrls.size}`);
+console.log(`HTML pages: ${pageUrls.size}`);
+
+if (missing.length > 0 || extra.length > 0) {
+  for (const url of missing) console.error(`MISSING_FROM_SITEMAP ${url}`);
+  for (const url of extra) console.error(`EXTRA_IN_SITEMAP ${url}`);
+  process.exit(1);
+}
+
+console.log('Sitemap covers every generated indexable HTML page.');

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -15,6 +15,8 @@ interface Props {
   articleModifiedTime?: string;
   articleSection?: string;
   articleTags?: string[];
+  robots?: string;
+  includeBreadcrumbSchema?: boolean;
 }
 
 const {
@@ -24,18 +26,19 @@ const {
   imageAlt,
   imageWidth,
   imageHeight,
-  url = Astro.url.href,
+  url,
   ogType,
   articlePublishedTime,
   articleModifiedTime,
   articleSection,
   articleTags = [],
+  robots = 'index,follow,max-snippet:-1,max-image-preview:large,max-video-preview:-1',
+  includeBreadcrumbSchema = true,
 } = Astro.props;
 
 const siteName = 'HelmForge';
 const fullTitle = title.includes(siteName) ? title : `${title} | ${siteName}`;
 const imageUrl = new URL(image, Astro.site).href;
-const robotsContent = 'index,follow,max-snippet:-1,max-image-preview:large,max-video-preview:-1';
 const googleAnalyticsId = import.meta.env.PUBLIC_GA_MEASUREMENT_ID || 'G-5PD0B83HRE';
 const googleSiteVerification = import.meta.env.PUBLIC_GOOGLE_SITE_VERIFICATION;
 const bingSiteVerification = import.meta.env.PUBLIC_BING_SITE_VERIFICATION;
@@ -43,6 +46,8 @@ const bingSiteVerification = import.meta.env.PUBLIC_BING_SITE_VERIFICATION;
 // Detect page type from path
 const pathname = Astro.url.pathname;
 const pathSegments = pathname.split('/').filter(Boolean);
+const normalizedPathname = pathname === '/' ? '/' : pathname.replace(/\/$/, '');
+const canonicalUrl = url ?? new URL(normalizedPathname, Astro.site).href;
 const isHomepage = pathname === '/' || pathname === '';
 const isChartPage = pathSegments[0] === 'docs' && pathSegments[1] === 'charts' && !!pathSegments[2];
 const isBlogPage = pathSegments[0] === 'blog';
@@ -164,7 +169,7 @@ const websiteJsonLd = isHomepage
     <title>{fullTitle}</title>
     <meta name="description" content={description} />
     <meta name="keywords" content={autoKeywords} />
-    <meta name="robots" content={robotsContent} />
+    <meta name="robots" content={robots} />
     {googleSiteVerification && <meta name="google-site-verification" content={googleSiteVerification} />}
     {bingSiteVerification && <meta name="msvalidate.01" content={bingSiteVerification} />}
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
@@ -172,13 +177,13 @@ const websiteJsonLd = isHomepage
     <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png" />
     <link rel="manifest" href="/site.webmanifest" />
     <meta name="theme-color" content="#7c3aed" />
-    <link rel="canonical" href={url} />
+    <link rel="canonical" href={canonicalUrl} />
     <link rel="alternate" type="application/rss+xml" title="HelmForge Feed" href="/rss.xml" />
     {isBlogPage && <link rel="alternate" type="application/rss+xml" title="HelmForge Blog" href="/blog/rss.xml" />}
 
     <!-- Open Graph -->
     <meta property="og:type" content={resolvedOgType} />
-    <meta property="og:url" content={url} />
+    <meta property="og:url" content={canonicalUrl} />
     <meta property="og:title" content={fullTitle} />
     <meta property="og:description" content={description} />
     <meta property="og:image" content={imageUrl} />
@@ -235,7 +240,11 @@ const websiteJsonLd = isHomepage
     {websiteJsonLd && <script type="application/ld+json" set:html={JSON.stringify(websiteJsonLd)} />}
 
     <!-- BreadcrumbList JSON-LD -->
-    {pathSegments.length > 0 && <script type="application/ld+json" set:html={JSON.stringify(breadcrumbJsonLd)} />}
+    {
+      includeBreadcrumbSchema && pathSegments.length > 0 && (
+        <script type="application/ld+json" set:html={JSON.stringify(breadcrumbJsonLd)} />
+      )
+    }
 
     <!-- Global CSS -->
     <style is:global>

--- a/src/layouts/BlogLayout.astro
+++ b/src/layouts/BlogLayout.astro
@@ -125,6 +125,7 @@ const articleJsonLd = {
   articleModifiedTime={modifiedDate.toISOString()}
   articleSection={articleSection}
   articleTags={tags}
+  url={canonicalUrl}
 >
   <Header />
 

--- a/src/layouts/DocsLayout.astro
+++ b/src/layouts/DocsLayout.astro
@@ -95,7 +95,7 @@ const techArticleJsonLd = isChartPage
   : null;
 ---
 
-<BaseLayout title={title} description={description}>
+<BaseLayout title={title} description={description} includeBreadcrumbSchema={false}>
   <Header />
 
   <script type="application/ld+json" set:html={JSON.stringify(breadcrumbJsonLd)} />

--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -4,7 +4,7 @@ import Header from '../components/Header.astro';
 import Footer from '../components/Footer.astro';
 ---
 
-<BaseLayout title="Page Not Found" description="The page you are looking for does not exist.">
+<BaseLayout title="Page Not Found" description="The page you are looking for does not exist." robots="noindex,follow">
   <Header />
   <main id="main-content" class="flex-1 flex items-center justify-center py-32">
     <div class="text-center px-4">

--- a/src/pages/docs/blog-authoring.mdx
+++ b/src/pages/docs/blog-authoring.mdx
@@ -1,7 +1,7 @@
 ---
 layout: ../../layouts/DocsLayout.astro
 title: Blog Authoring Guide — HelmForge
-description: Workflow for publishing discovery-ready HelmForge blog posts with required metadata, images, structured data, RSS, sitemap, IndexNow, and editorial review evidence.
+description: Publish discovery-ready HelmForge blog posts with metadata, images, structured data, RSS, sitemap, IndexNow, and editorial review evidence.
 ---
 
 # Blog Authoring Guide

--- a/src/pages/docs/charts/adguard-home.mdx
+++ b/src/pages/docs/charts/adguard-home.mdx
@@ -1,7 +1,7 @@
 ---
 layout: ../../../layouts/DocsLayout.astro
 title: AdGuard Home Chart
-description: HelmForge AdGuard Home chart — network-wide DNS ad/tracker blocker with wizard or pre-configured modes, dual PVC (conf+work), LoadBalancer DNS service, adguardhome-sync for multi-instance, full-volume S3 backup, and TLS ingress for Kubernetes.
+description: AdGuard Home Helm chart for Kubernetes with DNS ad blocking, wizard or preconfigured mode, sync, LoadBalancer DNS, TLS ingress, and S3 backup.
 ---
 
 import DocsTabs from '../../../components/DocsTabs.astro';

--- a/src/pages/docs/charts/alfio.mdx
+++ b/src/pages/docs/charts/alfio.mdx
@@ -1,7 +1,7 @@
 ---
 layout: ../../../layouts/DocsLayout.astro
 title: alf.io Chart
-description: HelmForge alf.io chart — open-source event ticketing and management platform with Spring Boot, PostgreSQL backend, payment gateway integration, and QR code check-in for Kubernetes.
+description: alf.io Helm chart for Kubernetes event ticketing with Spring Boot, PostgreSQL, payment gateway configuration, and QR code check-in.
 ---
 
 import DocsTabs from '../../../components/DocsTabs.astro';

--- a/src/pages/docs/charts/answer.mdx
+++ b/src/pages/docs/charts/answer.mdx
@@ -1,7 +1,7 @@
 ---
 layout: ../../../layouts/DocsLayout.astro
 title: Apache Answer Chart
-description: HelmForge Apache Answer chart — Q&A platform with SQLite (zero-config), PostgreSQL, or MySQL, auto-install via environment variables, database-aware S3 backup (tar/pg_dump/mysqldump), and TLS ingress for Kubernetes.
+description: Apache Answer Helm chart for Kubernetes Q&A with SQLite, PostgreSQL, or MySQL, auto-install, TLS ingress, and database-aware S3 backup.
 ---
 
 import DocsTabs from '../../../components/DocsTabs.astro';

--- a/src/pages/docs/charts/appwrite.mdx
+++ b/src/pages/docs/charts/appwrite.mdx
@@ -1,7 +1,7 @@
 ---
 layout: ../../../layouts/DocsLayout.astro
 title: Appwrite Chart
-description: HelmForge Appwrite chart — self-hosted BaaS with API, Console, Realtime, 12 workers, schedulers, MariaDB, Redis, shared PVCs, mysqldump S3 backup, and path-based Traefik ingress for Kubernetes.
+description: Appwrite Helm chart for Kubernetes BaaS with API, Console, Realtime, workers, schedulers, MariaDB, Redis, shared PVCs, and S3 backup.
 ---
 
 import DocsTabs from '../../../components/DocsTabs.astro';

--- a/src/pages/docs/charts/archivebox.mdx
+++ b/src/pages/docs/charts/archivebox.mdx
@@ -1,7 +1,7 @@
 ---
 layout: ../../../layouts/DocsLayout.astro
 title: ArchiveBox Chart
-description: HelmForge ArchiveBox chart — self-hosted web archiving platform with multi-format capture (HTML, PDF, screenshot, WARC), Chromium headless rendering, and S3 backup for Kubernetes.
+description: ArchiveBox Helm chart for Kubernetes web archiving with HTML, PDF, screenshot, WARC capture, Chromium rendering, persistence, and S3 backup.
 ---
 
 import DocsTabs from '../../../components/DocsTabs.astro';

--- a/src/pages/docs/charts/authelia.mdx
+++ b/src/pages/docs/charts/authelia.mdx
@@ -1,7 +1,7 @@
 ---
 layout: ../../../layouts/DocsLayout.astro
 title: Authelia Chart
-description: HelmForge Authelia chart — SSO gateway with MFA (TOTP, WebAuthn), OpenID Connect IdP, forward auth for Traefik/nginx, 3 mandatory secrets, file/LDAP user backends, PostgreSQL/Redis for HA, database-aware S3 backup, Prometheus metrics.
+description: Authelia Helm chart for Kubernetes SSO with MFA, OpenID Connect, forward auth, LDAP or file users, PostgreSQL/Redis HA, metrics, and S3 backup.
 ---
 
 import DocsTabs from '../../../components/DocsTabs.astro';

--- a/src/pages/docs/charts/automatisch.mdx
+++ b/src/pages/docs/charts/automatisch.mdx
@@ -1,7 +1,7 @@
 ---
 layout: ../../../layouts/DocsLayout.astro
 title: Automatisch Chart
-description: HelmForge Automatisch chart — open-source business automation platform (self-hosted Zapier alternative) with visual workflow builder, PostgreSQL, Redis, and webhook triggers for Kubernetes.
+description: Automatisch Helm chart for Kubernetes workflow automation with a visual builder, webhook triggers, PostgreSQL, Redis, persistence, and ingress.
 ---
 
 import DocsTabs from '../../../components/DocsTabs.astro';

--- a/src/pages/docs/charts/castopod.mdx
+++ b/src/pages/docs/charts/castopod.mdx
@@ -1,7 +1,7 @@
 ---
 layout: ../../../layouts/DocsLayout.astro
 title: Castopod Chart
-description: HelmForge Castopod chart — open-source podcast hosting platform with RSS feed generation, Fediverse integration, MariaDB backend, optional Redis cache, and S3 backup for Kubernetes.
+description: Castopod Helm chart for Kubernetes podcast hosting with RSS feeds, Fediverse support, MariaDB, optional Redis cache, persistence, and S3 backup.
 ---
 
 import DocsTabs from '../../../components/DocsTabs.astro';

--- a/src/pages/docs/charts/changedetection.mdx
+++ b/src/pages/docs/charts/changedetection.mdx
@@ -1,7 +1,7 @@
 ---
 layout: ../../../layouts/DocsLayout.astro
 title: changedetection.io Chart
-description: HelmForge changedetection.io chart — website change monitoring with CSS/XPath selectors, optional Playwright/Chromium sidecar for JavaScript-rendered pages, and notification support for Kubernetes.
+description: changedetection.io Helm chart for Kubernetes website monitoring with CSS/XPath selectors, notifications, persistence, and optional Playwright sidecar.
 ---
 
 import DocsTabs from '../../../components/DocsTabs.astro';

--- a/src/pages/docs/charts/ckan.mdx
+++ b/src/pages/docs/charts/ckan.mdx
@@ -1,7 +1,7 @@
 ---
 layout: ../../../layouts/DocsLayout.astro
 title: CKAN Chart
-description: HelmForge CKAN chart — open data portal with uWSGI web, DataPusher sidecar, CKAN-specific Solr StatefulSet, dual PostgreSQL databases (ckan+datastore), Redis, 3 required secrets, S3 backup, and TLS ingress for Kubernetes.
+description: CKAN Helm chart for Kubernetes open data portals with uWSGI, DataPusher, Solr, PostgreSQL datastore, Redis, TLS ingress, and S3 backup.
 ---
 
 import DocsTabs from '../../../components/DocsTabs.astro';

--- a/src/pages/docs/charts/cloudflared.mdx
+++ b/src/pages/docs/charts/cloudflared.mdx
@@ -1,7 +1,7 @@
 ---
 layout: ../../../layouts/DocsLayout.astro
 title: Cloudflare Tunnel Chart
-description: HelmForge Cloudflare Tunnel chart — secure outbound-only ARGO tunnel with HA replicas, PodDisruptionBudget, Prometheus metrics, and ServiceMonitor for Kubernetes. No open ports or public IP required.
+description: Cloudflare Tunnel Helm chart for Kubernetes with outbound-only access, HA replicas, PodDisruptionBudget, Prometheus metrics, and ServiceMonitor.
 ---
 
 import DocsTabs from '../../../components/DocsTabs.astro';

--- a/src/pages/docs/charts/countly.mdx
+++ b/src/pages/docs/charts/countly.mdx
@@ -1,7 +1,7 @@
 ---
 layout: ../../../layouts/DocsLayout.astro
-title: Countly Chart
-description: HelmForge Countly chart — product analytics with event tracking, crash reporting, push notifications, A/B testing, and 41+ plugins on MongoDB for Kubernetes.
+title: Countly Helm Chart for Product Analytics
+description: Countly Helm chart for Kubernetes product analytics with event tracking, crash reports, push notifications, plugins, and MongoDB persistence.
 ---
 
 import DocsTabs from '../../../components/DocsTabs.astro';

--- a/src/pages/docs/charts/cronicle.mdx
+++ b/src/pages/docs/charts/cronicle.mdx
@@ -1,7 +1,7 @@
 ---
 layout: ../../../layouts/DocsLayout.astro
 title: Cronicle Chart
-description: HelmForge Cronicle chart — multi-server task scheduler and cron replacement with web UI, SMTP notifications, session encryption, and persistent job storage for Kubernetes.
+description: Cronicle Helm chart for Kubernetes task scheduling with web UI, persistent job storage, SMTP notifications, session encryption, and ingress.
 ---
 
 import DocsTabs from '../../../components/DocsTabs.astro';

--- a/src/pages/docs/charts/ddns-updater.mdx
+++ b/src/pages/docs/charts/ddns-updater.mdx
@@ -1,7 +1,7 @@
 ---
 layout: ../../../layouts/DocsLayout.astro
 title: DDNS Updater Chart
-description: HelmForge DDNS Updater chart — dynamic DNS for 50+ providers including Cloudflare, Route53, DuckDNS, and Namecheap with web UI, update history persistence, and existingSecret support for Kubernetes.
+description: DDNS Updater Helm chart for Kubernetes dynamic DNS with Cloudflare, Route53, DuckDNS, Namecheap, web UI, persistence, and existingSecret support.
 ---
 
 import DocsTabs from '../../../components/DocsTabs.astro';

--- a/src/pages/docs/charts/discount-bandit.mdx
+++ b/src/pages/docs/charts/discount-bandit.mdx
@@ -1,7 +1,7 @@
 ---
 layout: ../../../layouts/DocsLayout.astro
 title: Discount Bandit Chart
-description: HelmForge Discount Bandit chart for Kubernetes with HelmForge MySQL, external MySQL, SQLite dev mode, Gateway API, External Secrets, NetworkPolicy, and dual-stack Service support.
+description: Discount Bandit Helm chart for Kubernetes with HelmForge MySQL, external MySQL, SQLite dev mode, Gateway API, External Secrets, and dual-stack Service.
 ---
 
 import DocsTabs from '../../../components/DocsTabs.astro';

--- a/src/pages/docs/charts/docmost.mdx
+++ b/src/pages/docs/charts/docmost.mdx
@@ -1,7 +1,7 @@
 ---
 layout: ../../../layouts/DocsLayout.astro
 title: Docmost Chart
-description: HelmForge Docmost chart — collaborative wiki with bundled PostgreSQL and Redis, local or S3 uploads storage, pg_dump backup, PostgreSQL extension bootstrap, and TLS ingress for Kubernetes.
+description: Docmost Helm chart for Kubernetes collaborative wiki with PostgreSQL, Redis, local or S3 uploads, extension bootstrap, TLS ingress, and S3 backup.
 ---
 
 import DocsTabs from '../../../components/DocsTabs.astro';

--- a/src/pages/docs/charts/dolibarr.mdx
+++ b/src/pages/docs/charts/dolibarr.mdx
@@ -1,7 +1,7 @@
 ---
 layout: ../../../layouts/DocsLayout.astro
 title: Dolibarr Chart
-description: HelmForge Dolibarr chart — ERP and CRM with unattended installation, module management, separate documents and custom-modules PVCs, MySQL backend, and S3 backup for Kubernetes.
+description: Dolibarr Helm chart for Kubernetes ERP and CRM with unattended install, module management, document PVCs, MySQL backend, and S3 backup.
 ---
 
 import DocsTabs from '../../../components/DocsTabs.astro';

--- a/src/pages/docs/charts/druid.mdx
+++ b/src/pages/docs/charts/druid.mdx
@@ -1,7 +1,7 @@
 ---
 layout: ../../../layouts/DocsLayout.astro
 title: Apache Druid Chart
-description: HelmForge Druid chart — high-performance analytics database with 6 independent components (coordinator, overlord, broker, router, historical, middlemanager), S3 or local deep storage, ZooKeeper, PostgreSQL metadata, per-component JVM tuning, and TLS ingress for Kubernetes.
+description: Apache Druid Helm chart for Kubernetes analytics with coordinator, broker, historical, router, deep storage, ZooKeeper, metadata, and JVM tuning.
 ---
 
 import DocsTabs from '../../../components/DocsTabs.astro';

--- a/src/pages/docs/charts/elasticsearch.mdx
+++ b/src/pages/docs/charts/elasticsearch.mdx
@@ -1,7 +1,7 @@
 ---
 layout: ../../../layouts/DocsLayout.astro
 title: Elasticsearch Chart
-description: HelmForge Elasticsearch chart — production-ready multi-role cluster with intelligent presets, automated backups, ILM policies, data tiers, and security by default.
+description: Elasticsearch Helm chart for Kubernetes with multi-role clusters, presets, automated backups, ILM policies, data tiers, and secure defaults.
 ---
 
 # Elasticsearch

--- a/src/pages/docs/charts/envoy-gateway.mdx
+++ b/src/pages/docs/charts/envoy-gateway.mdx
@@ -1,7 +1,7 @@
 ---
 layout: ../../../layouts/DocsLayout.astro
 title: Envoy Gateway Chart
-description: Deploy Envoy Gateway v1.7.1 on Kubernetes with HelmForge's production-ready Helm chart featuring Gateway API, SecurityPolicy (JWT/OIDC/CORS), BackendTrafficPolicy, and comprehensive observability.
+description: Envoy Gateway Helm chart for Kubernetes with Gateway API, JWT/OIDC/CORS SecurityPolicy, BackendTrafficPolicy, observability, and production defaults.
 ---
 
 # Envoy Gateway Chart

--- a/src/pages/docs/charts/fastmcp-server.mdx
+++ b/src/pages/docs/charts/fastmcp-server.mdx
@@ -1,7 +1,7 @@
 ---
 layout: ../../../layouts/DocsLayout.astro
 title: FastMCP Server
-description: Helm chart for FastMCP server — deploy MCP tools, resources, prompts, and knowledge bases on Kubernetes with inline, S3, Git, OCI, gateway, and multi-auth configuration.
+description: FastMCP Server Helm chart for Kubernetes MCP runtimes with tools, resources, prompts, knowledge bases, S3, Git, OCI, gateway, and auth.
 ---
 
 # FastMCP Server

--- a/src/pages/docs/charts/flowise.mdx
+++ b/src/pages/docs/charts/flowise.mdx
@@ -1,7 +1,7 @@
 ---
 layout: ../../../layouts/DocsLayout.astro
 title: Flowise Chart
-description: HelmForge Flowise chart — low-code LLM app builder with standalone SQLite mode or queue mode (PostgreSQL + Redis + S3 shared storage), 5-key auth secret management, uuid-ossp PostgreSQL extension, and TLS ingress for Kubernetes.
+description: Flowise Helm chart for Kubernetes low-code LLM apps with SQLite or queue mode, PostgreSQL, Redis, S3 shared storage, auth secrets, and TLS ingress.
 ---
 
 import DocsTabs from '../../../components/DocsTabs.astro';

--- a/src/pages/docs/charts/generic.mdx
+++ b/src/pages/docs/charts/generic.mdx
@@ -1,7 +1,7 @@
 ---
 layout: ../../../layouts/DocsLayout.astro
 title: Generic Chart
-description: HelmForge Generic chart — multi-purpose Helm chart for Deployments, StatefulSets, DaemonSets, Jobs, CronJobs, networking, security, storage, observability, autoscaling, Gateway API, and extraManifests with Helm templating.
+description: Generic Helm chart for Kubernetes apps with Deployments, StatefulSets, Jobs, networking, storage, security, autoscaling, Gateway API, and extra manifests.
 ---
 
 import DocsTabs from '../../../components/DocsTabs.astro';

--- a/src/pages/docs/charts/ghost.mdx
+++ b/src/pages/docs/charts/ghost.mdx
@@ -1,7 +1,7 @@
 ---
 layout: ../../../layouts/DocsLayout.astro
 title: Ghost Chart
-description: HelmForge Ghost chart — modern publishing platform for blogs, newsletters, and memberships with MySQL backend, content persistence, and S3 backup for Kubernetes.
+description: Ghost Helm chart for Kubernetes publishing with blogs, newsletters, memberships, MySQL backend, persistent content storage, and S3 backup.
 ---
 
 import DocsTabs from '../../../components/DocsTabs.astro';

--- a/src/pages/docs/charts/gitea.mdx
+++ b/src/pages/docs/charts/gitea.mdx
@@ -1,7 +1,7 @@
 ---
 layout: ../../../layouts/DocsLayout.astro
 title: Gitea Chart
-description: HelmForge Gitea chart — self-hosted Git service with rootless image, HTTP and SSH dual-service, SQLite/PostgreSQL/MySQL, admin bootstrap Job, GITEA__ env-based configuration, database-aware S3 backup, and TLS ingress for Kubernetes.
+description: Gitea Helm chart for Kubernetes Git hosting with rootless image, HTTP and SSH services, SQL backends, admin bootstrap, TLS ingress, and S3 backup.
 ---
 
 import DocsTabs from '../../../components/DocsTabs.astro';

--- a/src/pages/docs/charts/guacamole.mdx
+++ b/src/pages/docs/charts/guacamole.mdx
@@ -1,7 +1,7 @@
 ---
 layout: ../../../layouts/DocsLayout.astro
-title: Apache Guacamole Chart
-description: HelmForge Apache Guacamole chart — clientless remote desktop gateway with guacd sidecar, RDP/VNC/SSH/telnet, PostgreSQL (default) or MySQL, schema init Job, OIDC/SAML SSO, TOTP 2FA, Tomcat reverse-proxy header support, and database-aware S3 backup.
+title: Apache Guacamole Helm Chart for Kubernetes
+description: Apache Guacamole Helm chart for Kubernetes with guacd, RDP/VNC/SSH access, PostgreSQL or MySQL, SSO options, 2FA, and S3 backup.
 ---
 
 import DocsTabs from '../../../components/DocsTabs.astro';

--- a/src/pages/docs/charts/heimdall.mdx
+++ b/src/pages/docs/charts/heimdall.mdx
@@ -1,7 +1,7 @@
 ---
 layout: ../../../layouts/DocsLayout.astro
 title: Heimdall Chart
-description: HelmForge Heimdall chart — application dashboard for organizing and launching self-hosted services, with LinuxServer.io image, persistent SQLite storage, and S3 backup for Kubernetes.
+description: Heimdall Helm chart for Kubernetes app dashboards with LinuxServer.io image, persistent SQLite storage, ingress, and S3 backup.
 ---
 
 import DocsTabs from '../../../components/DocsTabs.astro';

--- a/src/pages/docs/charts/homarr.mdx
+++ b/src/pages/docs/charts/homarr.mdx
@@ -1,7 +1,7 @@
 ---
 layout: ../../../layouts/DocsLayout.astro
 title: Homarr Chart
-description: HelmForge Homarr chart — modern application dashboard with embedded Redis, SQLite/PostgreSQL/MySQL, encryption key for integration secrets, Kubernetes workload discovery, database-aware S3 backup, and TLS ingress for Kubernetes.
+description: Homarr Helm chart for Kubernetes dashboards with Redis, SQLite/PostgreSQL/MySQL, integration secrets, workload discovery, TLS ingress, and S3 backup.
 ---
 
 import DocsTabs from '../../../components/DocsTabs.astro';

--- a/src/pages/docs/charts/index.mdx
+++ b/src/pages/docs/charts/index.mdx
@@ -1,7 +1,7 @@
 ---
 layout: ../../../layouts/DocsLayout.astro
 title: All Helm Charts — HelmForge Chart Catalog
-description: Browse all HelmForge production-ready Helm charts for Kubernetes — databases (PostgreSQL, MySQL, MongoDB, Redis), identity (Keycloak, Vaultwarden), CMS, monitoring, analytics, AI, home automation, and more.
+description: Browse HelmForge Kubernetes Helm charts for databases, identity, CMS, monitoring, analytics, AI, home automation, networking, and backups.
 ---
 
 # Charts Overview

--- a/src/pages/docs/charts/kafka.mdx
+++ b/src/pages/docs/charts/kafka.mdx
@@ -1,7 +1,7 @@
 ---
 layout: ../../../layouts/DocsLayout.astro
 title: Kafka Chart
-description: HelmForge Apache Kafka chart — KRaft-only (no ZooKeeper), single-broker and cluster topologies with combined mode, JMX metrics, PodDisruptionBudget, and Prometheus ServiceMonitor for Kubernetes.
+description: Apache Kafka Helm chart for Kubernetes with KRaft mode, single-broker or cluster topologies, JMX metrics, PodDisruptionBudget, and ServiceMonitor.
 ---
 
 import DocsTabs from '../../../components/DocsTabs.astro';

--- a/src/pages/docs/charts/karakeep.mdx
+++ b/src/pages/docs/charts/karakeep.mdx
@@ -1,7 +1,7 @@
 ---
 layout: ../../../layouts/DocsLayout.astro
-title: Karakeep Chart
-description: HelmForge Karakeep chart — AI-powered bookmark manager with optional Meilisearch full-text search and Chromium screenshot sidecars for Kubernetes.
+title: Karakeep Helm Chart for Kubernetes
+description: Karakeep Helm chart for Kubernetes with AI bookmarks, Meilisearch full-text search, Chromium screenshots, persistence, and S3 backup.
 ---
 
 import DocsTabs from '../../../components/DocsTabs.astro';

--- a/src/pages/docs/charts/keycloak.mdx
+++ b/src/pages/docs/charts/keycloak.mdx
@@ -1,7 +1,7 @@
 ---
 layout: ../../../layouts/DocsLayout.astro
 title: Keycloak Chart
-description: HelmForge Keycloak chart — Keycloak 26.6.x identity and access management for Kubernetes with production mode, PostgreSQL/MySQL, Gateway API, External Secrets, metrics, and backup.
+description: Keycloak Helm chart for Kubernetes IAM with production mode, PostgreSQL or MySQL, Gateway API, External Secrets, metrics, and backup.
 ---
 
 import DocsTabs from '../../../components/DocsTabs.astro';

--- a/src/pages/docs/charts/komga.mdx
+++ b/src/pages/docs/charts/komga.mdx
@@ -1,7 +1,7 @@
 ---
 layout: ../../../layouts/DocsLayout.astro
 title: Komga Chart
-description: HelmForge Komga chart — comics and manga media server with OPDS, dual PVC for config and library, JVM tuning via javaToolOptions, SQLite S3 backup, and TLS ingress for Kubernetes.
+description: Komga Helm chart for Kubernetes comics and manga hosting with OPDS, config and library PVCs, JVM tuning, TLS ingress, and SQLite S3 backup.
 ---
 
 import DocsTabs from '../../../components/DocsTabs.astro';

--- a/src/pages/docs/charts/listmonk.mdx
+++ b/src/pages/docs/charts/listmonk.mdx
@@ -1,7 +1,7 @@
 ---
 layout: ../../../layouts/DocsLayout.astro
 title: Listmonk Chart
-description: HelmForge Listmonk chart — self-hosted newsletter and mailing list manager with PostgreSQL backend, persistent uploads storage, S3 backup, and idempotent database bootstrap for Kubernetes.
+description: Listmonk Helm chart for Kubernetes newsletters with PostgreSQL backend, persistent uploads, idempotent database bootstrap, ingress, and S3 backup.
 ---
 
 import DocsTabs from '../../../components/DocsTabs.astro';

--- a/src/pages/docs/charts/mariadb.mdx
+++ b/src/pages/docs/charts/mariadb.mdx
@@ -1,7 +1,7 @@
 ---
 layout: ../../../layouts/DocsLayout.astro
 title: MariaDB Chart
-description: HelmForge MariaDB chart — standalone and GTID-based replication, configuration presets, TLS, mysqld-exporter Prometheus metrics, mariadb-dump S3 backup, NetworkPolicy, PDB with default pod anti-affinity for Kubernetes.
+description: MariaDB Helm chart for Kubernetes with standalone or GTID replication, TLS, metrics, NetworkPolicy, PDB, anti-affinity, and S3 backup.
 ---
 
 import DocsTabs from '../../../components/DocsTabs.astro';

--- a/src/pages/docs/charts/memcached.mdx
+++ b/src/pages/docs/charts/memcached.mdx
@@ -1,7 +1,7 @@
 ---
 layout: ../../../layouts/DocsLayout.astro
 title: Memcached Chart
-description: HelmForge Memcached chart - official Memcached 1.6.41 for Kubernetes with standalone and distributed cache topologies, TLS, ASCII/SASL auth, extstore, metrics, dual-stack Services, External Secrets, NetworkPolicy, HPA, and PDB.
+description: Memcached Helm chart for Kubernetes with standalone or distributed cache, TLS, ASCII/SASL auth, extstore, metrics, External Secrets, HPA, and PDB.
 ---
 
 import DocsTabs from '../../../components/DocsTabs.astro';

--- a/src/pages/docs/charts/middleware.mdx
+++ b/src/pages/docs/charts/middleware.mdx
@@ -1,7 +1,7 @@
 ---
 layout: ../../../layouts/DocsLayout.astro
 title: Middleware Chart
-description: HelmForge Middleware chart — open-source DORA metrics platform measuring Deployment Frequency, Lead Time, MTTR, and Change Failure Rate with PostgreSQL, Redis, and API key persistence for Kubernetes.
+description: Middleware Helm chart for Kubernetes DORA metrics with Deployment Frequency, Lead Time, MTTR, Change Failure Rate, PostgreSQL, Redis, and API keys.
 ---
 
 import DocsTabs from '../../../components/DocsTabs.astro';

--- a/src/pages/docs/charts/minecraft.mdx
+++ b/src/pages/docs/charts/minecraft.mdx
@@ -1,7 +1,7 @@
 ---
 layout: ../../../layouts/DocsLayout.astro
 title: Minecraft Chart
-description: HelmForge Minecraft Java Edition chart — Vanilla, Paper, Forge, Fabric, GeyserMC Bedrock cross-play, Aikar GC flags, RCON-backed S3 backup, and Prometheus metrics via mc-monitor for Kubernetes.
+description: Minecraft Java Helm chart for Kubernetes with Vanilla, Paper, Forge, Fabric, GeyserMC, Aikar flags, RCON S3 backup, persistence, and metrics.
 ---
 
 import DocsTabs from '../../../components/DocsTabs.astro';

--- a/src/pages/docs/charts/mongodb.mdx
+++ b/src/pages/docs/charts/mongodb.mdx
@@ -1,7 +1,7 @@
 ---
 layout: ../../../layouts/DocsLayout.astro
 title: MongoDB Chart
-description: HelmForge MongoDB chart — standalone, replica set, and sharded cluster with official mongo image, replicaSetKey internal authentication, mongodump S3 backup, WiredTiger config, init scripts, Prometheus exporter, and non-root security context.
+description: MongoDB Helm chart for Kubernetes with standalone, replica set, sharded cluster, internal auth, WiredTiger config, init scripts, metrics, and S3 backup.
 ---
 
 import DocsTabs from '../../../components/DocsTabs.astro';

--- a/src/pages/docs/charts/mosquitto.mdx
+++ b/src/pages/docs/charts/mosquitto.mdx
@@ -1,7 +1,7 @@
 ---
 layout: ../../../layouts/DocsLayout.astro
 title: Mosquitto Chart
-description: HelmForge Eclipse Mosquitto chart — MQTT broker for IoT with standalone or federated topology, TLS and mTLS support, authentication, ACL, WebSocket listener, and optional MQTTX Web companion UI for Kubernetes.
+description: Eclipse Mosquitto Helm chart for Kubernetes MQTT with standalone or federated topology, TLS/mTLS, authentication, ACLs, WebSocket, and MQTTX UI.
 ---
 
 import DocsTabs from '../../../components/DocsTabs.astro';

--- a/src/pages/docs/charts/mysql.mdx
+++ b/src/pages/docs/charts/mysql.mdx
@@ -1,7 +1,7 @@
 ---
 layout: ../../../layouts/DocsLayout.astro
 title: MySQL Chart
-description: HelmForge MySQL chart - standalone and source-replica topologies with TLS, External Secrets, dual-stack Services, NetworkPolicy controls, metrics, and S3 backups.
+description: MySQL Helm chart for Kubernetes with standalone and source-replica topologies, TLS, External Secrets, dual-stack Services, metrics, and S3 backup.
 ---
 
 import DocsTabs from '../../../components/DocsTabs.astro';

--- a/src/pages/docs/charts/n8n.mdx
+++ b/src/pages/docs/charts/n8n.mdx
@@ -1,7 +1,7 @@
 ---
 layout: ../../../layouts/DocsLayout.astro
 title: n8n Chart
-description: HelmForge n8n chart — workflow automation with SQLite (zero-config), PostgreSQL, or MySQL, Redis queue mode with dedicated workers, encryption key protection, database-aware S3 backup, and TLS ingress for Kubernetes.
+description: n8n Helm chart for Kubernetes workflow automation with SQLite, PostgreSQL, or MySQL, Redis queue mode, workers, encryption key, ingress, and S3 backup.
 ---
 
 import DocsTabs from '../../../components/DocsTabs.astro';

--- a/src/pages/docs/charts/ntfy.mdx
+++ b/src/pages/docs/charts/ntfy.mdx
@@ -1,7 +1,7 @@
 ---
 layout: ../../../layouts/DocsLayout.astro
 title: ntfy Chart
-description: HelmForge ntfy chart — self-hosted push notification service via HTTP pub-sub, with Prometheus metrics, attachment support, and access control for Kubernetes.
+description: ntfy Helm chart for Kubernetes push notifications with HTTP pub-sub, metrics, attachments, access control, persistence, and ingress.
 ---
 
 import DocsTabs from '../../../components/DocsTabs.astro';

--- a/src/pages/docs/charts/olivetin.mdx
+++ b/src/pages/docs/charts/olivetin.mdx
@@ -1,7 +1,7 @@
 ---
 layout: ../../../layouts/DocsLayout.astro
 title: OliveTin Chart
-description: HelmForge OliveTin chart — browser-based UI for running predefined shell commands safely on Kubernetes, with Prometheus metrics and ConfigMap-based action definitions.
+description: OliveTin Helm chart for Kubernetes command panels with browser UI, ConfigMap-defined actions, Prometheus metrics, persistence, and ingress.
 ---
 
 import DocsTabs from '../../../components/DocsTabs.astro';

--- a/src/pages/docs/charts/open-webui.mdx
+++ b/src/pages/docs/charts/open-webui.mdx
@@ -1,7 +1,7 @@
 ---
 layout: ../../../layouts/DocsLayout.astro
 title: Open WebUI Chart
-description: HelmForge Open WebUI chart — self-hosted AI chat with Ollama and OpenAI-compatible backends, SQLite or PostgreSQL, Redis for multi-instance WebSocket coordination, RAG document uploads, pg_dump S3 backup, and TLS ingress for Kubernetes.
+description: Open WebUI Helm chart for Kubernetes AI chat with Ollama or OpenAI backends, SQLite/PostgreSQL, Redis WebSockets, RAG uploads, and S3 backup.
 ---
 
 import DocsTabs from '../../../components/DocsTabs.astro';

--- a/src/pages/docs/charts/openhab.mdx
+++ b/src/pages/docs/charts/openhab.mdx
@@ -1,7 +1,7 @@
 ---
 layout: ../../../layouts/DocsLayout.astro
 title: openHAB
-description: Production-ready openHAB home automation platform for Kubernetes with GitOps-friendly live configuration reload via ConfigMaps and Prometheus metrics support.
+description: openHAB Helm chart for Kubernetes home automation with GitOps-friendly ConfigMap reload, persistence, ingress, and Prometheus metrics.
 ---
 
 # openHAB

--- a/src/pages/docs/charts/phpmyadmin.mdx
+++ b/src/pages/docs/charts/phpmyadmin.mdx
@@ -1,7 +1,7 @@
 ---
 layout: ../../../layouts/DocsLayout.astro
 title: phpMyAdmin Chart
-description: HelmForge phpMyAdmin chart — MySQL and MariaDB administration for Kubernetes with multi-server modes, Gateway API, External Secrets, dual-stack Services, NetworkPolicy, sessions, HPA, and PDB.
+description: phpMyAdmin Helm chart for Kubernetes MySQL and MariaDB administration with multi-server mode, Gateway API, External Secrets, dual-stack Service, and HPA.
 ---
 
 import DocsTabs from '../../../components/DocsTabs.astro';

--- a/src/pages/docs/charts/pihole.mdx
+++ b/src/pages/docs/charts/pihole.mdx
@@ -1,7 +1,7 @@
 ---
 layout: ../../../layouts/DocsLayout.astro
 title: Pi-hole Chart
-description: HelmForge Pi-hole chart — DNS sinkhole with blocklist presets, gravity init container, Unbound recursive DNS sidecar, LoadBalancer DNS service, DHCP host networking, conditional forwarding, Prometheus exporter, and S3 backup for gravity.db.
+description: Pi-hole Helm chart for Kubernetes DNS blocking with blocklist presets, gravity init, Unbound sidecar, LoadBalancer DNS, DHCP options, metrics, and backup.
 ---
 
 import DocsTabs from '../../../components/DocsTabs.astro';

--- a/src/pages/docs/charts/postgresql.mdx
+++ b/src/pages/docs/charts/postgresql.mdx
@@ -1,7 +1,7 @@
 ---
 layout: ../../../layouts/DocsLayout.astro
 title: PostgreSQL Chart
-description: HelmForge PostgreSQL chart - PostgreSQL standalone and streaming replication with TLS, structured pg_hba CIDRs, External Secrets, dual-stack Services, replication slots, NetworkPolicy controls, and S3 backups.
+description: PostgreSQL Helm chart for Kubernetes with standalone or streaming replication, TLS, pg_hba CIDRs, External Secrets, dual-stack Services, and S3 backup.
 ---
 
 import DocsTabs from '../../../components/DocsTabs.astro';

--- a/src/pages/docs/charts/rabbitmq.mdx
+++ b/src/pages/docs/charts/rabbitmq.mdx
@@ -1,7 +1,7 @@
 ---
 layout: ../../../layouts/DocsLayout.astro
 title: RabbitMQ Chart
-description: HelmForge RabbitMQ chart — single-node and cluster architectures, quorum queues, Erlang cookie clustering, management UI ingress, Prometheus metrics, PDB, and TLS for Kubernetes.
+description: RabbitMQ Helm chart for Kubernetes with single-node or cluster mode, quorum queues, Erlang cookie clustering, management UI, TLS, metrics, and PDB.
 ---
 
 import DocsTabs from '../../../components/DocsTabs.astro';

--- a/src/pages/docs/charts/redis.mdx
+++ b/src/pages/docs/charts/redis.mdx
@@ -1,7 +1,7 @@
 ---
 layout: ../../../layouts/DocsLayout.astro
 title: Redis Chart
-description: HelmForge Redis chart - Redis standalone, replication, Sentinel HA, and cluster modes with official Redis image, existingSecret auth, External Secrets, TLS, dual-stack Services, maxmemory config, Prometheus exporter, PodDisruptionBudget, and non-root security context.
+description: Redis Helm chart for Kubernetes with standalone, replication, Sentinel HA, cluster mode, TLS, External Secrets, dual-stack Services, metrics, and PDB.
 ---
 
 import DocsTabs from '../../../components/DocsTabs.astro';

--- a/src/pages/docs/charts/strapi.mdx
+++ b/src/pages/docs/charts/strapi.mdx
@@ -1,7 +1,7 @@
 ---
 layout: ../../../layouts/DocsLayout.astro
 title: Strapi Chart
-description: Production-ready Strapi headless CMS with multi-replica support, S3/Cloudinary uploads, email providers, advanced security, and comprehensive configuration.
+description: Strapi Helm chart for Kubernetes headless CMS with multi-replica support, S3 or Cloudinary uploads, email providers, security, and persistence.
 ---
 
 # Strapi

--- a/src/pages/docs/charts/strava-statistics.mdx
+++ b/src/pages/docs/charts/strava-statistics.mdx
@@ -1,7 +1,7 @@
 ---
 layout: ../../../layouts/DocsLayout.astro
 title: Statistics for Strava Chart
-description: HelmForge Statistics for Strava chart — self-hosted fitness dashboard for Strava athletes with SQLite storage, OAuth integration, and detailed activity visualizations for Kubernetes.
+description: Statistics for Strava Helm chart for Kubernetes fitness dashboards with SQLite storage, Strava OAuth, activity visualizations, persistence, and ingress.
 ---
 
 import DocsTabs from '../../../components/DocsTabs.astro';

--- a/src/pages/docs/charts/superset.mdx
+++ b/src/pages/docs/charts/superset.mdx
@@ -1,7 +1,7 @@
 ---
 layout: ../../../layouts/DocsLayout.astro
-title: Apache Superset Chart
-description: HelmForge Superset chart — business intelligence platform with Gunicorn web, Celery workers, Celery Beat scheduler, init Job for migrations, PostgreSQL+Redis bundled by default, secretKey/existingSecret, extraConfig for superset_config.py, and pg_dump S3 backup.
+title: Apache Superset Helm Chart for Kubernetes
+description: Apache Superset Helm chart for Kubernetes BI with web, workers, Celery Beat, PostgreSQL, Redis, secret management, custom config, and S3 backup.
 ---
 
 import DocsTabs from '../../../components/DocsTabs.astro';

--- a/src/pages/docs/charts/umami.mdx
+++ b/src/pages/docs/charts/umami.mdx
@@ -1,7 +1,7 @@
 ---
 layout: ../../../layouts/DocsLayout.astro
 title: Umami Chart
-description: HelmForge Umami chart - Umami 3.1.0 privacy-first analytics for Kubernetes with PostgreSQL, Gateway API, External Secrets, dual-stack Services, NetworkPolicy, PDB, and S3 backup.
+description: Umami Helm chart for Kubernetes privacy analytics with PostgreSQL, Gateway API, External Secrets, dual-stack Services, NetworkPolicy, PDB, and S3 backup.
 ---
 
 import DocsTabs from '../../../components/DocsTabs.astro';

--- a/src/pages/docs/charts/uptime-kuma.mdx
+++ b/src/pages/docs/charts/uptime-kuma.mdx
@@ -1,7 +1,7 @@
 ---
 layout: ../../../layouts/DocsLayout.astro
 title: Uptime Kuma Chart
-description: HelmForge Uptime Kuma chart — self-hosted uptime monitoring with 20+ check types, 90+ notification services, public status pages, SQLite or MariaDB backend, and S3 backup for Kubernetes.
+description: Uptime Kuma Helm chart for Kubernetes monitoring with 20+ check types, 90+ notifications, public status pages, SQLite or MariaDB, and S3 backup.
 ---
 
 import DocsTabs from '../../../components/DocsTabs.astro';

--- a/src/pages/docs/charts/vaultwarden.mdx
+++ b/src/pages/docs/charts/vaultwarden.mdx
@@ -1,7 +1,7 @@
 ---
 layout: ../../../layouts/DocsLayout.astro
 title: Vaultwarden Chart
-description: HelmForge Vaultwarden chart — self-hosted Bitwarden-compatible password manager with SQLite, PostgreSQL, MySQL backends, Argon2 admin token, NetworkPolicy, and S3 backup for Kubernetes.
+description: Vaultwarden Helm chart for Kubernetes Bitwarden-compatible passwords with SQLite, PostgreSQL, or MySQL, Argon2 admin token, NetworkPolicy, and S3 backup.
 ---
 
 import DocsTabs from '../../../components/DocsTabs.astro';

--- a/src/pages/docs/charts/velero.mdx
+++ b/src/pages/docs/charts/velero.mdx
@@ -1,7 +1,7 @@
 ---
 layout: ../../../layouts/DocsLayout.astro
-title: Velero Chart
-description: HelmForge Velero chart — Kubernetes cluster backup, restore, and migration with S3-compatible storage, filesystem backup via node-agent, recurring schedules, and Prometheus metrics.
+title: Velero Helm Chart for Kubernetes Backup
+description: Velero Helm chart for Kubernetes backup and restore with S3-compatible storage, BackupStorageLocation, node-agent filesystem backup, and schedules.
 ---
 
 import DocsTabs from '../../../components/DocsTabs.astro';

--- a/src/pages/docs/charts/wallabag.mdx
+++ b/src/pages/docs/charts/wallabag.mdx
@@ -1,7 +1,7 @@
 ---
 layout: ../../../layouts/DocsLayout.astro
 title: Wallabag Chart
-description: HelmForge Wallabag chart — self-hosted read-it-later with full-text article extraction, PostgreSQL backend, optional Redis caching, and S3 backup for Kubernetes.
+description: Wallabag Helm chart for Kubernetes read-it-later hosting with full-text extraction, PostgreSQL backend, optional Redis cache, persistence, and S3 backup.
 ---
 
 import DocsTabs from '../../../components/DocsTabs.astro';

--- a/src/pages/docs/charts/wordpress.mdx
+++ b/src/pages/docs/charts/wordpress.mdx
@@ -1,7 +1,7 @@
 ---
 layout: ../../../layouts/DocsLayout.astro
 title: WordPress Chart
-description: HelmForge WordPress chart - official Apache image with HelmForge MySQL or external database, Gateway API, External Secrets, dual-stack Services, NetworkPolicy, Redis Object Cache, plugin installer, S3 backup, metrics, and production controls.
+description: WordPress Helm chart for Kubernetes with official Apache image, HelmForge MySQL, Gateway API, External Secrets, Redis cache, plugins, and S3 backup.
 ---
 
 import DocsTabs from '../../../components/DocsTabs.astro';

--- a/src/pages/docs/comparison.mdx
+++ b/src/pages/docs/comparison.mdx
@@ -1,7 +1,7 @@
 ---
 layout: ../../layouts/DocsLayout.astro
-title: HelmForge vs Bitnami — Open-Source Helm Chart Alternative
-description: HelmForge is the Apache-2.0-licensed Bitnami alternative for Kubernetes. Official upstream images, built-in S3 backup, pinned tags, and zero vendor lock-in. Full feature comparison with Bitnami and generic community charts.
+title: HelmForge vs Bitnami Helm Charts
+description: 'Compare HelmForge and Bitnami Helm charts for Kubernetes: official images, Apache-2.0 licensing, S3 backup, pinned tags, and vendor lock-in.'
 ---
 
 import { chartCount, backupCount } from '../../data/charts';

--- a/src/pages/docs/faq.mdx
+++ b/src/pages/docs/faq.mdx
@@ -1,7 +1,7 @@
 ---
 layout: ../../layouts/DocsLayout.astro
 title: Helm Charts FAQ — HelmForge
-description: Answers to common questions about HelmForge Helm charts — OCI registry, S3 backup with MinIO, TLS with cert-manager, ArgoCD and Flux integration, chart signing, and Kubernetes compatibility.
+description: HelmForge FAQ for OCI registry installs, S3 backup with MinIO, TLS with cert-manager, Argo CD and Flux, chart signing, and Kubernetes compatibility.
 ---
 
 import Callout from '../../components/Callout.astro';

--- a/src/pages/docs/getting-started.mdx
+++ b/src/pages/docs/getting-started.mdx
@@ -1,7 +1,7 @@
 ---
 layout: ../../layouts/DocsLayout.astro
 title: Getting Started with HelmForge Helm Charts
-description: Install HelmForge Helm charts in minutes. Add the repository, install Redis, PostgreSQL, or any production-ready chart via HTTPS repo or OCI registry. Kubernetes 1.28+ supported. ArgoCD and Flux compatible.
+description: Install HelmForge Helm charts with HTTPS or OCI, deploy Redis or PostgreSQL, and use Kubernetes 1.28+ with Argo CD or Flux.
 ---
 
 # Getting Started

--- a/src/pages/docs/index.mdx
+++ b/src/pages/docs/index.mdx
@@ -1,7 +1,7 @@
 ---
 layout: ../../layouts/DocsLayout.astro
 title: HelmForge Documentation — Helm Charts for Kubernetes
-description: Complete HelmForge documentation — install guides, chart configuration references, backup setup, troubleshooting, and FAQ for production-ready Kubernetes Helm charts.
+description: HelmForge documentation for installing charts, configuring values, setting up backups, troubleshooting, and running Kubernetes Helm charts.
 ---
 
 # Documentation

--- a/src/pages/docs/troubleshooting.mdx
+++ b/src/pages/docs/troubleshooting.mdx
@@ -1,7 +1,7 @@
 ---
 layout: ../../layouts/DocsLayout.astro
 title: Helm Chart Troubleshooting Guide — HelmForge
-description: Diagnose and fix common Kubernetes Helm chart issues — CrashLoopBackOff, PVC Pending, ingress 404/503, backup CronJob not running, helm upgrade conflicts, OOMKilled pods, and database connection errors.
+description: Troubleshoot Helm charts with fixes for CrashLoopBackOff, PVC Pending, ingress 404/503, backup CronJobs, upgrades, OOMKilled pods, and DB errors.
 ---
 
 import Callout from '../../components/Callout.astro';

--- a/src/pages/playground.astro
+++ b/src/pages/playground.astro
@@ -5190,8 +5190,8 @@ const scenariosJson = JSON.stringify(scenarios);
 ---
 
 <BaseLayout
-  title="Values Playground"
-  description="Interactively configure HelmForge chart values and generate ready-to-use Helm install commands."
+  title="Helm Values Playground for Kubernetes Charts"
+  description="Configure HelmForge chart values online, preview values.yaml, and generate Helm install commands for Kubernetes deployments."
 >
   <Header />
   <main id="main-content" class="py-16 sm:py-20" data-pagefind-body>

--- a/src/pages/playground/gophish.astro
+++ b/src/pages/playground/gophish.astro
@@ -16,7 +16,7 @@ import Container from '../../components/Container.astro';
         <p class="text-sm font-bold uppercase tracking-[0.16em] text-text-muted">Playground</p>
         <h1 class="mt-4 text-3xl font-bold heading-font text-text-base">Gophish values playground</h1>
         <p class="mt-4 text-text-muted">Configure Gophish chart values in the interactive playground.</p>
-        <a class="mt-6 inline-flex text-primary-light hover:underline" href="/playground/">
+        <a class="mt-6 inline-flex text-primary-light hover:underline" href="/playground">
           Open Gophish in the playground
         </a>
       </div>

--- a/src/pages/playground/hoppscotch.astro
+++ b/src/pages/playground/hoppscotch.astro
@@ -16,7 +16,7 @@ import Container from '../../components/Container.astro';
         <p class="text-sm font-bold uppercase tracking-[0.16em] text-text-muted">Playground</p>
         <h1 class="mt-4 text-3xl font-bold heading-font text-text-base">Hoppscotch values playground</h1>
         <p class="mt-4 text-text-muted">Configure Hoppscotch chart values in the interactive playground.</p>
-        <a class="mt-6 inline-flex text-primary-light hover:underline" href="/playground/">
+        <a class="mt-6 inline-flex text-primary-light hover:underline" href="/playground">
           Open Hoppscotch in the playground
         </a>
       </div>


### PR DESCRIPTION
## Summary

- Adds Cloudflare Pages redirects for the Search Console 404 URLs and the `www` host canonicalization.
- Normalizes canonical and Open Graph URLs from `Astro.site` plus the slashless pathname.
- Adds configurable robots metadata, marks the 404 page as `noindex,follow`, and removes duplicate docs breadcrumb JSON-LD.
- Improves SEO titles/descriptions for low-CTR pages and shortens long documentation descriptions to reduce search snippet rewrites.
- Adds sitemap coverage verification to CI and deploy so every generated indexable HTML page must be present in the sitemap.

## Validation

- `npm run format:check`
- `npm run lint`
- `npm run build && npm run seo:verify-sitemap`
- `npm run test:e2e` (`316 passed`, `2 skipped`)

## Notes

The generated sitemap was verified locally with `135` sitemap URLs matching `135` generated indexable HTML pages.