### PR TITLE
docs(charts): expand chart documentation

### DIFF
--- a/src/pages/docs/charts/apache.mdx
+++ b/src/pages/docs/charts/apache.mdx
@@ -59,6 +59,171 @@ gateway:
 
 Use `serverStatus.require` carefully when metrics are enabled. The Apache exporter reads `mod_status`; keep status paths restricted to the metrics sidecar or trusted networks in production.
 
+## Architecture
+
+The chart runs Apache HTTP Server as a non-root Deployment listening on port `8080`. The web root is populated from
+`content.files` or from `content.existingConfigMap`, while the generated Apache configuration keeps logs on
+stdout/stderr and avoids writable paths outside the configured volumes.
+
+Typical production traffic is:
+
+1. Client traffic enters through Ingress or Gateway API.
+2. The HelmForge Service forwards requests to Apache pods.
+3. Apache serves static files, reverse-proxy rules, or extra virtual hosts from chart-managed configuration.
+4. Optional metrics scraping reaches the exporter sidecar and `mod_status`.
+5. Optional Basic Auth material is mounted from a Secret or an ExternalSecret-managed target Secret.
+
+## Production Values
+
+Use explicit content, resources, replica count, disruption budgets, and network boundaries for production:
+
+```yaml
+replicaCount: 3
+
+content:
+  existingConfigMap: apache-site-content
+
+resources:
+  requests:
+    cpu: 100m
+    memory: 128Mi
+  limits:
+    cpu: 1
+    memory: 512Mi
+
+pdb:
+  enabled: true
+  minAvailable: 1
+
+networkPolicy:
+  enabled: true
+  egress:
+    enabled: true
+    allowDns: true
+    allowInternet: false
+```
+
+Use immutable ConfigMaps for content releases. If a CI system rebuilds site assets, publish a new ConfigMap name and
+roll the release instead of mutating files inside the running container.
+
+## Routing
+
+Ingress uses `ingress.ingressClassName`, matching the rest of the HelmForge chart catalog:
+
+```yaml
+ingress:
+  enabled: true
+  ingressClassName: nginx
+  hosts:
+    - host: apache.example.com
+      paths:
+        - path: /
+          pathType: Prefix
+  tls:
+    - secretName: apache-tls
+      hosts:
+        - apache.example.com
+```
+
+Gateway API uses the single `gateway` block:
+
+```yaml
+gateway:
+  enabled: true
+  parentRefs:
+    - name: public-gateway
+      namespace: gateway-system
+  hostnames:
+    - apache.example.com
+  path: /
+  pathType: PathPrefix
+```
+
+Dual-stack Service fields are exposed directly:
+
+```yaml
+service:
+  ipFamilyPolicy: PreferDualStack
+  ipFamilies:
+    - IPv4
+    - IPv6
+```
+
+## Authentication And Secrets
+
+Basic Auth is optional and expects an htpasswd file in an existing Secret:
+
+```yaml
+basicAuth:
+  enabled: true
+  existingSecret: apache-basicauth
+  htpasswdKey: htpasswd
+```
+
+For GitOps platforms, let External Secrets Operator reconcile that Secret:
+
+```yaml
+basicAuth:
+  enabled: true
+  existingSecret: apache-basicauth
+
+externalSecrets:
+  enabled: true
+  secretStoreRef:
+    name: cluster-secrets
+    kind: ClusterSecretStore
+  data:
+    - secretKey: htpasswd
+      remoteRef:
+        key: apache/basicauth
+        property: htpasswd
+```
+
+The chart intentionally does not install a certificate manager, ingress controller, Gateway implementation, or WAF.
+Those platform responsibilities should be managed outside the Apache release.
+
+## Observability
+
+Enable the exporter only when `serverStatus.require` allows the sidecar or a trusted scrape path to read `mod_status`:
+
+```yaml
+metrics:
+  enabled: true
+  serviceMonitor:
+    enabled: true
+    labels:
+      release: prometheus
+
+serverStatus:
+  require: 'all granted'
+```
+
+In locked-down environments, prefer restricting metrics with NetworkPolicy and ServiceMonitor selectors instead of
+opening `mod_status` to arbitrary client traffic.
+
+## Validation
+
+After deployment:
+
+```bash
+helm test apache -n apache
+kubectl get pods -n apache -l app.kubernetes.io/name=apache
+kubectl logs -n apache deploy/apache --since=10m
+kubectl get events -n apache --sort-by=.lastTimestamp
+```
+
+The chart exposes `/healthz` for probes and Helm tests. If you replace the generated configuration, keep the health
+endpoint or update probes to a path served by your application.
+
+## Common Issues
+
+| Symptom                            | Likely Cause                                          | Fix                                                                     |
+| ---------------------------------- | ----------------------------------------------------- | ----------------------------------------------------------------------- |
+| `403` from `/server-status`        | `serverStatus.require` blocks the exporter            | Permit the exporter path or disable metrics.                            |
+| Pods restart after adding content  | ConfigMap checksum changed                            | Expected rollout; publish immutable ConfigMaps for controlled releases. |
+| Ingress works but Gateway does not | `parentRefs` points to the wrong Gateway or namespace | Verify Gateway API resources and listener hostnames.                    |
+| Basic Auth is ignored              | Secret key does not match `basicAuth.htpasswdKey`     | Check Secret data keys and ExternalSecret target keys.                  |
+
 <a id="values"></a>
 
 ## Values

--- a/src/pages/docs/charts/immich.mdx
+++ b/src/pages/docs/charts/immich.mdx
@@ -64,6 +64,166 @@ ingress:
 
 Persistent uploads are application data. Keep the upload PVC backed up with your platform backup tool. For production, prefer an external PostgreSQL instance or explicitly size the bundled PostgreSQL and cache PVCs.
 
+## Architecture
+
+The chart deploys the Immich server, the machine-learning service, HelmForge PostgreSQL, and a Redis/Valkey-compatible
+cache by default. Uploads, database data, cache data, and machine-learning model cache are separate persistence concerns
+and should be sized independently.
+
+Runtime flow:
+
+1. Ingress or Gateway API exposes the Immich server.
+2. The server stores metadata in PostgreSQL and binary media in the uploads volume.
+3. The cache service backs queues and application cache behavior.
+4. The machine-learning service stores model files on its own cache volume.
+5. Optional External Secrets wire external database or cache credentials.
+
+## Production Values
+
+Use durable uploads, durable dependencies, stable credentials, and explicit routing:
+
+```yaml
+server:
+  replicaCount: 1
+  persistence:
+    enabled: true
+    accessModes:
+      - ReadWriteOnce
+    storageClass: fast-retain
+    size: 500Gi
+
+machineLearning:
+  persistence:
+    enabled: true
+    storageClass: fast-retain
+    size: 20Gi
+
+postgresql:
+  auth:
+    existingSecret: immich-postgresql-auth
+    existingSecretPostgresPasswordKey: postgres-password
+    existingSecretUserPasswordKey: user-password
+  standalone:
+    persistence:
+      enabled: true
+      storageClass: fast-retain
+      size: 100Gi
+
+valkey:
+  auth:
+    enabled: true
+    existingSecret: immich-cache-auth
+    existingSecretPasswordKey: valkey-password
+  standalone:
+    persistence:
+      enabled: true
+      storageClass: fast-retain
+      size: 10Gi
+```
+
+Do not increase server replicas while uploads use `ReadWriteOnce` storage. The chart blocks unsafe multi-writer shapes
+so media libraries are not corrupted by multiple pods writing to a single-writer volume.
+
+## External Services
+
+For platform-managed PostgreSQL and Redis/Valkey:
+
+```yaml
+postgresql:
+  enabled: false
+
+database:
+  external:
+    host: postgres.example.com
+    port: 5432
+    database: immich
+    username: immich
+    existingSecret: immich-db
+    existingSecretPasswordKey: database-password
+
+valkey:
+  internal:
+    enabled: false
+  external:
+    host: valkey.example.com
+    port: 6379
+    existingSecret: immich-cache
+    existingSecretPasswordKey: redis-password
+```
+
+The external database must include the extensions required by Immich before application startup. Validate extension
+ownership and upgrade behavior in the database runbook, not only in the Helm release.
+
+## Networking
+
+Ingress example:
+
+```yaml
+ingress:
+  enabled: true
+  ingressClassName: traefik
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt-prod
+  hosts:
+    - host: immich.example.com
+      paths:
+        - path: /
+          pathType: Prefix
+  tls:
+    - secretName: immich-tls
+      hosts:
+        - immich.example.com
+```
+
+Gateway API example:
+
+```yaml
+gateway:
+  enabled: true
+  parentRefs:
+    - name: public
+      namespace: gateway-system
+  hostnames:
+    - immich.example.com
+  path: /
+  pathType: PathPrefix
+```
+
+## Storage And Backup
+
+Back up at least:
+
+- the uploads PVC
+- PostgreSQL data, whether bundled or external
+- Secrets used for database/cache credentials
+- any external object storage or backup configuration used by the platform
+
+The cache is usually rebuildable, but persistent cache storage can reduce cold-start impact. Do not treat the cache as
+the source of truth for photos or videos.
+
+## Validation
+
+After deployment:
+
+```bash
+helm test immich -n immich
+kubectl get pods -n immich -l app.kubernetes.io/name=immich
+kubectl logs -n immich deploy/immich --since=10m
+kubectl get events -n immich --sort-by=.lastTimestamp
+```
+
+Also validate browser login, upload, thumbnail generation, search, and machine-learning classification against a small
+test library.
+
+## Common Issues
+
+| Symptom                                | Likely Cause                                                 | Fix                                                     |
+| -------------------------------------- | ------------------------------------------------------------ | ------------------------------------------------------- |
+| Render fails when scaling server       | Upload volume is single-writer                               | Use `ReadWriteMany` storage or keep one server replica. |
+| Startup fails on database migrations   | External PostgreSQL lacks required extensions or permissions | Prepare the database before deploying Immich.           |
+| ML features are slow after restart     | Model cache is ephemeral                                     | Enable `machineLearning.persistence`.                   |
+| Uploads disappear after pod recreation | Upload persistence disabled or wrong PVC                     | Enable server persistence and verify PVC binding.       |
+
 <a id="values"></a>
 
 ## Values

