### PR TITLE
docs(ghost): update image tag to 6.37.1

### DIFF
--- a/src/pages/docs/charts/ghost.mdx
+++ b/src/pages/docs/charts/ghost.mdx
@@ -203,7 +203,7 @@ backup:
 | Parameter          | Type   | Default                   | Description                          |
 | ------------------ | ------ | ------------------------- | ------------------------------------ |
 | `image.repository` | string | `docker.io/library/ghost` | Ghost container image.               |
-| `image.tag`        | string | `"6.25.1"`                | Image tag.                           |
+| `image.tag`        | string | `"6.37.1"`                | Image tag.                           |
 | `image.pullPolicy` | string | `IfNotPresent`            | Image pull policy.                   |
 | `imagePullSecrets` | array  | `[]`                      | Pull secrets for private registries. |
 


### PR DESCRIPTION
## Summary
- Updates the Ghost chart documentation default image tag to `6.37.1`.
- Paired with helmforgedev/charts#269 for issue helmforgedev/charts#247.

## Local Validation
- `npm run lint`
- `npm run format:check -- src/pages/docs/charts/ghost.mdx`
- `npm run build`
- Internal link/assets traversal over `dist`

## Merge Sequencing / Guardrails
- This docs PR should be merged together with or after helmforgedev/charts#269 so published docs stay aligned with the released chart defaults.
- HelmForge MCP `check_site_sync(chart_name=ghost, change_type=defaults)` is PASS for `src/pages/docs/charts/ghost.mdx`, so this page is the required GR-007 docs update for the paired chart default change.