### PR TITLE
docs(mongodb): update image tag to 8.3.1

### DIFF
--- a/src/pages/docs/charts/mongodb.mdx
+++ b/src/pages/docs/charts/mongodb.mdx
@@ -220,7 +220,7 @@ config:
 | Parameter          | Type   | Default                   | Description    |
 | ------------------ | ------ | ------------------------- | -------------- |
 | `image.repository` | string | `docker.io/library/mongo` | MongoDB image. |
-| `image.tag`        | string | `"8.2.6"`                 | Image tag.     |
+| `image.tag`        | string | `"8.3.1"`                 | Image tag.     |
 
 ### Authentication
 
@@ -297,6 +297,13 @@ Backup uses `mongodump` (not `pg_dump`). All databases are dumped and archived.
 | `extraManifests`                | array   | `[]`          | Extra Kubernetes manifests.             |
 
 ## Upgrade Notes
+
+MongoDB `8.3.1` is an upstream minor release update from `8.2.7`. Review the
+MongoDB 8.3 release notes before upgrading production clusters, take a backup,
+and verify existing PVC data files are compatible with the target `mongod`
+version. Keep replica set keyFiles and root credentials stable across
+`helm upgrade`; rotate them with MongoDB administrative commands instead of
+changing chart values.
 
 <Callout type="warning" title="Switching from standalone to replicaset requires a full dump and restore">
   MongoDB cannot automatically convert a standalone instance to a replica set with data. You must:


### PR DESCRIPTION
## Summary

- Update the MongoDB chart docs default image tag to `8.3.1`.
- Add upgrade notes for the upstream minor update from `8.2.7`, including backup and PVC compatibility guidance.

Related to helmforgedev/charts#253.
Companion chart PR: helmforgedev/charts#265.

## Validation

- `npm run lint`
- `npm run format:check -- src/pages/docs/charts/mongodb.mdx`
- `npm run build`
- Local internal link check over `dist/**/*.html`: all internal links valid