--- a/src/pages/docs/charts/jenkins.mdx
+++ b/src/pages/docs/charts/jenkins.mdx
@@ -62,6 +62,153 @@ gateway:
 
 Store admin credentials outside the values file for production. If `jcasC.enabled=true`, include the Configuration as Code plugin through the image or the plugin bootstrap list.
 
+## Architecture
+
+The chart runs the Jenkins controller as a StatefulSet with persistent `JENKINS_HOME`. Optional init logic installs
+pinned plugins before startup, JCasC config maps can seed controller configuration, and RBAC can be created for
+Kubernetes-based build agents.
+
+Main paths:
+
+1. Users reach the controller through Ingress or Gateway API.
+2. The controller stores jobs, plugin state, and build metadata on the Jenkins home PVC.
+3. Optional plugin bootstrap installs pinned plugin versions before Jenkins starts.
+4. Optional JCasC files configure Jenkins from code once the Configuration as Code plugin is available.
+5. Optional Kubernetes agent RBAC lets the controller schedule ephemeral build agents.
+
+## Production Values
+
+Production Jenkins should use stable credentials, persistent storage, pinned plugins, explicit resources, and network
+boundaries:
+
+```yaml
+persistence:
+  enabled: true
+  size: 100Gi
+
+admin:
+  existingSecret: jenkins-admin
+
+resources:
+  requests:
+    cpu: 1
+    memory: 2Gi
+  limits:
+    cpu: 4
+    memory: 6Gi
+
+networkPolicy:
+  enabled: true
+  egress:
+    enabled: true
+    allowDns: true
+    allowInternet: true
+```
+
+Keep `allowInternet=true` only when plugin installation, SCM checkout, or build workloads require outbound internet. In
+restricted environments, mirror plugins and build dependencies internally.
+
+## Plugins And JCasC
+
+Pin plugins and test upgrades outside production:
+
+```yaml
+plugins:
+  install:
+    enabled: true
+    initializeOnce: true
+    list:
+      - configuration-as-code:2074.va_57f83f7a_10b_
+      - workflow-aggregator:608.v67378e9d3db_1
+      - git:5.10.1
+      - kubernetes:4423.vb_59f230b_ce53
+
+jcasC:
+  enabled: true
+  configScripts:
+    welcome.yaml: |
+      jenkins:
+        systemMessage: "Managed by HelmForge"
+```
+
+`initializeOnce` prevents repeated plugin install work after the first initialized Jenkins home. Disable it only when
+the release process intentionally reconciles plugins on every start.
+
+## Credentials
+
+By default, the chart can create initial admin credentials. For production, point both the workload and optional
+ExternalSecret at the same target Secret:
+
+```yaml
+admin:
+  existingSecret: jenkins-admin
+
+externalSecrets:
+  enabled: true
+  secretStoreRef:
+    name: cluster-secrets
+    kind: ClusterSecretStore
+  data:
+    - secretKey: jenkins-admin-user
+      remoteRef:
+        key: jenkins/admin
+        property: username
+    - secretKey: jenkins-admin-password
+      remoteRef:
+        key: jenkins/admin
+        property: password
+```
+
+## Networking And Agents
+
+Expose the controller with Ingress or Gateway API. Disable the inbound TCP agent listener when all builds use WebSocket
+agents or Kubernetes plugin agents:
+
+```yaml
+agent:
+  enabled: false
+
+gateway:
+  enabled: true
+  parentRefs:
+    - name: public-gateway
+      namespace: gateway-system
+  hostnames:
+    - jenkins.example.com
+```
+
+For Kubernetes agents, keep `rbac.create=true` only in namespaces where Jenkins is allowed to create build pods.
+
+## Backup And Upgrade Notes
+
+Back up `JENKINS_HOME` before plugin, Java, or Jenkins LTS upgrades. Treat plugin upgrades as application changes:
+review plugin changelogs, test JCasC reloads, and validate representative pipelines before promotion.
+
+Avoid changing the controller image and a large plugin set in the same release unless you have a rollback plan for both
+the image and persistent home contents.
+
+## Validation
+
+After deployment:
+
+```bash
+helm test jenkins -n jenkins
+kubectl get pods -n jenkins -l app.kubernetes.io/name=jenkins
+kubectl logs -n jenkins statefulset/jenkins --since=10m
+kubectl get events -n jenkins --sort-by=.lastTimestamp
+```
+
+Also validate a real pipeline run if Kubernetes agents, credentials, or network egress policies changed.
+
+## Common Issues
+
+| Symptom                             | Likely Cause                                     | Fix                                                             |
+| ----------------------------------- | ------------------------------------------------ | --------------------------------------------------------------- |
+| Jenkins starts without JCasC        | Configuration as Code plugin is missing          | Include the plugin in the image or `plugins.install.list`.      |
+| Plugin install repeats every start  | `initializeOnce` disabled or home not persistent | Enable persistence and `initializeOnce` for stable controllers. |
+| Agents cannot start                 | RBAC or NetworkPolicy blocks agent pods          | Check ServiceAccount permissions and egress to the API server.  |
+| Admin password changes unexpectedly | Chart-generated Secret was recreated             | Use `admin.existingSecret` or External Secrets.                 |
+
 <a id="values"></a>
 
 ## Values

--- a/src/pages/docs/charts/jupyterhub.mdx
+++ b/src/pages/docs/charts/jupyterhub.mdx
@@ -59,6 +59,181 @@ singleuser:
 
 Keep the default SQLite Hub database to a single Hub replica. For HA Hub deployments, configure an external database, provide a shared cookie secret, and avoid single-writer PVC modes for shared Hub state.
 
