### PR TITLE
fix(navigation): add drupal entry to cms charts category

### DIFF
--- a/src/data/navigation.ts
+++ b/src/data/navigation.ts
@@ -50,6 +50,7 @@ export const chartCategories: ChartCategory[] = [
     charts: [
       { label: 'WordPress', href: '/docs/charts/wordpress', maturity: 'stable' },
       { label: 'Strapi', href: '/docs/charts/strapi', maturity: 'stable' },
+      { label: 'Drupal', href: '/docs/charts/drupal', maturity: 'stable' },
       { label: 'Docmost', href: '/docs/charts/docmost', maturity: 'stable' },
       { label: 'Ghost', href: '/docs/charts/ghost', maturity: 'stable' },
       { label: 'Komga', href: '/docs/charts/komga', maturity: 'stable' },


### PR DESCRIPTION
## Summary

The `drupal` chart has a docs page, catalog entry and icon, but was missing from the sidebar navigation (`src/data/navigation.ts`). Detected by helmforge-ops `make org-check` (chart/site parity scan across all 78 charts).

Added `Drupal` to the CMS & Content category next to WordPress and Strapi.

## Evidence

- `npm run lint`: pass
- `npm run format:check`: pass
- `npm run build`: pass (145 pages indexed)
- `make org-check` after: 0 blockers

Related: helmforgedev/.github PR updating stale profile counts.