### PR TITLE
docs(elasticsearch): update image tag to 9.4.0

### DIFF
--- a/src/pages/docs/charts/elasticsearch.mdx
+++ b/src/pages/docs/charts/elasticsearch.mdx
@@ -297,7 +297,7 @@ monitoring:
 | ---------------------------------- | --------------------------- | ------------------------------------------------- |
 | `clusterProfile`                   | `dev`                       | Cluster preset: `dev`, `staging`, `production-ha` |
 | `clusterName`                      | `helmforge-cluster`         | Elasticsearch cluster name                        |
-| `image.tag`                        | `8.17.4`                    | Elasticsearch version                             |
+| `image.tag`                        | `9.4.0`                     | Elasticsearch version                             |
 | `master.replicaCount`              | profile-driven              | Number of master-eligible nodes (must be odd)     |
 | `master.heapSize`                  | auto (50% mem)              | JVM heap for master nodes                         |
 | `data.replicaCount`                | profile-driven              | Number of data nodes                              |
@@ -313,6 +313,15 @@ monitoring:
 | `dataTiers.warm.enabled`           | `false`                     | Enable dedicated warm tier nodes                  |
 | `monitoring.enabled`               | `false`                     | Enable Prometheus exporter sidecar                |
 | `kibana.enabled`                   | `false`                     | Deploy optional Kibana                            |
+| `kibana.image.tag`                 | `9.4.0`                     | Kibana version aligned with Elasticsearch         |
+
+## Upgrade Notes
+
+`docker.io/library/elasticsearch:9.4.0` is an upstream image update from
+`9.3.4`. Review the upstream Elasticsearch release notes before upgrading
+production clusters, take a snapshot backup, and verify Kibana compatibility,
+plugins, ILM policies, and index templates in a staging environment before
+reusing existing PVCs.
 
 ## Troubleshooting
 


### PR DESCRIPTION
## Summary

- Update Elasticsearch chart docs to reflect the 9.4.0 image default.
- Add the aligned Kibana image tag default.
- Add upgrade notes for the upstream 9.3.4 -> 9.4.0 update.

Related to helmforgedev/charts#245.

## Validation

- `npm run lint`
- `npm run format:check -- src/pages/docs/charts/elasticsearch.mdx`
- `npm run build`
- Internal link/assets traversal over `dist` after build
- HelmForge `check_site_sync`: PASS
- HelmForge compliance evidence: PASS for site docs completeness, lint/format/link evidence, and official product link evidence