### PR TITLE
docs(charts): sync adguard and changedetection values

### DIFF
--- a/src/pages/docs/charts/adguard-home.mdx
+++ b/src/pages/docs/charts/adguard-home.mdx
@@ -273,7 +273,7 @@ ingress:
 | Parameter          | Type   | Default                         | Description         |
 | ------------------ | ------ | ------------------------------- | ------------------- |
 | `image.repository` | string | `docker.io/adguard/adguardhome` | AdGuard Home image. |
-| `image.tag`        | string | `"v0.107.73"`                   | Image tag.          |
+| `image.tag`        | string | `"v0.107.76"`                   | Image tag.          |
 
 ### Configuration
 
@@ -305,6 +305,15 @@ Use the output (starting with `$2y$10$...`) as the `password` value.
 | `persistence.work.size`          | string  | `2Gi`   | Work PVC size. Increase for longer query log retention.                    |
 | `persistence.work.storageClass`  | string  | `""`    | StorageClass for work PVC.                                                 |
 | `persistence.work.existingClaim` | string  | `""`    | Use an existing PVC for work.                                              |
+
+### Init Permissions
+
+| Parameter                          | Type    | Default                     | Description                                                                 |
+| ---------------------------------- | ------- | --------------------------- | --------------------------------------------------------------------------- |
+| `initPermissions.enabled`          | boolean | `true`                      | Normalize `/opt/adguardhome/conf` and `/opt/adguardhome/work` before start. |
+| `initPermissions.image.repository` | string  | `docker.io/library/busybox` | Init container image repository.                                            |
+| `initPermissions.image.tag`        | string  | `"1.37"`                    | Init container image tag.                                                   |
+| `initPermissions.resources`        | object  | `{}`                        | Resource requests and limits for the init container.                        |
 
 ### Services
 

--- a/src/pages/docs/charts/adguard-home.mdx
+++ b/src/pages/docs/charts/adguard-home.mdx
@@ -308,13 +308,13 @@ Use the output (starting with `$2y$10$...`) as the `password` value.
 
 ### Init Permissions
 
-| Parameter                                          | Type    | Default                            | Description                                                                              |
-| -------------------------------------------------- | ------- | ---------------------------------- | ---------------------------------------------------------------------------------------- |
-| `initPermissions.enabled`                          | boolean | `true`                             | Normalize `/opt/adguardhome/conf` and `/opt/adguardhome/work` before start.              |
-| `initPermissions.image.repository`                 | string  | `docker.io/library/busybox`        | Init container image repository.                                                         |
-| `initPermissions.image.tag`                        | string  | `"1.37"`                           | Init container image tag.                                                                |
-| `initPermissions.securityContext.capabilities.add` | array   | `[CHOWN, DAC_READ_SEARCH, FOWNER]` | Minimal capabilities for PVC ownership, recursive traversal, and directory mode changes. |
-| `initPermissions.resources`                        | object  | `{}`                               | Resource requests and limits for the init container.                                     |
+| Parameter                                          | Type    | Default                         | Description                                                                                          |
+| -------------------------------------------------- | ------- | ------------------------------- | ---------------------------------------------------------------------------------------------------- |
+| `initPermissions.enabled`                          | boolean | `true`                          | Normalize `/opt/adguardhome/conf` and `/opt/adguardhome/work` before start.                          |
+| `initPermissions.image.repository`                 | string  | `docker.io/library/busybox`     | Init container image repository.                                                                     |
+| `initPermissions.image.tag`                        | string  | `"1.37"`                        | Init container image tag.                                                                            |
+| `initPermissions.securityContext.capabilities.add` | array   | `[CHOWN, DAC_OVERRIDE, FOWNER]` | Baseline-compatible capabilities for PVC ownership, recursive traversal, and directory mode changes. |
+| `initPermissions.resources`                        | object  | `{}`                            | Resource requests and limits for the init container.                                                 |
 
 When `securityContext.runAsUser` or `podSecurityContext.runAsUser` is configured for a non-root runtime, pre-seed `AdGuardHome.yaml` with
 `config.adGuardHome` or `config.existingSecret`. The interactive setup wizard requires administrator privileges on first launch;

--- a/src/pages/docs/charts/adguard-home.mdx
+++ b/src/pages/docs/charts/adguard-home.mdx
@@ -308,12 +308,17 @@ Use the output (starting with `$2y$10$...`) as the `password` value.
 
 ### Init Permissions
 
