### PR TITLE
docs(n8n): update image tag to 2.20.6

### DIFF
--- a/src/pages/docs/charts/n8n.mdx
+++ b/src/pages/docs/charts/n8n.mdx
@@ -225,7 +225,7 @@ backup:
 | Parameter          | Type   | Default               | Description          |
 | ------------------ | ------ | --------------------- | -------------------- |
 | `image.repository` | string | `docker.io/n8nio/n8n` | n8n container image. |
-| `image.tag`        | string | `"2.12.3"`            | Image tag.           |
+| `image.tag`        | string | `"2.20.6"`            | Image tag.           |
 | `image.pullPolicy` | string | `IfNotPresent`        | Image pull policy.   |
 
 ### n8n Configuration


### PR DESCRIPTION
Related to helmforgedev/charts#254 and companion chart PR helmforgedev/charts#264.

## Summary
- Update the n8n chart docs values table to show `image.tag` default `"2.20.6"`.

## Validation
- `npm run lint`
- `npm run format:check -- src/pages/docs/charts/n8n.mdx`
- `npm run build`