+## Architecture
+
+The chart deploys a JupyterHub Hub, configurable-http-proxy, and RBAC for KubeSpawner-managed user pods. The Hub owns
+authentication, spawning decisions, and user state. The proxy receives browser traffic and routes each authenticated
+user to the correct notebook server.
+
+Main runtime pieces:
+
+1. Public traffic reaches configurable-http-proxy through Ingress or Gateway API.
+2. The Hub authenticates users and instructs KubeSpawner to create notebook pods.
+3. User notebook pods run with the configured single-user image and optional per-user storage.
+4. The proxy routes each user to their notebook server.
+5. Optional metrics and ServiceMonitor expose Hub and proxy observability.
+
+## Production Values
+
+For production, replace DummyAuthenticator, use durable storage, configure a real authenticator, and keep metrics
+private:
+
+```yaml
+auth:
+  type: custom
+
+hub:
+  extraConfig: |
+    c.JupyterHub.authenticator_class = "nativeauthenticator.NativeAuthenticator"
+    # Configure c.JupyterHub.db_url before increasing hub.replicaCount.
+  persistence:
+    enabled: true
+    storageClass: fast-retain
+    size: 20Gi
+
+singleuser:
+  storage:
+    enabled: true
+    storageClass: fast-retain
+    capacity: 20Gi
+  profiles:
+    - display_name: Standard Lab
+      slug: standard
+      default: true
+      kubespawner_override:
+        default_url: /lab
+
+metrics:
+  authenticatePrometheus: true
+  serviceMonitor:
+    enabled: false
+```
+
+Do not expose the default dummy authentication mode on a public route. It is useful for local validation only.
+
+## Hub Database And HA
+
+The default Hub state uses SQLite on the Hub PVC. Keep `hub.replicaCount=1` in that mode. Before increasing replicas:
+
+1. Configure an external database with `c.JupyterHub.db_url` in `hub.extraConfig`.
+2. Provide a stable shared cookie secret.
+3. Avoid single-writer PVC modes for state shared by multiple Hub replicas.
+4. Validate login, spawn, stop, and resume flows behind your load balancer.
+
+For HA Hubs without Hub persistence, create a Secret containing the hex-encoded JupyterHub cookie secret:
+
+```yaml
+hub:
+  cookieSecret:
+    existingSecret: jupyterhub-cookie-secret
+  persistence:
+    enabled: false
+```
+
+Without a shared cookie secret, login sessions can fail when requests move between Hub replicas.
+
+## Single-User Profiles
+
+Profiles give platform teams controlled notebook options:
+
+```yaml
+singleuser:
+  image:
+    name: quay.io/jupyter/scipy-notebook
+    tag: '2026-05-26'
+  profiles:
+    - display_name: Data Science
+      slug: data-science
+      default: true
+      kubespawner_override:
+        cpu_limit: 2
+        mem_limit: 4G
+    - display_name: Lightweight
+      slug: lightweight
+      kubespawner_override:
+        cpu_limit: 1
+        mem_limit: 1G
+```
+
+Use profile overrides to limit CPU, memory, GPU access, default URL, images, and storage behavior.
+
+## Networking
+
+Ingress example:
+
+```yaml
+ingress:
+  enabled: true
+  ingressClassName: traefik
+  hosts:
+    - host: hub.example.com
+      paths:
+        - path: /
+          pathType: Prefix
+  tls:
+    - secretName: jupyterhub-tls
+      hosts:
+        - hub.example.com
+```
+
+Gateway API example:
+
+```yaml
+gateway:
+  enabled: true
+  parentRefs:
+    - name: public
+      namespace: gateway-system
+  hostnames:
+    - hub.example.com
+```
+
+Enable NetworkPolicy once you have confirmed the CNI enforces it and user pods can still reach the Hub and proxy.
+
+## Secrets
+
+The proxy token can be chart-generated for local environments. Production should use an existing Secret or External
+Secrets Operator:
+
+```yaml
+proxy:
+  existingSecret: jupyterhub-proxy-token
+
+externalSecrets:
+  enabled: true
+  secretStoreRef:
+    name: platform-secrets
+    kind: ClusterSecretStore
+  data:
+    - secretKey: proxy-token
+      remoteRef:
+        key: jupyterhub/proxy
+        property: proxy-token
+```
+
+## Validation
+
+After deployment:
+
+```bash
+helm test jupyterhub -n jupyterhub
+kubectl get pods -n jupyterhub -l app.kubernetes.io/name=jupyterhub
+kubectl logs -n jupyterhub deploy/jupyterhub-hub --since=10m
+kubectl get events -n jupyterhub --sort-by=.lastTimestamp
+```
+
+Also validate a full user workflow: login, spawn a notebook, restart the Hub, and confirm the notebook session survives
+when `hub.cleanupServers=false`.
+
+## Common Issues
+
+| Symptom                                  | Likely Cause                                     | Fix                                                                                  |
+| ---------------------------------------- | ------------------------------------------------ | ------------------------------------------------------------------------------------ |
+| Login sessions fail behind multiple Hubs | Cookie secret is not shared                      | Set `hub.cookieSecret.existingSecret`.                                               |
+| HA Hub render fails                      | SQLite DB or RWO persistence is incompatible     | Configure external DB and compatible persistence.                                    |
+| ServiceMonitor cannot scrape             | Prometheus auth remains enabled                  | Use private scrape credentials or explicitly disable metrics auth for private paths. |
+| User pods stay pending                   | RBAC, quotas, storage class, or image pulls fail | Describe the user pod and check namespace events.                                    |
+
 <a id="values"></a>
 
 ## Values

--- a/src/pages/docs/charts/kibana.mdx
+++ b/src/pages/docs/charts/kibana.mdx
@@ -63,6 +63,162 @@ elasticsearch:
 
 Set stable encryption keys before scaling beyond one replica. Elastic recommends matching Kibana and Elasticsearch versions across the stack.
 
+## Architecture
+
+The chart deploys Kibana as the visualization layer for Elasticsearch. It can connect to an external Elasticsearch
+cluster or deploy the HelmForge Elasticsearch subchart for self-contained environments. Authentication can be disabled
+for local tests, use basic credentials, or use a service account token.
+
+Runtime flow:
+
+1. Users reach Kibana through Ingress or Gateway API.
+2. Kibana reads stable encryption keys from generated or existing Secrets.
+3. Kibana connects to one or more Elasticsearch endpoints.
+4. Optional TLS CA material verifies Elasticsearch certificates.
+5. Optional ServiceMonitor scrapes Kibana process metrics.
+
+## Production Values
+
+Use stable encryption keys, TLS verification, service account tokens, and explicit network policy:
+
+```yaml
+replicaCount: 2
+
+elasticsearch:
+  hosts:
+    - https://elasticsearch:9200
+  auth:
+    type: serviceAccountToken
+    existingSecret: kibana-elasticsearch-token
+  tls:
+    enabled: true
+    certificateAuthoritiesSecret: elasticsearch-ca
+    verificationMode: certificate
+
+encryptionKeys:
+  existingSecret: kibana-encryption-keys
+
+networkPolicy:
+  enabled: true
+```
+
+Stable encryption keys are required before scaling beyond one pod. Without them, sessions, saved object encryption, and
+reporting features can fail across restarts or replicas.
+
+## Bundled Elasticsearch
+
+For development or self-contained validation, enable the HelmForge Elasticsearch dependency:
+
+```yaml
+bundledElasticsearch:
+  enabled: true
+
+elasticsearch:
+  hosts:
+    - http://kibana-bundled-elasticsearch:9200
+
+bundled-elasticsearch:
+  clusterProfile: dev
+  image:
+    tag: '9.4.2'
+  kibana:
+    enabled: false
+  master:
+    persistence:
+      enabled: false
+  sysctlInit:
+    enabled: false
+```
+
+For production, prefer a separately managed Elasticsearch release with its own capacity, backup, and upgrade plan.
+
+## Secrets And External Secrets
+
+Service account token example:
+
+```yaml
+elasticsearch:
+  auth:
+    type: serviceAccountToken
+    existingSecret: kibana-elasticsearch-token
+
+externalSecrets:
+  enabled: true
+  secretStoreRef:
+    name: cluster-secrets
+    kind: ClusterSecretStore
+  data:
+    - secretKey: service-account-token
+      remoteRef:
+        key: elastic/kibana
+        property: service-account-token
+```
+
+Use the same target Secret names in Kibana values and ExternalSecret configuration to avoid race conditions or orphaned
+credentials.
+
+## Networking
+
+Ingress example:
+
+```yaml
+ingress:
+  enabled: true
+  ingressClassName: nginx
+  hosts:
+    - host: kibana.example.com
+      paths:
+        - path: /
+          pathType: Prefix
+  tls:
+    - secretName: kibana-tls
+      hosts:
+        - kibana.example.com
+```
+
+Gateway API example:
+
+```yaml
+gateway:
+  enabled: true
+  parentRefs:
+    - name: shared-gateway
+      namespace: gateway-system
+  hostnames:
+    - kibana.example.com
+```
+
+## Upgrade Notes
+
+Keep Kibana and Elasticsearch versions aligned. When upgrading:
+
+1. Confirm Elasticsearch is compatible with the target Kibana version.
+2. Back up saved objects and Elasticsearch data according to the Elastic runbook.
+3. Keep encryption keys stable.
+4. Roll out Kibana after Elasticsearch is healthy.
+
+## Validation
+
+After deployment:
+
+```bash
+helm test kibana -n kibana
+kubectl get pods -n kibana -l app.kubernetes.io/name=kibana
+kubectl logs -n kibana deploy/kibana --since=10m
+kubectl get events -n kibana --sort-by=.lastTimestamp
+```
+
+Also validate login, saved object access, index pattern discovery, and TLS verification against Elasticsearch.
+
+## Common Issues
+
+| Symptom                                | Likely Cause                                   | Fix                                               |
+| -------------------------------------- | ---------------------------------------------- | ------------------------------------------------- |
+| Kibana reports encryption key warnings | Keys are generated or unstable                 | Set `encryptionKeys.existingSecret`.              |
+| Cannot connect to Elasticsearch        | Wrong hosts, credentials, CA, or NetworkPolicy | Validate DNS, Secret keys, CA Secret, and egress. |
+| TLS verification fails                 | CA Secret missing or verification mode wrong   | Mount the correct CA and set `verificationMode`.  |
+| Version compatibility errors           | Kibana and Elasticsearch versions differ       | Align stack versions before rollout.              |
+
 <a id="values"></a>
 
 ## Values

