### PR TITLE
docs(redis): update image tag to 8.6.3

### DIFF
--- a/src/pages/docs/charts/redis.mdx
+++ b/src/pages/docs/charts/redis.mdx
@@ -303,7 +303,7 @@ clustered deployments.
 | Parameter          | Type   | Default                   | Description  |
 | ------------------ | ------ | ------------------------- | ------------ |
 | `image.repository` | string | `docker.io/library/redis` | Redis image. |
-| `image.tag`        | string | `"8.6.2"`                 | Image tag.   |
+| `image.tag`        | string | `"8.6.3"`                 | Image tag.   |
 
 ### Authentication
 


### PR DESCRIPTION
Related to helmforgedev/charts#255 and companion chart PR helmforgedev/charts#263.

## Summary
- Update the Redis chart docs values table to show `image.tag` default `"8.6.3"`.

## Validation
- `npm run format:check -- src/pages/docs/charts/redis.mdx`
- `npm run build`