### PR TITLE
docs(strava-statistics): update image tag to v4.7.10

### DIFF
--- a/src/pages/docs/charts/strava-statistics.mdx
+++ b/src/pages/docs/charts/strava-statistics.mdx
@@ -191,7 +191,7 @@ ingress:
 | Parameter          | Type   | Default                                        | Description                          |
 | ------------------ | ------ | ---------------------------------------------- | ------------------------------------ |
 | `image.repository` | string | `docker.io/robiningelbrecht/strava-statistics` | Container image.                     |
-| `image.tag`        | string | `"v4.7.5"`                                     | Image tag.                           |
+| `image.tag`        | string | `"v4.7.10"`                                    | Image tag.                           |
 | `image.pullPolicy` | string | `IfNotPresent`                                 | Image pull policy.                   |
 | `imagePullSecrets` | array  | `[]`                                           | Pull secrets for private registries. |
 
@@ -243,11 +243,13 @@ ingress:
 
 ### Service
 
-| Parameter             | Type    | Default     | Description                          |
-| --------------------- | ------- | ----------- | ------------------------------------ |
-| `service.type`        | string  | `ClusterIP` | Kubernetes service type.             |
-| `service.port`        | integer | `80`        | Service port exposed to the cluster. |
-| `service.annotations` | object  | `{}`        | Annotations for the Service.         |
+| Parameter                | Type    | Default     | Description                          |
+| ------------------------ | ------- | ----------- | ------------------------------------ |
+| `service.type`           | string  | `ClusterIP` | Kubernetes service type.             |
+| `service.port`           | integer | `80`        | Service port exposed to the cluster. |
+| `service.annotations`    | object  | `{}`        | Annotations for the Service.         |
+| `service.ipFamilyPolicy` | string  | omitted     | Service IP family policy.            |
+| `service.ipFamilies`     | array   | omitted     | Ordered Service IP families.         |
 
 ### Ingress
 
@@ -315,6 +317,20 @@ ingress:
 | `extraVolumes`      | array | `[]`    | Extra volumes to attach to the pod.                      |
 | `extraVolumeMounts` | array | `[]`    | Extra volume mounts for the container.                   |
 | `extraManifests`    | array | `[]`    | Extra Kubernetes manifests deployed alongside the chart. |
+
+### Gateway API
+
+| Parameter               | Type    | Default | Description                      |
+| ----------------------- | ------- | ------- | -------------------------------- |
+| `gatewayApi.enabled`    | boolean | `false` | Enable HTTPRoute resources.      |
+| `gatewayApi.httpRoutes` | array   | `[]`    | HTTPRoute definitions to render. |
+
+### External Secrets
+
+| Parameter                 | Type    | Default | Description                           |
+| ------------------------- | ------- | ------- | ------------------------------------- |
+| `externalSecrets.enabled` | boolean | `false` | Enable ExternalSecret resources.      |
+| `externalSecrets.items`   | array   | `[]`    | ExternalSecret definitions to render. |
 
 ## Common Issues
 


### PR DESCRIPTION
Related to helmforgedev/charts#256

## Summary
- Update the Strava Statistics chart docs to show `v4.7.10` as the default image tag.
- Add missing values reference rows for Service dual-stack, Gateway API, and External Secrets settings.

## Validation
- `npm run format:check -- src/pages/docs/charts/strava-statistics.mdx`
- `npm run build`
- `git diff --check`