--- a/src/pages/docs/charts/metrics-server.mdx
+++ b/src/pages/docs/charts/metrics-server.mdx
@@ -47,6 +47,123 @@ Do not enable insecure kubelet TLS in production unless your platform explicitly
 
 Metrics Server `0.8.x` targets Kubernetes `1.31+`. For HA, use at least two replicas and configure aggregator routing on the API server where supported.
 
+## Architecture
+
+Metrics Server is a cluster add-on. The chart renders the Deployment, Service, RBAC, and optional APIService that backs
+`metrics.k8s.io/v1beta1`. The pod scrapes kubelets, aggregates CPU and memory samples, and serves them through the
+Kubernetes aggregation layer for `kubectl top`, HPA, and VPA integrations.
+
+Traffic flow:
+
+1. Metrics Server connects to kubelets on the configured secure port.
+2. The Kubernetes API aggregation layer proxies `metrics.k8s.io` requests to the Metrics Server Service.
+3. Controllers such as HPA read pod and node metrics from the aggregated API.
+4. Optional ServiceMonitor resources scrape Metrics Server's own process metrics.
+
+## Production Values
+
+Use two replicas, a PDB, and topology spread in production clusters:
+
+```yaml
+replicaCount: 2
+
+pdb:
+  enabled: true
+  maxUnavailable: 1
+  unhealthyPodEvictionPolicy: AlwaysAllow
+
+topologySpreadConstraints:
+  - maxSkew: 1
+    topologyKey: kubernetes.io/hostname
+    whenUnsatisfiable: ScheduleAnyway
+    labelSelector:
+      matchLabels:
+        app.kubernetes.io/name: metrics-server
+```
+
+For local k3d or self-signed kubelet serving certificates, use the dedicated local override:
+
+```yaml
+metricsServer:
+  kubelet:
+    insecureTLS: true
+```
+
+Do not carry `insecureTLS: true` into production unless the platform team has explicitly accepted the TLS validation
+tradeoff.
+
+## APIService And RBAC
+
+Keep `apiService.create=true` when the cluster does not already provide Metrics Server. The APIService must be
+`Available=True` before HPA and `kubectl top` can work:
+
+```bash
+kubectl get apiservice v1beta1.metrics.k8s.io
+kubectl describe apiservice v1beta1.metrics.k8s.io
+```
+
+The chart can also run without creating RBAC or the APIService for distributions that already manage those resources,
+but in that mode ownership must be clear to avoid reconciliation conflicts.
+
+## Networking
+
+Metrics Server usually needs egress from the pod to every node kubelet. If NetworkPolicy enforcement is enabled, allow
+node/kubelet traffic and DNS:
+
+```yaml
+networkPolicy:
+  enabled: true
+  egress:
+    enabled: true
+    allowDns: true
+```
+
+Host networking is opt-in for platforms where pod-to-kubelet routing requires it:
+
+```yaml
+hostNetwork:
+  enabled: true
+dnsPolicy: ClusterFirstWithHostNet
+```
+
+## Observability
+
+Enable the ServiceMonitor when Prometheus Operator is installed:
+
+```yaml
+serviceMonitor:
+  enabled: true
+  labels:
+    release: prometheus
+```
+
+Use Metrics Server process metrics to detect scrape failures, API aggregation errors, and high request latency. Use the
+Metrics API itself for autoscaling signals rather than scraping application metrics from Metrics Server.
+
+## Validation
+
+After deployment:
+
+```bash
+helm test metrics-server -n kube-system
+kubectl get pods -n kube-system -l app.kubernetes.io/name=metrics-server
+kubectl top nodes
+kubectl top pods -A
+kubectl get events -n kube-system --sort-by=.lastTimestamp
+```
+
+If `kubectl top` returns no data immediately after install, wait for at least one metric resolution interval and check
+the APIService condition.
+
+## Common Issues
+
+| Symptom                                           | Likely Cause                          | Fix                                                                       |
+| ------------------------------------------------- | ------------------------------------- | ------------------------------------------------------------------------- |
+| `kubectl top` returns `Metrics API not available` | APIService is unavailable             | Describe `v1beta1.metrics.k8s.io` and check Service endpoints.            |
+| Logs show kubelet certificate errors              | Kubelet serving certs are not trusted | Configure platform CA trust or use `insecureTLS` only for local clusters. |
+| HPA never scales                                  | Metrics API has no pod samples        | Check pod readiness, Metrics Server logs, and kubelet connectivity.       |
+| Pods cannot scrape kubelets                       | NetworkPolicy blocks node egress      | Allow kubelet ports and DNS in egress policy.                             |
+
 <a id="values"></a>
 
 ## Values

--- a/src/pages/docs/charts/oauth2-proxy.mdx
+++ b/src/pages/docs/charts/oauth2-proxy.mdx
@@ -63,6 +63,142 @@ config:
 
 Keep `config.reverseProxy.enabled=false` unless the deployment is behind a trusted ingress, gateway, or edge proxy. When enabled, define narrow `trustedProxyIps` CIDRs to avoid trusting client-supplied forwarded headers.
 
+## Architecture
+
+OAuth2 Proxy usually sits between an ingress or Gateway and protected upstream applications. This chart can run it as a
+dedicated authentication endpoint, a reverse proxy, or a forward-auth style component depending on how your ingress
+controller or Gateway implementation is configured.
+
+Typical flow:
+
+1. The browser reaches `/oauth2/start` or a protected route.
+2. OAuth2 Proxy redirects the user to the configured OAuth2/OIDC provider.
+3. The provider sends the browser back to `config.redirectUrl`.
+4. OAuth2 Proxy validates the response, sets a secure cookie, and forwards authenticated requests.
+5. Metrics and health endpoints stay separate from application traffic.
+
+## Production Values
+
+Use existing Secrets, secure cookies, explicit trusted proxy CIDRs, and at least two replicas:
+
+```yaml
+replicaCount: 2
+
+auth:
+  createSecret: false
+  existingSecret: oauth2-proxy-auth
+
+config:
+  provider: oidc
+  oidcIssuerUrl: https://idp.example.com/realms/platform
+  redirectUrl: https://auth.example.com/oauth2/callback
+  cookie:
+    secure: true
+    domains:
+      - .example.com
+  reverseProxy:
+    enabled: true
+    trustedProxyIps:
+      - 10.42.0.0/16
+
+metrics:
+  enabled: true
+  serviceMonitor:
+    enabled: true
+
+networkPolicy:
+  enabled: true
+```
+
+The Secret referenced by `auth.existingSecret` should contain the client secret and cookie secret keys expected by the
+chart. Keep cookie secrets stable across rollouts or users will be logged out.
+
+## OIDC Routing
+
+Ingress example:
+
+```yaml
+ingress:
+  enabled: true
+  ingressClassName: traefik
+  hosts:
+    - host: auth.example.com
+      paths:
+        - path: /oauth2
+          pathType: Prefix
+  tls:
+    - secretName: oauth2-proxy-tls
+      hosts:
+        - auth.example.com
+```
+
+Gateway API example:
+
+```yaml
+gateway:
+  enabled: true
+  parentRefs:
+    - name: public
+      namespace: gateway-system
+  hostnames:
+    - auth.example.com
+  path: /oauth2
+  pathType: PathPrefix
+```
+
+Make sure `config.redirectUrl` exactly matches the externally reachable callback URL, including scheme, host, and path.
+
+## External Secrets
+
+For GitOps, let External Secrets Operator manage the OAuth2 credentials:
+
+```yaml
+auth:
+  createSecret: false
+  existingSecret: oauth2-proxy-auth
+
+externalSecrets:
+  enabled: true
+  secretStoreRef:
+    name: platform-secrets
+    kind: ClusterSecretStore
+  dataFrom:
+    - extract:
+        key: oauth2-proxy/auth
+```
+
+Use `data` when your secret backend stores each key separately, and `dataFrom` when a single remote object contains all
+required keys.
+
+## Alpha Config
+
+Use `alphaConfig.enabled=true` when you need structured OAuth2 Proxy alpha configuration instead of command-line flags.
+Keep the generated config and classic `config` values aligned so the rendered arguments do not describe a different
+provider or cookie contract than the mounted config file.
+
+## Validation
+
+After deployment:
+
+```bash
+helm test oauth2-proxy -n oauth2-proxy
+kubectl get pods -n oauth2-proxy -l app.kubernetes.io/name=oauth2-proxy
+kubectl logs -n oauth2-proxy deploy/oauth2-proxy --since=10m
+kubectl get events -n oauth2-proxy --sort-by=.lastTimestamp
+```
+
+Validate a browser login flow as well as a direct health check. A healthy pod does not guarantee the OIDC provider,
+callback URL, cookie domain, and upstream proxy integration are correct.
+
+## Common Issues
+
+| Symptom                                  | Likely Cause                                            | Fix                                                      |
+| ---------------------------------------- | ------------------------------------------------------- | -------------------------------------------------------- |
+| Callback returns `redirect_uri mismatch` | `config.redirectUrl` differs from provider registration | Update either the chart value or the IdP client.         |
+| Users are logged out on every rollout    | Cookie secret changes                                   | Use `auth.existingSecret` or External Secrets.           |
+| Client IPs are spoofable                 | Reverse proxy trust is too broad                        | Keep `trustedProxyIps` narrow and platform-owned.        |
+| Login works but upstream denies user     | Missing headers or email/domain allow-list              | Check OAuth2 Proxy config and upstream expected headers. |
+
 <a id="values"></a>
 
 ## Values

