### PR TITLE
docs(charts): sync chart value references

### DIFF
--- a/src/pages/docs/charts/cloudflared.mdx
+++ b/src/pages/docs/charts/cloudflared.mdx
@@ -1,7 +1,7 @@
 ---
 layout: ../../../layouts/DocsLayout.astro
 title: Cloudflare Tunnel Chart
-description: Cloudflare Tunnel Helm chart for Kubernetes with outbound-only access, HA replicas, PodDisruptionBudget, Prometheus metrics, and ServiceMonitor.
+description: Cloudflare Tunnel Helm chart for Kubernetes with outbound-only access, HA replicas, PodDisruptionBudget, Prometheus metrics, ServiceMonitor, External Secrets, quick tunnel mode, and dual-stack Service support.
 ---
 
 import DocsTabs from '../../../components/DocsTabs.astro';
@@ -30,6 +30,9 @@ connection for high availability.
 - **Prometheus metrics** — `/ready` and `/metrics` endpoint on port 2000, enabled by default
 - **ServiceMonitor** — optional Prometheus Operator integration
 - **Existing Secret support** — bring your own Secret for the tunnel token
+- **External Secrets Operator** — optionally render an `ExternalSecret` for the tunnel token
+- **Quick tunnel mode** — ephemeral tunnel mode for demos and smoke tests
+- **Dual-stack Service fields** — optional `ipFamilyPolicy` and `ipFamilies`
 
 ## Quick Start
 
@@ -67,6 +70,8 @@ helm install cloudflared oci://ghcr.io/helmforgedev/helm/cloudflared -f values.y
   tabs={[
     { id: 'basic', label: 'Basic' },
     { id: 'production', label: 'Production (Secret + Metrics)' },
+    { id: 'external-secrets', label: 'External Secrets' },
+    { id: 'quick-tunnel', label: 'Quick Tunnel' },
     { id: 'single', label: 'Single Replica (Dev)' },
   ]}
 >
@@ -122,6 +127,44 @@ serviceMonitor:
 
 </div>
 
+<div data-tab-panel="external-secrets">
+
+```yaml
+# values.yaml — External Secrets Operator generates the Kubernetes Secret
+tunnel:
+  existingSecret: cloudflared-tunnel-token
+  existingSecretKey: token
+
+externalSecrets:
+  enabled: true
+  secretStoreRef:
+    name: platform-secrets
+    kind: ClusterSecretStore
+  data:
+    - secretKey: token
+      remoteRef:
+        key: cloudflared/tunnel
+        property: token
+```
+
+</div>
+
+<div data-tab-panel="quick-tunnel">
+
+```yaml
+# values.yaml — ephemeral quick tunnel for demos and smoke tests only
+tunnel:
+  quickTunnel:
+    enabled: true
+    helloWorld: true
+
+replicaCount: 1
+pdb:
+  enabled: false
+```
+
+</div>
+
 <div data-tab-panel="single">
 
 ```yaml
@@ -155,17 +198,20 @@ pdb:
 | Parameter          | Type   | Default                            | Description                          |
 | ------------------ | ------ | ---------------------------------- | ------------------------------------ |
 | `image.repository` | string | `docker.io/cloudflare/cloudflared` | cloudflared container image.         |
-| `image.tag`        | string | `"2026.3.0"`                       | Image tag.                           |
+| `image.tag`        | string | `"2026.5.2"`                       | Image tag.                           |
 | `image.pullPolicy` | string | `IfNotPresent`                     | Image pull policy.                   |
 | `imagePullSecrets` | array  | `[]`                               | Pull secrets for private registries. |
 
 ### Tunnel
 
-| Parameter                  | Type   | Default | Description                                                                        |
-| -------------------------- | ------ | ------- | ---------------------------------------------------------------------------------- |
-| `tunnel.token`             | string | `""`    | Tunnel token from the Cloudflare dashboard. Prefer `existingSecret` in production. |
-| `tunnel.existingSecret`    | string | `""`    | Existing Kubernetes Secret containing the tunnel token.                            |
-| `tunnel.existingSecretKey` | string | `token` | Key inside the existing Secret for the token value.                                |
+| Parameter                       | Type    | Default                 | Description                                                                        |
+| ------------------------------- | ------- | ----------------------- | ---------------------------------------------------------------------------------- |
+| `tunnel.token`                  | string  | `""`                    | Tunnel token from the Cloudflare dashboard. Prefer `existingSecret` in production. |
+| `tunnel.existingSecret`         | string  | `""`                    | Existing Kubernetes Secret containing the tunnel token.                            |
+| `tunnel.existingSecretKey`      | string  | `token`                 | Key inside the existing Secret for the token value.                                |
+| `tunnel.quickTunnel.enabled`    | boolean | `false`                 | Run an ephemeral quick tunnel without a managed tunnel token.                      |
+| `tunnel.quickTunnel.helloWorld` | boolean | `true`                  | Use cloudflared's built-in hello-world origin in quick tunnel mode.                |
+| `tunnel.quickTunnel.url`        | string  | `http://localhost:8080` | Origin URL when quick tunnel mode does not use hello-world.                        |
 
 <Callout type="danger" title="Do not store the tunnel token inline in values.yaml for production">
   Setting `tunnel.token` inline exposes the token in `helm get values` and Helm release history. Use