-| Parameter                          | Type    | Default                     | Description                                                                 |
-| ---------------------------------- | ------- | --------------------------- | --------------------------------------------------------------------------- |
-| `initPermissions.enabled`          | boolean | `true`                      | Normalize `/opt/adguardhome/conf` and `/opt/adguardhome/work` before start. |
-| `initPermissions.image.repository` | string  | `docker.io/library/busybox` | Init container image repository.                                            |
-| `initPermissions.image.tag`        | string  | `"1.37"`                    | Init container image tag.                                                   |
-| `initPermissions.resources`        | object  | `{}`                        | Resource requests and limits for the init container.                        |
+| Parameter                                          | Type    | Default                     | Description                                                                 |
+| -------------------------------------------------- | ------- | --------------------------- | --------------------------------------------------------------------------- |
+| `initPermissions.enabled`                          | boolean | `true`                      | Normalize `/opt/adguardhome/conf` and `/opt/adguardhome/work` before start. |
+| `initPermissions.image.repository`                 | string  | `docker.io/library/busybox` | Init container image repository.                                            |
+| `initPermissions.image.tag`                        | string  | `"1.37"`                    | Init container image tag.                                                   |
+| `initPermissions.securityContext.capabilities.add` | array   | `[CHOWN]`                   | Minimal capability required for PVC ownership changes.                      |
+| `initPermissions.resources`                        | object  | `{}`                        | Resource requests and limits for the init container.                        |
+
+When `securityContext.runAsUser` is configured for a non-root runtime, pre-seed `AdGuardHome.yaml` with `config.adGuardHome` or
+`config.existingSecret`. The interactive setup wizard requires administrator privileges on first launch; pre-seeded mode runs with
+non-root UID and `podSecurityContext.fsGroup`.
 
 ### Services
 

--- a/src/pages/docs/charts/adguard-home.mdx
+++ b/src/pages/docs/charts/adguard-home.mdx
@@ -316,9 +316,9 @@ Use the output (starting with `$2y$10$...`) as the `password` value.
 | `initPermissions.securityContext.capabilities.add` | array   | `[CHOWN]`                   | Minimal capability required for PVC ownership changes.                      |
 | `initPermissions.resources`                        | object  | `{}`                        | Resource requests and limits for the init container.                        |
 
-When `securityContext.runAsUser` is configured for a non-root runtime, pre-seed `AdGuardHome.yaml` with `config.adGuardHome` or
-`config.existingSecret`. The interactive setup wizard requires administrator privileges on first launch; pre-seeded mode runs with
-non-root UID and `podSecurityContext.fsGroup`.
+When `securityContext.runAsUser` or `podSecurityContext.runAsUser` is configured for a non-root runtime, pre-seed `AdGuardHome.yaml` with
+`config.adGuardHome` or `config.existingSecret`. The interactive setup wizard requires administrator privileges on first launch;
+pre-seeded mode runs with non-root UID and `podSecurityContext.fsGroup`.
 
 ### Services
 

--- a/src/pages/docs/charts/adguard-home.mdx
+++ b/src/pages/docs/charts/adguard-home.mdx
@@ -308,13 +308,13 @@ Use the output (starting with `$2y$10$...`) as the `password` value.
 
 ### Init Permissions
 
-| Parameter                                          | Type    | Default                     | Description                                                                 |
-| -------------------------------------------------- | ------- | --------------------------- | --------------------------------------------------------------------------- |
-| `initPermissions.enabled`                          | boolean | `true`                      | Normalize `/opt/adguardhome/conf` and `/opt/adguardhome/work` before start. |
-| `initPermissions.image.repository`                 | string  | `docker.io/library/busybox` | Init container image repository.                                            |
-| `initPermissions.image.tag`                        | string  | `"1.37"`                    | Init container image tag.                                                   |
-| `initPermissions.securityContext.capabilities.add` | array   | `[CHOWN]`                   | Minimal capability required for PVC ownership changes.                      |
-| `initPermissions.resources`                        | object  | `{}`                        | Resource requests and limits for the init container.                        |
+| Parameter                                          | Type    | Default                            | Description                                                                              |
+| -------------------------------------------------- | ------- | ---------------------------------- | ---------------------------------------------------------------------------------------- |
+| `initPermissions.enabled`                          | boolean | `true`                             | Normalize `/opt/adguardhome/conf` and `/opt/adguardhome/work` before start.              |
+| `initPermissions.image.repository`                 | string  | `docker.io/library/busybox`        | Init container image repository.                                                         |
+| `initPermissions.image.tag`                        | string  | `"1.37"`                           | Init container image tag.                                                                |
+| `initPermissions.securityContext.capabilities.add` | array   | `[CHOWN, DAC_READ_SEARCH, FOWNER]` | Minimal capabilities for PVC ownership, recursive traversal, and directory mode changes. |
+| `initPermissions.resources`                        | object  | `{}`                               | Resource requests and limits for the init container.                                     |
 
 When `securityContext.runAsUser` or `podSecurityContext.runAsUser` is configured for a non-root runtime, pre-seed `AdGuardHome.yaml` with
 `config.adGuardHome` or `config.existingSecret`. The interactive setup wizard requires administrator privileges on first launch;