--- a/src/pages/docs/charts/opencut.mdx
+++ b/src/pages/docs/charts/opencut.mdx
@@ -63,6 +63,174 @@ redisHttp:
 
 The chart uses HelmForge subcharts for databases by default. For production, pin credentials through existing Secrets or External Secrets and size PostgreSQL and Redis PVCs explicitly.
 
+## Architecture
+
+The chart deploys OpenCut with HelmForge PostgreSQL and Redis by default, plus the Redis-over-HTTP bridge required by
+the application path. The application pod receives a stable site URL, authentication secret, database connection, Redis
+connection, and optional workspace integration values.
+
+Runtime flow:
+
+1. Public traffic enters through Ingress or Gateway API.
+2. OpenCut handles browser and API traffic through the main Service.
+3. PostgreSQL stores application state.
+4. Redis and the Redis HTTP bridge support cache and application integration paths.
+5. Optional External Secrets reconcile database, Redis, and app secrets.
+
+## Production Values
+
+Use stable application secrets, durable PostgreSQL and Redis, explicit route settings, and NetworkPolicy:
+
+```yaml
+opencut:
+  siteUrl: https://opencut.example.com
+  betterAuthSecret: replace-with-a-stable-secret
+  marbleWorkspaceKey: replace-with-workspace-key
+
+postgresql:
+  auth:
+    existingSecret: opencut-postgresql-auth
+    existingSecretUserPasswordKey: user-password
+  standalone:
+    persistence:
+      enabled: true
+      storageClass: fast-retain
+      size: 50Gi
+
+redis:
+  auth:
+    enabled: true
+    existingSecret: opencut-redis-auth
+    existingSecretPasswordKey: redis-password
+  standalone:
+    persistence:
+      enabled: true
+      storageClass: fast-retain
+      size: 8Gi
+
+redisHttp:
+  resources:
+    requests:
+      cpu: 50m
+      memory: 128Mi
+    limits:
+      cpu: 500m
+      memory: 512Mi
+
+networkPolicy:
+  enabled: true
+```
+
+`opencut.siteUrl` should match the externally visible URL exactly. Authentication callback and generated links depend on
+that value.
+
+## External Services
+
+Use external dependencies when PostgreSQL or Redis are platform-managed:
+
+```yaml
+opencut:
+  siteUrl: https://opencut.example.com
+  betterAuthSecret: replace-with-a-stable-secret
+
+postgresql:
+  enabled: false
+
+database:
+  external:
+    host: postgres.example.com
+    port: 5432
+    name: opencut
+    username: opencut
+    existingSecret: opencut-db
+    existingSecretPasswordKey: database-password
+
+redis:
+  enabled: false
+  external:
+    host: redis.example.com
+    port: 6379
+    existingSecret: opencut-redis
+    existingSecretPasswordKey: redis-password
+```
+
+Keep the Redis HTTP bridge enabled unless your deployment provides a compatible external bridge through
+`redisHttp.externalUrl`.
+
+## Networking And Scaling
+
+Ingress example:
+
+```yaml
+ingress:
+  enabled: true
+  ingressClassName: traefik
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt-prod
+  hosts:
+    - host: opencut.example.com
+      paths:
+        - path: /
+          pathType: Prefix
+  tls:
+    - secretName: opencut-tls
+      hosts:
+        - opencut.example.com
+```
+
+Gateway API example:
+
+```yaml
+gateway:
+  enabled: true
+  parentRefs:
+    - name: public
+      namespace: gateway-system
+  hostnames:
+    - opencut.example.com
+  path: /
+  pathType: PathPrefix
+```
+
+Enable HPA only after database and Redis capacity have been sized for additional application pods:
+
+```yaml
+autoscaling:
+  enabled: true
+  minReplicas: 2
+  maxReplicas: 6
+```
+
+## Secrets
+
+For GitOps, store app and dependency secrets outside values files. The chart supports generated Kubernetes Secrets for
+local tests, existing Secrets for production, and ExternalSecret resources when External Secrets Operator is installed.
+
+Rotate `betterAuthSecret` carefully because it can invalidate sessions or signed application state.
+
+## Validation
+
+After deployment:
+
+```bash
+helm test opencut -n opencut
+kubectl get pods -n opencut -l app.kubernetes.io/name=opencut
+kubectl logs -n opencut deploy/opencut --since=10m
+kubectl get events -n opencut --sort-by=.lastTimestamp
+```
+
+Also validate the browser editor loads, authentication works, project creation succeeds, and the Redis HTTP bridge is
+reachable from the OpenCut pod.
+
+## Common Issues
+
+| Symptom                                  | Likely Cause                                   | Fix                                                         |
+| ---------------------------------------- | ---------------------------------------------- | ----------------------------------------------------------- |
+| Login or callbacks use the wrong URL     | `opencut.siteUrl` does not match public route  | Set the exact external HTTPS URL.                           |
+| App starts before dependencies are ready | External DB/Redis DNS or credentials are wrong | Check connection Secrets and service reachability.          |
+| Redis HTTP bridge errors                 | Bridge disabled or external URL wrong          | Keep `redisHttp.enabled=true` or set a valid `externalUrl`. |
+| Sessions break after redeploy            | Auth secret changed                            | Store `betterAuthSecret` in a stable Secret.                |
+
 <a id="values"></a>
 
 ## Values

--- a/src/pages/docs/charts/openreel-video.mdx
+++ b/src/pages/docs/charts/openreel-video.mdx
@@ -60,6 +60,136 @@ gateway:
 
 The chart is stateless by default. Scale horizontally with HPA when the ingress layer can distribute requests across replicas.
 