@@ -204,11 +250,22 @@ pdb:
 
 ### Service
 
-| Parameter             | Type    | Default     | Description                  |
-| --------------------- | ------- | ----------- | ---------------------------- |
-| `service.type`        | string  | `ClusterIP` | Kubernetes service type.     |
-| `service.port`        | integer | `2000`      | Metrics service port.        |
-| `service.annotations` | object  | `{}`        | Annotations for the Service. |
+| Parameter                | Type    | Default     | Description                                       |
+| ------------------------ | ------- | ----------- | ------------------------------------------------- |
+| `service.type`           | string  | `ClusterIP` | Kubernetes service type.                          |
+| `service.port`           | integer | `2000`      | Metrics service port.                             |
+| `service.annotations`    | object  | `{}`        | Annotations for the Service.                      |
+| `service.ipFamilyPolicy` | string  | `""`        | Optional Service IP family policy for dual-stack. |
+| `service.ipFamilies`     | array   | `[]`        | Optional ordered Service IP families.             |
+
+### External Secrets
+
+| Parameter                             | Type    | Default       | Description                                             |
+| ------------------------------------- | ------- | ------------- | ------------------------------------------------------- |
+| `externalSecrets.enabled`             | boolean | `false`       | Render an External Secrets Operator `ExternalSecret`.   |
+| `externalSecrets.secretStoreRef.name` | string  | `""`          | SecretStore or ClusterSecretStore name.                 |
+| `externalSecrets.secretStoreRef.kind` | string  | `SecretStore` | Secret store kind.                                      |
+| `externalSecrets.data`                | array   | `[]`          | Data mappings used to populate the tunnel token Secret. |
 
 ### Metrics
 
@@ -224,7 +281,7 @@ pdb:
 | Parameter                              | Type    | Default | Description                         |
 | -------------------------------------- | ------- | ------- | ----------------------------------- |
 | `probes.startup.enabled`               | boolean | `true`  | Enable startup probe on `/ready`.   |
-| `probes.startup.initialDelaySeconds`   | integer | `5`     | Startup probe initial delay.        |
+| `probes.startup.initialDelaySeconds`   | integer | `15`    | Startup probe initial delay.        |
 | `probes.startup.periodSeconds`         | integer | `5`     | Startup probe period.               |
 | `probes.startup.timeoutSeconds`        | integer | `3`     | Startup probe timeout.              |
 | `probes.startup.failureThreshold`      | integer | `12`    | Startup probe failure threshold.    |
@@ -241,11 +298,14 @@ pdb:
 
 ### Resources and Security
 