--- a/src/pages/docs/charts/changedetection.mdx
+++ b/src/pages/docs/charts/changedetection.mdx
@@ -212,7 +212,7 @@ ingress:
 | Parameter          | Type   | Default                               | Description                          |
 | ------------------ | ------ | ------------------------------------- | ------------------------------------ |
 | `image.repository` | string | `ghcr.io/dgtlmoon/changedetection.io` | changedetection.io container image.  |
-| `image.tag`        | string | `"0.54.7"`                            | Image tag.                           |
+| `image.tag`        | string | `"0.55.5"`                            | Image tag.                           |
 | `image.pullPolicy` | string | `IfNotPresent`                        | Image pull policy.                   |
 | `imagePullSecrets` | array  | `[]`                                  | Pull secrets for private registries. |
 
@@ -225,6 +225,7 @@ ingress:
 | `changedetection.fetchWorkers`              | integer | `10`    | Number of concurrent fetch workers. Reduce when using the browser sidecar. |
 | `changedetection.minimumSecondsRecheckTime` | string  | `""`    | Minimum interval between rechecks in seconds. Empty means no minimum.      |
 | `changedetection.timezone`                  | string  | `""`    | Container timezone for scheduling and display.                             |
+| `changedetection.locale`                    | string  | `C`     | Locale assigned to `LANG` and `LC_ALL`.                                    |
 | `changedetection.extraEnv`                  | array   | `[]`    | Extra environment variables for advanced configuration.                    |
 
 <Callout type="tip" title="Reduce fetchWorkers when enabling the browser sidecar">
@@ -319,11 +320,14 @@ changedetection.io stores its SQLite database and all page snapshots (HTML conte
 `resources` applies to the main changedetection.io container only. Set `browser.resources` separately for the
 Chromium sidecar when `browser.enabled: true`.
 
-| Parameter            | Type   | Default | Description                                          |
-| -------------------- | ------ | ------- | ---------------------------------------------------- |
-| `resources`          | object | `{}`    | CPU and memory for the changedetection.io container. |
-| `podSecurityContext` | object | `{}`    | Pod-level security context.                          |
-| `securityContext`    | object | `{}`    | Container-level security context.                    |
+| Parameter                                  | Type    | Default | Description                                                          |
+| ------------------------------------------ | ------- | ------- | -------------------------------------------------------------------- |
+| `resources.requests.cpu`                   | string  | `100m`  | Default CPU request for the changedetection.io container.            |
+| `resources.requests.memory`                | string  | `256Mi` | Default memory request for the changedetection.io container.         |
+| `resources.limits`                         | object  | unset   | Optional CPU and memory limits for the changedetection.io container. |
+| `podSecurityContext`                       | object  | `{}`    | Pod-level security context.                                          |
+| `securityContext.allowPrivilegeEscalation` | boolean | `false` | Prevent privilege escalation in the main container.                  |
+| `securityContext.capabilities.drop`        | array   | `[ALL]` | Drop Linux capabilities by default.                                  |
 
 ### Service Account
 


### PR DESCRIPTION
## Summary
- Sync AdGuard Home site docs with chart PR #342 / issue helmforgedev/charts#306.
- Sync changedetection.io site docs with chart PR #343 / issue helmforgedev/charts#307.
- Update image tag defaults and newly documented values: `initPermissions.*` for AdGuard Home and `changedetection.locale` plus current resources/security defaults for changedetection.io.

## Merge Order / Release Gate
- Do not merge this site PR before helmforgedev/charts#342 and helmforgedev/charts#343 are merged and the chart release is available.
- This keeps public documentation from getting ahead of the installable chart packages.

## Validation
- [x] `npm run format:check`
- [x] `npm run lint`
- [x] `npm run build`
- [x] `git diff --check`

## MCP / Site Sync
- HelmForge MCP GR-007 passed for `/docs/charts/adguard-home#values` after the init permissions documentation update.
- HelmForge MCP previously identified `/docs/charts/adguard-home#values` and `/docs/charts/changedetection#values` as required updates.