+## Architecture
+
+OpenReel Video is deployed as a stateless web workload. The chart is designed for browser-based editing frontends and
+WebCodecs-ready static hosting, so the main operational concerns are routing, cache behavior, temporary writable
+storage, and safe horizontal scaling.
+
+Runtime flow:
+
+1. Ingress or Gateway API receives public HTTPS traffic.
+2. The Service load-balances requests across OpenReel Video pods.
+3. The container serves static assets and browser application code.
+4. Temporary files are written only to the configured `tmpVolume`.
+5. Optional HPA and PDB keep the frontend available during rollouts.
+
+## Production Values
+
+Use multiple replicas, explicit resources, NetworkPolicy, and either Ingress or Gateway API:
+
+```yaml
+replicaCount: 2
+
+service:
+  ipFamilyPolicy: PreferDualStack
+  ipFamilies:
+    - IPv4
+    - IPv6
+
+ingress:
+  enabled: true
+  ingressClassName: traefik
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt-prod
+  hosts:
+    - host: openreel.example.com
+      paths:
+        - path: /
+          pathType: Prefix
+  tls:
+    - secretName: openreel-video-tls
+      hosts:
+        - openreel.example.com
+
+networkPolicy:
+  enabled: true
+
+resources:
+  requests:
+    cpu: 100m
+    memory: 128Mi
+  limits:
+    cpu: 500m
+    memory: 256Mi
+```
+
+## ExternalName Compatibility
+
+When the Kubernetes Service should point clients at an externally hosted OpenReel endpoint, use `ExternalName` and keep
+Ingress/Gateway disabled:
+
+```yaml
+service:
+  type: ExternalName
+  externalName: openreel-static.example.com
+
+ingress:
+  enabled: false
+
+gateway:
+  enabled: false
+```
+
+This is useful during migration from external hosting into the cluster, or when consumers need a stable Kubernetes DNS
+name for a service that remains outside Kubernetes.
+
+## Gateway API
+
+Gateway API is first-class and uses the shared HelmForge `gateway` shape:
+
+```yaml
+gateway:
+  enabled: true
+  parentRefs:
+    - name: public
+      namespace: gateway-system
+  hostnames:
+    - openreel.example.com
+  path: /
+  pathType: PathPrefix
+```
+
+## Scaling And Rollouts
+
+The chart is stateless, so HPA is safe when the edge layer can distribute requests:
+
+```yaml
+autoscaling:
+  enabled: true
+  minReplicas: 2
+  maxReplicas: 6
+
+pdb:
+  enabled: true
+  minAvailable: 1
+```
+
+Keep `tmpVolume.enabled=true` unless your custom image does not need writable temporary storage. The root filesystem can
+remain read-only while `/tmp` stays writable.
+
+## Validation
+
+After deployment:
+
+```bash
+helm test openreel-video -n openreel-video
+kubectl get pods -n openreel-video -l app.kubernetes.io/name=openreel-video
+kubectl logs -n openreel-video deploy/openreel-video --since=10m
+kubectl get events -n openreel-video --sort-by=.lastTimestamp
+```
+
+For public routes, validate that static assets load with the same host, scheme, and path used by the browser.
+
+## Common Issues
+
+| Symptom                                    | Likely Cause                                           | Fix                                                                      |
+| ------------------------------------------ | ------------------------------------------------------ | ------------------------------------------------------------------------ |
+| Blank page after route exposure            | Base URL or static asset path does not match the route | Check browser network errors and Gateway/Ingress path settings.          |
+| Pods fail with read-only filesystem errors | Application writes outside `tmpVolume`                 | Mount an explicit writable volume for the path or fix the image.         |
+| HPA scales but requests still hit one pod  | Edge proxy affinity or cache behavior                  | Review ingress/gateway load-balancing settings.                          |
+| ExternalName has no endpoints              | Expected Kubernetes behavior                           | Validate DNS resolution from a client pod instead of checking Endpoints. |
+
 <a id="values"></a>
 
 ## Values

--- a/src/pages/docs/charts/sonarqube.mdx
+++ b/src/pages/docs/charts/sonarqube.mdx
@@ -58,6 +58,169 @@ communityBranchPlugin:
 
 SonarQube embeds Elasticsearch and has host kernel requirements for production bootstrap checks. The chart keeps local evaluation approachable, but production clusters should satisfy SonarQube host requirements and use PostgreSQL, either bundled or external.
 
+## Architecture
+
+The chart runs SonarQube Community Build with one of three database paths:
+
+- `embedded` for disposable local validation
+- `postgresql` for the HelmForge PostgreSQL subchart
+- `external` for a platform-managed PostgreSQL database
+
+SonarQube also embeds Elasticsearch for search. That makes node kernel settings, persistent data, and startup probes
+part of the production contract.
+
+## Production Values
+
+Use PostgreSQL, persistent data and extensions volumes, and production bootstrap checks:
+
+```yaml
+sonarqube:
+  databaseMode: external
+  esBootstrapChecksDisable: false
+
+database:
+  external:
+    jdbcUrl: jdbc:postgresql://postgresql.database.svc.cluster.local:5432/sonarqube
+    username: sonar
+    existingSecret: sonarqube-database
+    existingSecretPasswordKey: jdbc-password
+
+persistence:
+  data:
+    enabled: true
+    size: 50Gi
+  extensions:
+    enabled: true
+    size: 10Gi
+
+networkPolicy:
+  enabled: true
+  egress:
+    enabled: true
+
+pdb:
+  enabled: true
+```
+
+Bundled HelmForge PostgreSQL is useful for self-contained releases:
+
+```yaml
+sonarqube:
+  databaseMode: postgresql
+  esBootstrapChecksDisable: false
+
+postgresql:
+  enabled: true
+  auth:
+    database: sonarqube
+    username: sonar
+    password: change-me
+  standalone:
+    persistence:
+      enabled: true
+      size: 50Gi
+```
+
+## Host Requirements
+
+Production nodes must satisfy SonarQube's Elasticsearch requirements before enabling bootstrap checks:
+
+- `vm.max_map_count=524288`
+- `fs.file-max=131072`
+- file descriptor limit of `131072`
+- process limit of `8192`
+
+Keep `sonarqube.esBootstrapChecksDisable=true` only for local and disposable environments.
+
+## Plugins
+
+The chart can download plugins during initialization:
+
+```yaml
+plugins:
+  enabled: true
+  install:
+    - name: sonar-auth-oidc
+      url: https://artifacts.example.com/sonar-auth-oidc.jar
+```
+
+Use an internal artifact repository for production. Startup should not depend on public internet availability.
+
+## Community Branch Plugin
+
+Community Branch Plugin wiring is explicit because it replaces web application files and adds Java agents:
+
+```yaml
+communityBranchPlugin:
+  enabled: true
+  version: '26.4.0'
+
+plugins:
+  enabled: true
+
+persistence:
+  extensions:
+    enabled: true
+    size: 10Gi
+```
+
+Keep the plugin major and minor version aligned with the SonarQube major and minor version. Mirror `jarUrl` and
+`webappUrl` internally when outbound internet is restricted.
+
+## Networking
+
+Ingress example:
+
+```yaml
+ingress:
+  enabled: true
+  ingressClassName: nginx
+  hosts:
+    - host: sonarqube.example.com
+      paths:
+        - path: /
+          pathType: Prefix
+  tls:
+    - secretName: sonarqube-tls
+      hosts:
+        - sonarqube.example.com
+```
+
+Gateway API uses `gatewayAPI` for this chart:
+
+```yaml
+gatewayAPI:
+  enabled: true
+  parentRefs:
+    - name: public-gateway
+      namespace: gateway-system
+  hostnames:
+    - sonarqube.example.com
+```
+
+## Validation
+
+After deployment:
+
+```bash
+helm test sonarqube -n sonarqube
+kubectl get pods -n sonarqube -l app.kubernetes.io/name=sonarqube
+kubectl logs -n sonarqube deploy/sonarqube --since=10m
+kubectl get events -n sonarqube --sort-by=.lastTimestamp
+```
+
+Also validate the UI system status, a project scan, plugin loading, and branch analysis when the community branch plugin
+is enabled.
+
+## Common Issues
+
+| Symptom                             | Likely Cause                                     | Fix                                              |
+| ----------------------------------- | ------------------------------------------------ | ------------------------------------------------ |
+| Elasticsearch bootstrap check fails | Node kernel limits are too low                   | Configure node sysctls and process/file limits.  |
+| Plugin disappears after restart     | Extensions persistence disabled                  | Enable `persistence.extensions`.                 |
+| Startup waits forever for DB        | JDBC URL, Secret key, or network policy is wrong | Check DB Secret, DNS, and egress policy.         |
+| Branch plugin fails after upgrade   | Plugin version mismatches SonarQube              | Align plugin and SonarQube major/minor versions. |
+
 <a id="values"></a>
 
 ## Values

--- a/src/pages/docs/charts/tomcat.mdx
+++ b/src/pages/docs/charts/tomcat.mdx
@@ -58,6 +58,164 @@ jmx:
 
 Prefer immutable Tomcat images or init containers that fetch versioned WAR artifacts. Enable JMX only on trusted networks and add authentication or TLS flags through `jmx.extraOpts` when exposing remote JMX.
 