-| Parameter            | Type   | Default | Description                         |
-| -------------------- | ------ | ------- | ----------------------------------- |
-| `resources`          | object | `{}`    | CPU and memory requests and limits. |
-| `podSecurityContext` | object | `{}`    | Pod-level security context.         |
-| `securityContext`    | object | `{}`    | Container-level security context.   |
+| Parameter                   | Type   | Default                     | Description                       |
+| --------------------------- | ------ | --------------------------- | --------------------------------- |
+| `resources.requests.cpu`    | string | `50m`                       | Default CPU request.              |
+| `resources.requests.memory` | string | `64Mi`                      | Default memory request.           |
+| `resources.limits.cpu`      | string | `250m`                      | Default CPU limit.                |
+| `resources.limits.memory`   | string | `128Mi`                     | Default memory limit.             |
+| `podSecurityContext`        | object | non-root seccomp defaults   | Pod-level security context.       |
+| `securityContext`           | object | non-root read-only defaults | Container-level security context. |
 
 ### Service Account
 

--- a/src/pages/docs/charts/discount-bandit.mdx
+++ b/src/pages/docs/charts/discount-bandit.mdx
@@ -291,6 +291,14 @@ externalSecrets:
 | `discountBandit.exchangeRateApiKey` | `""`          | ExchangeRate API key. Prefer a Secret or ExternalSecret in production.           |
 | `discountBandit.extraEnv`           | `[]`          | Extra environment variables for mail, notifications, or advanced Laravel config. |
 
+### Image
+
+| Parameter          | Default                               | Description                      |
+| ------------------ | ------------------------------------- | -------------------------------- |
+| `image.repository` | `docker.io/cybrarist/discount-bandit` | Discount Bandit container image. |
+| `image.tag`        | `"v4.0.4"`                            | Image tag.                       |
+| `image.pullPolicy` | `IfNotPresent`                        | Image pull policy.               |
+
 ### Networking
 
 | Parameter                      | Default     | Description                                                              |

--- a/src/pages/docs/charts/docmost.mdx
+++ b/src/pages/docs/charts/docmost.mdx
@@ -271,7 +271,7 @@ ingress:
 | Parameter          | Type   | Default                     | Description        |
 | ------------------ | ------ | --------------------------- | ------------------ |
 | `image.repository` | string | `docker.io/docmost/docmost` | Docmost image.     |
-| `image.tag`        | string | `"0.70.3"`                  | Image tag.         |
+| `image.tag`        | string | `"0.90.0"`                  | Image tag.         |
 | `image.pullPolicy` | string | `IfNotPresent`              | Image pull policy. |
 
 ### Docmost Configuration

--- a/src/pages/docs/charts/drupal.mdx
+++ b/src/pages/docs/charts/drupal.mdx
@@ -22,7 +22,7 @@ This chart uses `docker.io/library/drupal` because Drupal does not currently pub
 
 HelmForge pins:
 
-- `docker.io/library/drupal:11.3.9-php8.5-apache-bookworm`
+- `docker.io/library/drupal:11.3.10-php8.5-apache-bookworm`
 
 That choice is intentional:
 
@@ -213,7 +213,7 @@ The chart still has an installer-oriented surface, but it now covers production 
 | ----------------------- | -------------------------------- | ----------------------------------------------- |
 | `replicaCount`          | `1`                              | Number of Drupal replicas                       |
 | `image.repository`      | `docker.io/library/drupal`       | Docker Official Drupal image repository         |
-| `image.tag`             | `11.3.9-php8.5-apache-bookworm`  | Pinned Drupal image tag                         |
+| `image.tag`             | `11.3.10-php8.5-apache-bookworm` | Pinned Drupal image tag                         |
 | `image.pullPolicy`      | `IfNotPresent`                   | Container pull policy                           |
 | `imagePullSecrets`      | `[]`                             | Optional image pull secrets                     |
 | `drupal.siteName`       | `Drupal`                         | Suggested site name shown in install guidance   |

--- a/src/pages/docs/charts/generic.mdx
+++ b/src/pages/docs/charts/generic.mdx
@@ -15,7 +15,7 @@ containers, Services, Ingress, storage, security resources, observability hooks,
 arbitrary extra manifests rendered through Helm `tpl`.
 
 <Callout type="warning" title="Breaking feature release">
