### PR TITLE
docs(drupal): update image tag to 11.3.9

### DIFF
--- a/src/pages/docs/charts/drupal.mdx
+++ b/src/pages/docs/charts/drupal.mdx
@@ -22,7 +22,7 @@ This chart uses `docker.io/library/drupal` because Drupal does not currently pub
 
 HelmForge pins:
 
-- `docker.io/library/drupal:11.3.8-php8.5-apache-bookworm`
+- `docker.io/library/drupal:11.3.9-php8.5-apache-bookworm`
 
 That choice is intentional:
 
@@ -213,7 +213,7 @@ The chart still has an installer-oriented surface, but it now covers production 
 | ----------------------- | -------------------------------- | ----------------------------------------------- |
 | `replicaCount`          | `1`                              | Number of Drupal replicas                       |
 | `image.repository`      | `docker.io/library/drupal`       | Docker Official Drupal image repository         |
-| `image.tag`             | `11.3.8-php8.5-apache-bookworm`  | Pinned Drupal image tag                         |
+| `image.tag`             | `11.3.9-php8.5-apache-bookworm`  | Pinned Drupal image tag                         |
 | `image.pullPolicy`      | `IfNotPresent`                   | Container pull policy                           |
 | `imagePullSecrets`      | `[]`                             | Optional image pull secrets                     |
 | `drupal.siteName`       | `Drupal`                         | Suggested site name shown in install guidance   |


### PR DESCRIPTION
Related to helmforgedev/charts#244

## Summary
- Update the Drupal chart site documentation for `11.3.9-php8.5-apache-bookworm`.
- Keep the documented default values aligned with the chart update.

## Validation
- `npm run format:check -- src/pages/docs/charts/drupal.mdx`
- `npm run build`
- `git diff --check`