+## Architecture
+
+The chart deploys the official Tomcat image with a writable application layer for `webapps`, `logs`, `temp`, and `work`.
+This keeps the container security posture strict while still allowing Tomcat to unpack WARs and write runtime files.
+
+Application delivery options:
+
+1. Bake WAR files or exploded applications into a custom Tomcat image.
+2. Mount WAR artifacts through an init container and shared volume.
+3. Use `webapps.persistence` for controlled mutable deployments.
+4. Disable the default ROOT health webapp when your application provides its own health endpoint.
+
+The default ROOT application exists only to make probes and Helm tests deterministic on a fresh install.
+
+## Production Values
+
+For production applications, disable the sample ROOT app, switch probes to an application-safe endpoint or TCP mode, and
+configure routing explicitly:
+
+```yaml
+replicaCount: 2
+
+webapps:
+  defaultRoot:
+    enabled: false
+  copyImageContent:
+    enabled: true
+
+startupProbe:
+  mode: tcp
+livenessProbe:
+  mode: tcp
+readinessProbe:
+  mode: tcp
+
+gatewayAPI:
+  enabled: true
+  parentRefs:
+    - name: public-gateway
+      namespace: gateway-system
+  hostnames:
+    - tomcat.example.com
+
+networkPolicy:
+  enabled: true
+  ingress:
+    extraFrom:
+      - namespaceSelector:
+          matchLabels:
+            kubernetes.io/metadata.name: gateway-system
+```
+
+## Deploying Applications
+
+For immutable images, keep `webapps.copyImageContent.enabled=true`; the chart copies image-baked contents from
+`/usr/local/tomcat/webapps` into the writable volume only when that volume is empty.
+
+For artifact-driven deployments, add an init container:
+
+```yaml
+extraInitContainers:
+  - name: fetch-war
+    image: docker.io/curlimages/curl:8.17.0
+    command:
+      - sh
+      - -ec
+      - |
+        curl -fsSL "$WAR_URL" -o /webapps/ROOT.war
+    env:
+      - name: WAR_URL
+        value: https://artifacts.example.com/apps/myapp-1.2.3.war
+    volumeMounts:
+      - name: webapps
+        mountPath: /webapps
+```
+
+Use persistent `webapps` only when applications are intentionally installed or mutated at runtime:
+
+```yaml
+webapps:
+  persistence:
+    enabled: true
+    size: 20Gi
+logs:
+  persistence:
+    enabled: true
+    size: 10Gi
+```
+
+## Reverse Proxy Configuration
+
+When Tomcat is behind an ingress controller or Gateway, configure connector proxy attributes so applications generate
+correct absolute URLs and redirects:
+
+```yaml
+tomcat:
+  serverXml: |
+    <Server port="8005" shutdown="SHUTDOWN">
+      <Service name="Catalina">
+        <Connector port="8080" protocol="HTTP/1.1"
+          proxyName="tomcat.example.com"
+          proxyPort="443"
+          scheme="https"
+          secure="true" />
+        <Engine name="Catalina" defaultHost="localhost">
+          <Host name="localhost" appBase="webapps" />
+        </Engine>
+      </Service>
+    </Server>
+```
+
+Use `tomcat.existingServerXmlConfigMap` when platform teams manage the full server configuration externally.
+
+## JMX
+
+Remote JMX is opt-in and should stay on trusted networks:
+
+```yaml
+jmx:
+  enabled: true
+  hostname: tomcat.example.local
+  extraOpts: '-Dcom.sun.management.jmxremote.local.only=false'
+
+networkPolicy:
+  enabled: true
+  ingress:
+    extraFrom:
+      - namespaceSelector:
+          matchLabels:
+            kubernetes.io/metadata.name: monitoring
+```
+
+For authenticated or TLS-secured JMX, mount the required files with `extraVolumes` and append the JVM flags through
+`jmx.extraOpts`.
+
+## Validation
+
+After deployment:
+
+```bash
+helm test tomcat -n tomcat
+kubectl get pods -n tomcat -l app.kubernetes.io/name=tomcat
+kubectl logs -n tomcat deploy/tomcat --since=10m
+kubectl get events -n tomcat --sort-by=.lastTimestamp
+```
+
+If probes use HTTP paths, confirm the deployed application serves those paths before disabling the default ROOT health
+webapp.
+
+## Common Issues
+
+| Symptom                              | Likely Cause                                | Fix                                                         |
+| ------------------------------------ | ------------------------------------------- | ----------------------------------------------------------- |
+| Probe failures after deploying a WAR | `/health.jsp` no longer exists              | Switch probes to TCP or configure app-specific probe paths. |
+| Redirects use `http://` behind TLS   | Connector proxy attributes missing          | Set `proxyName`, `proxyPort`, `scheme`, and `secure`.       |
+| Image-baked apps disappear           | Writable webapps volume hides image content | Keep `webapps.copyImageContent.enabled=true`.               |
+| JMX cannot connect                   | RMI hostname or NetworkPolicy is wrong      | Set `jmx.hostname` and allow monitoring namespace traffic.  |
+
 <a id="values"></a>
 
 ## Values

--- a/src/pages/docs/charts/valkey.mdx
+++ b/src/pages/docs/charts/valkey.mdx
@@ -63,6 +63,190 @@ metrics:
 
 Choose topology before production use. Sentinel requires Sentinel-aware clients. Cluster mode requires Valkey Cluster-aware clients and a fresh cluster bootstrap.
 
+## Architecture
+
+One HelmForge Valkey chart supports four topologies through `architecture`:
+
+| Architecture  | Contract                                    | Best Fit                                                |
+| ------------- | ------------------------------------------- | ------------------------------------------------------- |
+| `standalone`  | One Valkey pod with optional persistence    | Development, small caches, simple app state             |
+| `replication` | Fixed primary with read replicas            | Read-heavy workloads that can tolerate manual failover  |
+| `sentinel`    | Replication plus Sentinel primary discovery | HA clients that support Sentinel                        |
+| `cluster`     | Native Valkey Cluster sharding and replicas | Cluster-aware clients and horizontally growing datasets |
+
+Each topology renders the appropriate StatefulSets, Services, persistence settings, and tests. Select topology as an
+application contract, not only as a replica count.
+
+## Standalone
+
+Minimal standalone with an existing password Secret:
+
+```yaml
+architecture: standalone
+
+auth:
+  enabled: true
+  existingSecret: valkey-auth
+  existingSecretPasswordKey: valkey-password
+
+standalone:
+  persistence:
+    enabled: true
+    size: 10Gi
+```
+
+Standalone does not provide failover. Use it when the workload can tolerate downtime or when Valkey is a disposable
+cache.
+
+## Replication
+
+Replication gives one fixed primary endpoint and separate read replicas:
+
+```yaml
+architecture: replication
+
+auth:
+  enabled: true
+  existingSecret: valkey-auth
+  existingSecretPasswordKey: valkey-password
+
+replication:
+  replicaCount: 2
+  primary:
+    persistence:
+      enabled: true
+      size: 50Gi
+  replica:
+    persistence:
+      enabled: true
+      size: 50Gi
+
+metrics:
+  enabled: true
+  serviceMonitor:
+    enabled: true
+
+pdb:
+  enabled: true
+```
+
+Replication alone does not promote a replica automatically. Applications should write only to the primary Service.
+
+## Sentinel
+
+Sentinel adds primary discovery and failover for Sentinel-aware clients:
+
+```yaml
+architecture: sentinel
+
+replication:
+  replicaCount: 2
+
+sentinel:
+  replicaCount: 3
+  quorum: 2
+
+pdb:
+  enabled: true
+```
+
+Keep at least three Sentinels and choose a quorum that matches the failure domains. Validate application reconnect
+behavior before production rollout.
+
+## Cluster
+
+Cluster mode is for native sharding and requires Valkey Cluster-compatible clients:
+
+```yaml
+architecture: cluster
+
+auth:
+  enabled: true
+  existingSecret: valkey-auth
+  existingSecretPasswordKey: valkey-password
+
+cluster:
+  nodes: 6
+  replicasPerMaster: 1
+  persistence:
+    enabled: true
+    size: 20Gi
+```
+
+Cluster clients must handle `MOVED` and `ASK` redirects. Plan operational windows for future resharding, expansion, or
+maintenance.
+
+## TLS And Secrets
+
+Password authentication is enabled by default. Production should use existing Secrets or External Secrets:
+
+```yaml
+auth:
+  enabled: true
+  existingSecret: valkey-auth
+  existingSecretPasswordKey: valkey-password
+
+externalSecrets:
+  enabled: true
+  secretStoreRef:
+    name: cluster-secrets
+    kind: ClusterSecretStore
+  data:
+    - secretKey: valkey-password
+      remoteRef:
+        key: valkey/auth
+        property: password
+```
+
+TLS is file-based and expects the referenced Secrets to be created by the platform:
+
+```yaml
+tls:
+  enabled: true
+  existingSecret: valkey-tls
+  certKey: tls.crt
+  keyKey: tls.key
+  caKey: ca.crt
+```
+
+## Observability
+
+Enable the exporter sidecar and ServiceMonitor for production topologies:
+
+```yaml
+metrics:
+  enabled: true
+  serviceMonitor:
+    enabled: true
+    labels:
+      release: prometheus
+```
+
+Monitor memory pressure, evictions, replication lag, Sentinel quorum, cluster slot health, and restart counts.
+
+## Validation
+
+After deployment:
+
+```bash
+helm test valkey -n valkey
+kubectl get pods -n valkey -l app.kubernetes.io/name=valkey
+kubectl logs -n valkey statefulset/valkey --since=10m
+kubectl get events -n valkey --sort-by=.lastTimestamp
+```
+
+For Sentinel and cluster mode, test the exact client library used by the application. A healthy pod does not prove the
+client understands Sentinel discovery or Cluster redirects.
+
+## Common Issues
+
+| Symptom                                  | Likely Cause                                | Fix                                                        |
+| ---------------------------------------- | ------------------------------------------- | ---------------------------------------------------------- |
+| Writes fail in replication mode          | Application writes to replica Service       | Use the primary Service for writes.                        |
+| Sentinel failover is not observed by app | Client is not Sentinel-aware                | Configure Sentinel client support or use another topology. |
+| Cluster client receives redirect errors  | Client lacks Cluster support                | Use a Cluster-compatible client library.                   |
+| Auth changes break clients               | Password Secret rotated without app rollout | Coordinate Secret rotation and application restarts.       |
+
 <a id="values"></a>
 
 ## Values