-  The default image is now pinned to `docker.io/library/nginx:1.27.5`, image pull policy defaults to `IfNotPresent`, pod
+  The default image is now pinned to `docker.io/library/nginx:1.31.1`, image pull policy defaults to `IfNotPresent`, pod
   templates are deterministic, and stricter validation blocks invalid combinations such as HPA on DaemonSets. Review
   image, HPA, PDB, and rollout values before upgrading.
 </Callout>
@@ -80,7 +80,7 @@ workload:
 
 image:
   repository: docker.io/library/nginx
-  tag: '1.27.5'
+  tag: '1.31.1'
   pullPolicy: IfNotPresent
 
 containers:
@@ -259,7 +259,7 @@ Kubernetes or operator API fields inside the corresponding value.
 | `workload.*`           | varies                    | StatefulSet and DaemonSet-specific workload fields.           |
 | `global.imageRegistry` | `""`                      | Registry prefix for image repositories without a registry.    |
 | `image.repository`     | `docker.io/library/nginx` | Default image repository.                                     |
-| `image.tag`            | `1.27.5`                  | Default image tag.                                            |
+| `image.tag`            | `1.31.1`                  | Default image tag.                                            |
 | `image.digest`         | `""`                      | Image digest; takes precedence over tag.                      |
 | `image.pullPolicy`     | `IfNotPresent`            | Default image pull policy.                                    |
 | `imagePullSecrets`     | `[]`                      | Pull secrets for private registries.                          |
@@ -378,7 +378,7 @@ Deployment and StatefulSet HPA resources use the Kubernetes `autoscaling/v2` API
 
 ## More Information
 