--- a/src/pages/docs/charts/zookeeper.mdx
+++ b/src/pages/docs/charts/zookeeper.mdx
@@ -62,6 +62,178 @@ metrics:
 
 Keep production replica counts odd. Use `allowEvenReplicas=true` only for a deliberate platform-specific reason. Enable NetworkPolicy and explicitly allow client, quorum, DNS, and metrics flows.
 
+## Architecture
+
+ZooKeeper is deployed as a StatefulSet with stable pod DNS, a client Service, a headless Service for quorum traffic, and
+optional metrics exposure. Production ensembles should use an odd replica count so quorum can survive a member failure.
+
+Ports and roles:
+
+- client port for application connections
+- quorum election and follower communication ports between pods
+- optional secure client port when TLS is enabled
+- optional metrics port for Prometheus scraping
+
+The chart blocks accidental even replica counts by default. Set `allowEvenReplicas=true` only when an operator has a
+clear reason and accepts the quorum tradeoff.
+
+## Production Values
+
+Use three replicas, persistent data, a data log volume, PDB, metrics, topology spread, and NetworkPolicy:
+
+```yaml
+replicaCount: 3
+
+persistence:
+  enabled: true
+  size: 20Gi
+  dataLogDir:
+    enabled: true
+    size: 10Gi
+
+resources:
+  requests:
+    cpu: 500m
+    memory: 1Gi
+  limits:
+    memory: 2Gi
+
+podDisruptionBudget:
+  enabled: true
+  maxUnavailable: 1
+
+networkPolicy:
+  enabled: true
+
+metrics:
+  enabled: true
+  serviceMonitor:
+    enabled: true
+  prometheusRule:
+    enabled: true
+```
+
+For local or CI smoke tests, standalone mode is intentionally simple:
+
+```yaml
+replicaCount: 1
+
+persistence:
+  enabled: false
+```
+
+## Authentication
+
+Client SASL/Digest authentication is optional:
+
+```yaml
+auth:
+  client:
+    enabled: true
+    existingSecret: zookeeper-client-auth
+    usernameKey: username
+    passwordKey: password
+```
+
+When clients use authentication, update every application connection string and client JAAS configuration before
+enforcing the authenticated path.
+
+## TLS
+
+Secure client port support expects existing JKS keystore and truststore material:
+
+```yaml
+tls:
+  client:
+    enabled: true
+    existingSecret: zookeeper-client-tls
+    keystoreKey: keystore.jks
+    truststoreKey: truststore.jks
+    existingPasswordsSecret: zookeeper-client-tls-passwords
+```
+
+TLS changes affect both server startup and client compatibility. Validate the exact client libraries used by Kafka,
+Solr, or other ZooKeeper consumers before rollout.
+
+## External Secrets
+
+External Secrets Operator can reconcile auth and TLS material when the operator already exists:
+
+```yaml
+externalSecrets:
+  enabled: true
+  secretStoreRef:
+    name: cluster-secrets
+    kind: ClusterSecretStore
+  data:
+    - secretKey: password
+      remoteRef:
+        key: zookeeper/client
+        property: password
+```
+
+The chart renders ExternalSecret resources only when explicitly enabled; it does not install External Secrets Operator
+or create a SecretStore.
+
+## Networking
+
+NetworkPolicy must allow:
+
+- client traffic from approved application namespaces
+- quorum traffic between ZooKeeper pods
+- DNS egress
+- metrics scraping from the monitoring namespace when metrics are enabled
+
+Dual-stack Service fields are available:
+
+```yaml
+service:
+  ipFamilyPolicy: PreferDualStack
+  ipFamilies:
+    - IPv4
+    - IPv6
+```
+
+## Observability
+
+Enable metrics, ServiceMonitor, and PrometheusRule together when Prometheus Operator is available:
+
+```yaml
+metrics:
+  enabled: true
+  serviceMonitor:
+    enabled: true
+    additionalLabels:
+      release: prometheus
+  prometheusRule:
+    enabled: true
+```
+
+Watch quorum health, outstanding requests, latency, watches, open file descriptors, leader changes, and pod restarts.
+
+## Validation
+
+After deployment:
+
+```bash
+helm test zookeeper -n zookeeper
+kubectl get pods -n zookeeper -l app.kubernetes.io/name=zookeeper
+kubectl logs -n zookeeper statefulset/zookeeper --since=10m
+kubectl get events -n zookeeper --sort-by=.lastTimestamp
+```
+
+For production, validate a real client connection, quorum after a pod restart, and behavior during voluntary disruption
+with the PDB enabled.
+
+## Common Issues
+
+| Symptom                          | Likely Cause                                    | Fix                                                                    |
+| -------------------------------- | ----------------------------------------------- | ---------------------------------------------------------------------- |
+| Render blocks even replicas      | Quorum safety validation                        | Use an odd replica count or deliberately set `allowEvenReplicas=true`. |
+| Ensemble never forms quorum      | Pod DNS, NetworkPolicy, or quorum ports blocked | Check headless Service DNS and intra-ensemble policy.                  |
+| Clients fail after enabling auth | Client JAAS/config not updated                  | Roll client configuration before enforcing auth.                       |
+| TLS startup fails                | JKS Secret keys or passwords mismatch           | Verify Secret keys and password Secret values.                         |
+
 <a id="values"></a>
 
 ## Values


### PR DESCRIPTION
## Summary
- Expand the basic chart docs for Apache, Immich, Jenkins, JupyterHub, Kibana, Metrics Server, OAuth2 Proxy, OpenCut, OpenReel Video, SonarQube, Tomcat, Valkey, and ZooKeeper.
- Add chart-specific architecture, production values, routing/networking, secrets, observability, validation, and common issues sections based on the chart repo sources.
- Bring these pages closer to the documentation depth of PostgreSQL, Keycloak, and Pi-hole.

## Validation
- MCP Helmforge `mcp_health`: PASS
- MCP Helmforge `analyze_change_set`: PASS
- `npm run format:check`: PASS
- `npm run lint`: PASS
- `npm run build`: PASS
- `npx playwright install`: installed missing local Firefox/WebKit browsers for full local validation
- `npm run test:e2e`: PASS (316 passed, 2 skipped)
- `npm run test:a11y`: PASS (52 passed, 2 skipped)