-- [Blog guide: Migrating to the Generic Chart Breaking Platform Contract](/blog/migration-generic-breaking-platform-contract)
-- [Blog guide: Kubernetes 1.34 and Short Image Names](/blog/kubernetes-1-34-image-short-names)
+- [Blog guide: Migrating to the Generic Chart Breaking Platform Contract](https://helmforge.dev/blog/migration-generic-breaking-platform-contract)
+- [Blog guide: Kubernetes 1.34 and Short Image Names](https://helmforge.dev/blog/kubernetes-1-34-image-short-names)
 - [HelmForge Generic Chart Source](https://github.com/helmforgedev/charts/tree/main/charts/generic)
 - [Kubernetes Documentation](https://kubernetes.io/docs/home/)

--- a/src/pages/docs/charts/gitea.mdx
+++ b/src/pages/docs/charts/gitea.mdx
@@ -257,7 +257,7 @@ backup:
 | Parameter          | Type   | Default                 | Description                    |
 | ------------------ | ------ | ----------------------- | ------------------------------ |
 | `image.repository` | string | `docker.io/gitea/gitea` | Gitea image.                   |
-| `image.tag`        | string | `"1.25.5-rootless"`     | Rootless image tag (UID 1000). |
+| `image.tag`        | string | `"1.26.2-rootless"`     | Rootless image tag (UID 1000). |
 
 ### Gitea Configuration
 

--- a/src/pages/docs/charts/homarr.mdx
+++ b/src/pages/docs/charts/homarr.mdx
@@ -221,7 +221,7 @@ ingress:
 | Parameter          | Type   | Default                      | Description        |
 | ------------------ | ------ | ---------------------------- | ------------------ |
 | `image.repository` | string | `ghcr.io/homarr-labs/homarr` | Homarr image.      |
-| `image.tag`        | string | `"v1.61.0"`                  | Image tag.         |
+| `image.tag`        | string | `"v1.62.0"`                  | Image tag.         |
 | `image.pullPolicy` | string | `IfNotPresent`               | Image pull policy. |
 
 ### Homarr Configuration
@@ -400,6 +400,6 @@ externalSecrets:
 
 ## More Information
 
-- [Homarr Official Documentation](https://homarr.dev/docs/)
+- [Homarr Official Documentation](https://homarr.dev/docs/category/installation-1)
 - [Homarr GitHub Repository](https://github.com/homarr-labs/homarr)
 - [HelmForge Homarr Chart Source](https://github.com/helmforgedev/charts/tree/main/charts/homarr)

--- a/src/pages/docs/charts/kafka.mdx
+++ b/src/pages/docs/charts/kafka.mdx
@@ -234,7 +234,7 @@ pdb:
 | Parameter          | Type   | Default                  | Description                          |
 | ------------------ | ------ | ------------------------ | ------------------------------------ |
 | `image.repository` | string | `docker.io/apache/kafka` | Kafka container image.               |
-| `image.tag`        | string | `"4.2.0"`                | Image tag.                           |
+| `image.tag`        | string | `"4.3.0"`                | Image tag.                           |
 | `image.pullPolicy` | string | `IfNotPresent`           | Image pull policy.                   |
 | `imagePullSecrets` | array  | `[]`                     | Pull secrets for private registries. |
 

--- a/src/pages/docs/charts/keycloak.mdx
+++ b/src/pages/docs/charts/keycloak.mdx
@@ -12,14 +12,14 @@ import KeycloakDiagram from '../../../components/diagrams/KeycloakDiagram.astro'
 # Keycloak
 
 Deploy [Keycloak](https://www.keycloak.org/) on Kubernetes for identity and access management, SSO, OAuth 2.0,
-OpenID Connect, and SAML. The chart supports explicit `dev` and `production` modes, Keycloak `26.6.1`, bundled or
+OpenID Connect, and SAML. The chart supports explicit `dev` and `production` modes, Keycloak `26.6.2`, bundled or
 external PostgreSQL/MySQL-compatible databases, optional Gateway API routes, External Secrets Operator integration,
 Prometheus metrics, S3-compatible database backup, and dual-stack Service fields.
 
 ## Key Features
 
 - **Explicit runtime mode** — `mode: dev` for local testing and `mode: production` for hostname/database-backed deployments.
-- **Keycloak 26.6.x alignment** — image tag and app version use `quay.io/keycloak/keycloak:26.6.1`.
+- **Keycloak 26.6.x alignment** — image tag and app version use `quay.io/keycloak/keycloak:26.6.2`.
 - **Database choices** — embedded H2 for dev only, bundled PostgreSQL/MySQL subcharts, or external PostgreSQL/MySQL/MariaDB.
 - **HA-ready controls** — JDBC_PING cache stack, multi-replica scheduling defaults, PDB, rollout strategy, and capacity profiles.
 - **Routing options** — separate public/admin Ingress resources plus optional Gateway API `HTTPRoute` resources.
@@ -309,7 +309,7 @@ externalSecrets:
 | `commonLabels`     | object | `{}`                        | Labels added to all resources.       |
 | `clusterDomain`    | string | `cluster.local`             | Kubernetes cluster DNS domain.       |
 | `image.repository` | string | `quay.io/keycloak/keycloak` | Keycloak image repository.           |
-| `image.tag`        | string | `"26.6.1"`                  | Keycloak image tag.                  |
+| `image.tag`        | string | `"26.6.2"`                  | Keycloak image tag.                  |
 | `image.pullPolicy` | string | `IfNotPresent`              | Image pull policy.                   |
 | `imagePullSecrets` | array  | `[]`                        | Pull secrets for private registries. |
 

--- a/src/pages/docs/charts/mariadb.mdx
+++ b/src/pages/docs/charts/mariadb.mdx
@@ -337,6 +337,16 @@ standalone:
 | `metrics.serviceMonitor.enabled`  | boolean | `false`                          | Create a Prometheus Operator ServiceMonitor. |
 | `metrics.serviceMonitor.interval` | string  | `30s`                            | Scrape interval.                             |
 
+When metrics are enabled, the chart writes a locked-down mysqld-exporter client config from the same MariaDB Secret used
+by the database container. This avoids exposing the root password through `DATA_SOURCE_NAME` and keeps TLS client settings
+aligned with the MariaDB pod.
+
+To inspect exporter startup issues:
+
+```bash
+kubectl logs -n mariadb mariadb-0 -c mysqld-exporter
+```
+
 ### NetworkPolicy
 
 | Parameter                                  | Type    | Default | Description                                    |

--- a/src/pages/docs/charts/memcached.mdx
+++ b/src/pages/docs/charts/memcached.mdx
@@ -13,7 +13,7 @@ import MemcachedDiagram from '../../../components/diagrams/MemcachedDiagram.astr
 
 Deploy [Memcached](https://memcached.org/) on Kubernetes as a fast, volatile object cache for applications that
 need to reduce database, API, or page-rendering load. The chart uses the official
-`docker.io/library/memcached:1.6.41` image and supports a small development cache as well as a production path with
+`docker.io/library/memcached:1.6.42` image and supports a small development cache as well as a production path with
 distributed pods, TLS, authentication, metrics, NetworkPolicy, HPA, PDB, dual-stack Services, extstore, and External
 Secrets Operator integration.
 
@@ -24,7 +24,7 @@ Secrets Operator integration.
 
 ## Key Features
 
-- **Official image alignment** - defaults to `docker.io/library/memcached:1.6.41`, the current stable upstream release.
+- **Official image alignment** - defaults to `docker.io/library/memcached:1.6.42`, the current stable upstream release.
 - **Two topologies** - `standalone` for development and `distributed` for multi-pod production caches.
 - **Stable Kubernetes networking** - client Service, headless Service for pod-aware clients, optional LoadBalancer, and dual-stack Service fields.
 - **IPv6-aware binding** - when `service.ipFamilies` includes `IPv6` and the default listen address is kept, Memcached starts with `0.0.0.0,::`.
@@ -272,7 +272,7 @@ Memcached authentication is disabled.
 | `architecture`                                | `standalone`                  | `standalone` or `distributed`.                                                |
 | `replicaCount`                                | `1`                           | Number of Memcached pods. Standalone requires exactly one pod.                |
 | `image.repository`                            | `docker.io/library/memcached` | Official Memcached image repository.                                          |
-| `image.tag`                                   | `1.6.41`                      | Pinned Memcached image tag.                                                   |
+| `image.tag`                                   | `1.6.42`                      | Pinned Memcached image tag.                                                   |
 | `memcached.memoryLimitMB`                     | `64`                          | Item memory limit passed to `-m`.                                             |
 | `memcached.maxConnections`                    | `1024`                        | Connection limit passed to `-c`.                                              |
 | `memcached.threads`                           | `4`                           | Worker thread count passed to `-t`.                                           |

--- a/src/pages/docs/charts/metabase.mdx
+++ b/src/pages/docs/charts/metabase.mdx
@@ -201,7 +201,7 @@ ingress:
 | Parameter          | Type   | Default                       | Description                          |
 | ------------------ | ------ | ----------------------------- | ------------------------------------ |
 | `image.repository` | string | `docker.io/metabase/metabase` | Metabase container image.            |
-| `image.tag`        | string | `"v0.60.4"`                   | Image tag.                           |
+| `image.tag`        | string | `"v0.61.2"`                   | Image tag.                           |
 | `image.pullPolicy` | string | `IfNotPresent`                | Image pull policy.                   |
 | `imagePullSecrets` | array  | `[]`                          | Pull secrets for private registries. |
 

--- a/src/pages/docs/charts/n8n.mdx
+++ b/src/pages/docs/charts/n8n.mdx
@@ -225,7 +225,7 @@ backup:
 | Parameter          | Type   | Default               | Description          |
 | ------------------ | ------ | --------------------- | -------------------- |
 | `image.repository` | string | `docker.io/n8nio/n8n` | n8n container image. |
-| `image.tag`        | string | `"2.20.6"`            | Image tag.           |
+| `image.tag`        | string | `"2.22.3"`            | Image tag.           |
 | `image.pullPolicy` | string | `IfNotPresent`        | Image pull policy.   |
 
 ### n8n Configuration

--- a/src/pages/docs/charts/olivetin.mdx
+++ b/src/pages/docs/charts/olivetin.mdx
@@ -211,7 +211,7 @@ ingress:
 | Parameter          | Type   | Default                        | Description                          |
 | ------------------ | ------ | ------------------------------ | ------------------------------------ |
 | `image.repository` | string | `docker.io/jamesread/olivetin` | OliveTin container image.            |
-| `image.tag`        | string | `"3000.11.3"`                  | Image tag.                           |
+| `image.tag`        | string | `"3000.13.0"`                  | Image tag.                           |
 | `image.pullPolicy` | string | `IfNotPresent`                 | Image pull policy.                   |
 | `imagePullSecrets` | array  | `[]`                           | Pull secrets for private registries. |
 

--- a/src/pages/docs/charts/strava-statistics.mdx
+++ b/src/pages/docs/charts/strava-statistics.mdx
@@ -191,7 +191,7 @@ ingress:
 | Parameter          | Type   | Default                                        | Description                          |
 | ------------------ | ------ | ---------------------------------------------- | ------------------------------------ |
 | `image.repository` | string | `docker.io/robiningelbrecht/strava-statistics` | Container image.                     |
-| `image.tag`        | string | `"v4.7.10"`                                    | Image tag.                           |
+| `image.tag`        | string | `"v4.8.1"`                                     | Image tag.                           |
 | `image.pullPolicy` | string | `IfNotPresent`                                 | Image pull policy.                   |
 | `imagePullSecrets` | array  | `[]`                                           | Pull secrets for private registries. |
 

--- a/src/pages/docs/charts/velero.mdx
+++ b/src/pages/docs/charts/velero.mdx
@@ -226,7 +226,7 @@ aws_secret_access_key=your-secret-key' \
 | Parameter          | Type   | Default                   | Description                          |
 | ------------------ | ------ | ------------------------- | ------------------------------------ |
 | `image.repository` | string | `docker.io/velero/velero` | Velero server image.                 |
-| `image.tag`        | string | `"v1.18.0"`               | Image tag.                           |
+| `image.tag`        | string | `"v1.18.1"`               | Image tag.                           |
 | `image.pullPolicy` | string | `IfNotPresent`            | Image pull policy.                   |
 | `imagePullSecrets` | array  | `[]`                      | Pull secrets for private registries. |
 

--- a/src/pages/docs/charts/wordpress.mdx
+++ b/src/pages/docs/charts/wordpress.mdx
@@ -12,7 +12,7 @@ import WordPressDiagram from '../../../components/diagrams/WordPressDiagram.astr
 # WordPress
 
 Deploy [WordPress](https://wordpress.org/) on Kubernetes with the official
-`docker.io/library/wordpress:6.9.4-apache` image. The chart keeps the default install useful for
+`docker.io/library/wordpress:7.0.0-apache` image. The chart keeps the default install useful for
 development while exposing explicit production controls for database selection, secrets, routing,
 storage, backup, network policy, metrics, WordPress cron, plugin installation, and Redis Object Cache.
 
@@ -464,7 +464,7 @@ consistency. A successful backup upload is not a complete disaster recovery vali
 | `commonLabels`     | object  | `{}`                          | Labels added to every rendered resource. |
 | `replicaCount`     | integer | `1`                           | WordPress replicas when HPA is disabled. |
 | `image.repository` | string  | `docker.io/library/wordpress` | WordPress image repository.              |
-| `image.tag`        | string  | `6.9.4-apache`                | Image tag.                               |
+| `image.tag`        | string  | `7.0.0-apache`                | Image tag.                               |
 | `image.pullPolicy` | string  | `IfNotPresent`                | Image pull policy.                       |
 | `imagePullSecrets` | array   | `[]`                          | Pull secrets for private registries.     |
 


### PR DESCRIPTION
## Summary
- sync chart docs value references for the completed chart issue PRs
- document cloudflared External Secrets, quick tunnel mode, dual-stack Service fields, hardened defaults, and 2026.5.2 image
- document Discount Bandit v4.0.4 image values and MariaDB mysqld-exporter credential handling
- fix chart docs links discovered by local link validation

## Validation
- npm run lint
- npm run format:check
- npm run build
- npm run seo:verify-sitemap
- npx --yes markdown-link-check src/pages/docs/charts/cloudflared.mdx ... src/pages/docs/charts/wordpress.mdx
- npm run test:e2e (316 passed, 2 skipped)

Related chart PRs: helmforgedev/charts#325, #326, #327, #328, #329, #330, #331, #332, #333, #334, #335, #336, #337, #338, #339, #340, #341