### PR TITLE
docs: sync updated chart pages

### DIFF
--- a/src/data/charts.ts
+++ b/src/data/charts.ts
@@ -58,7 +58,8 @@ export const charts: Chart[] = [
   {
     name: 'RabbitMQ',
     slug: 'rabbitmq',
-    description: 'RabbitMQ with management UI and clustering support.',
+    description:
+      'RabbitMQ with single-node or cluster mode, quorum queues, Gateway API, External Secrets, and dual-stack Services.',
     maturity: 'stable',
     backup: false,
   },
@@ -164,7 +165,8 @@ export const charts: Chart[] = [
   {
     name: 'Uptime Kuma',
     slug: 'uptime-kuma',
-    description: 'Self-hosted monitoring with status pages and broad notification support.',
+    description:
+      'Self-hosted monitoring with SQLite or MariaDB, Gateway API, External Secrets, S3 backup, and status pages.',
     maturity: 'stable',
     backup: true,
   },
@@ -339,7 +341,8 @@ export const charts: Chart[] = [
   {
     name: 'Statistics for Strava',
     slug: 'strava-statistics',
-    description: 'Self-hosted fitness dashboard with SQLite and Strava OAuth integration.',
+    description:
+      'Self-hosted fitness dashboard with SQLite, Strava OAuth, Gateway API, External Secrets, and dual-stack Services.',
     maturity: 'stable',
     backup: false,
   },
@@ -423,7 +426,8 @@ export const charts: Chart[] = [
   {
     name: 'OliveTin',
     slug: 'olivetin',
-    description: 'Browser-based UI for predefined shell commands and system actions.',
+    description:
+      'Browser-based command panel with ConfigMap actions, metrics, Gateway API, External Secrets, and dual-stack Services.',
     maturity: 'stable',
     backup: false,
   },

--- a/src/pages/docs/charts/olivetin.mdx
+++ b/src/pages/docs/charts/olivetin.mdx
@@ -1,7 +1,7 @@
 ---
 layout: ../../../layouts/DocsLayout.astro
 title: OliveTin Chart
-description: OliveTin Helm chart for Kubernetes command panels with browser UI, ConfigMap-defined actions, Prometheus metrics, persistence, and ingress.
+description: OliveTin Helm chart for Kubernetes command panels with browser UI, ConfigMap-defined actions, Prometheus metrics, persistence, Ingress, Gateway API, External Secrets, and dual-stack Services.
 ---
 
 import DocsTabs from '../../../components/DocsTabs.astro';
@@ -24,6 +24,9 @@ clean web UI, without giving users direct shell access.
 - **ConfigMap-based actions** — define shell commands in YAML, mounted as a ConfigMap
 - **No external dependencies** — no database, no state, stateless by design
 - **Prometheus metrics** — optional scraping with ServiceMonitor support
+- **Gateway API and Ingress** — expose the UI with either classic Ingress or HTTPRoute
+- **External Secrets Operator** — render ExternalSecret resources for credentials used by custom actions
+- **Dual-stack Services** — optional `ipFamilyPolicy` and `ipFamilies` controls
 - **Confirmation prompts** — require user confirmation before running destructive commands
 - **Icon and title customization** — human-friendly labels for each action
 - **Lightweight** — minimal resource footprint
@@ -52,6 +55,8 @@ helm install olivetin oci://ghcr.io/helmforgedev/helm/olivetin
     { id: 'actions', label: 'Rich Actions' },
     { id: 'metrics', label: 'With Metrics' },
     { id: 'auth-proxy', label: 'With Auth Proxy' },
+    { id: 'gateway-api', label: 'Gateway API' },
+    { id: 'external-secrets', label: 'External Secrets' },
   ]}
 >
 
@@ -194,6 +199,71 @@ ingress:
 
 </div>
 
+<div data-tab-panel="gateway-api">
+
+```yaml
+# values.yaml — expose OliveTin through Gateway API
+config: |
+  actions:
+    - title: "Show Disk Usage"
+      shell: "df -h"
+
+gatewayAPI:
+  enabled: true
+  httpRoutes:
+    - name: olivetin
+      spec:
+        parentRefs:
+          - name: internal-gateway
+            namespace: gateway-system
+        hostnames:
+          - olivetin.internal.example.com
+        rules:
+          - matches:
+              - path:
+                  type: PathPrefix
+                  value: /
+```
+
+</div>
+
+<div data-tab-panel="external-secrets">
+
+```yaml
+# values.yaml — credentials for custom actions managed by External Secrets Operator
+config: |
+  actions:
+    - title: "Trigger API"
+      shell: "curl -H \"Authorization: Bearer ${API_TOKEN}\" https://api.example.com/jobs"
+
+extraEnv:
+  - name: API_TOKEN
+    valueFrom:
+      secretKeyRef:
+        name: olivetin-command-credentials
+        key: API_TOKEN
+
+externalSecrets:
+  enabled: true
+  apiVersion: external-secrets.io/v1
+  refreshInterval: 1h
+  items:
+    - name: command-credentials
+      spec:
+        secretStoreRef:
+          name: platform-secrets
+          kind: ClusterSecretStore
+        target:
+          name: olivetin-command-credentials
+          creationPolicy: Owner
+        data:
+          - secretKey: API_TOKEN
+            remoteRef:
+              key: olivetin/api-token
+```
+
+</div>
+
 </DocsTabs>
 
 ## Configuration Reference
@@ -211,7 +281,7 @@ ingress:
 | Parameter          | Type   | Default                        | Description                          |
 | ------------------ | ------ | ------------------------------ | ------------------------------------ |
 | `image.repository` | string | `docker.io/jamesread/olivetin` | OliveTin container image.            |
-| `image.tag`        | string | `"3000.13.0"`                  | Image tag.                           |
+| `image.tag`        | string | `"3000.14.0"`                  | Image tag.                           |
 | `image.pullPolicy` | string | `IfNotPresent`                 | Image pull policy.                   |
 | `imagePullSecrets` | array  | `[]`                           | Pull secrets for private registries. |
 
@@ -268,11 +338,13 @@ and only needed if your actions produce output files that must survive pod resta
 
 ### Service
 
-| Parameter             | Type    | Default     | Description                          |
-| --------------------- | ------- | ----------- | ------------------------------------ |
-| `service.type`        | string  | `ClusterIP` | Kubernetes service type.             |
-| `service.port`        | integer | `80`        | Service port exposed to the cluster. |
-| `service.annotations` | object  | `{}`        | Annotations for the Service.         |
+| Parameter                | Type    | Default     | Description                                                                        |
+| ------------------------ | ------- | ----------- | ---------------------------------------------------------------------------------- |
+| `service.type`           | string  | `ClusterIP` | Kubernetes service type.                                                           |
+| `service.port`           | integer | `80`        | Service port exposed to the cluster.                                               |
+| `service.annotations`    | object  | `{}`        | Annotations for the Service.                                                       |
+| `service.ipFamilyPolicy` | string  | _omitted_   | Service IP family policy: `SingleStack`, `PreferDualStack`, or `RequireDualStack`. |
+| `service.ipFamilies`     | array   | _omitted_   | Ordered Service IP families such as `IPv4` and `IPv6`.                             |
 
 ### Ingress
 
@@ -283,6 +355,27 @@ and only needed if your actions produce output files that must survive pod resta
 | `ingress.annotations`      | object  | `{}`      | Annotations for the Ingress (e.g. ForwardAuth, TLS). |
 | `ingress.hosts`            | array   | `[]`      | Ingress host and path rules.                         |
 | `ingress.tls`              | array   | `[]`      | TLS configuration (secret name and hosts).           |
+
+### Gateway API
+
+Use `gatewayAPI` when your cluster exposes applications through Gateway API instead of Ingress. The chart renders
+HTTPRoute resources and routes them to the OliveTin Service by default.
+
+| Parameter               | Type    | Default | Description                             |
+| ----------------------- | ------- | ------- | --------------------------------------- |
+| `gatewayAPI.enabled`    | boolean | `false` | Render Gateway API HTTPRoute resources. |
+| `gatewayAPI.httpRoutes` | array   | `[]`    | HTTPRoute definitions to render.        |
+
+### External Secrets Operator
+
+External Secrets can materialize credentials for custom actions without committing secrets to the values file.
+
+| Parameter                         | Type    | Default                  | Description                                                   |
+| --------------------------------- | ------- | ------------------------ | ------------------------------------------------------------- |
+| `externalSecrets.enabled`         | boolean | `false`                  | Render ExternalSecret resources.                              |
+| `externalSecrets.apiVersion`      | string  | `external-secrets.io/v1` | ExternalSecret API version.                                   |
+| `externalSecrets.refreshInterval` | string  | `1h`                     | Default refresh interval for items that do not set one.       |
+| `externalSecrets.items`           | array   | `[]`                     | ExternalSecret definitions. Each item requires a full `spec`. |
 
 ### Probes
 

--- a/src/pages/docs/charts/rabbitmq.mdx
+++ b/src/pages/docs/charts/rabbitmq.mdx
@@ -1,7 +1,7 @@
 ---
 layout: ../../../layouts/DocsLayout.astro
 title: RabbitMQ Chart
-description: RabbitMQ Helm chart for Kubernetes with single-node or cluster mode, quorum queues, Erlang cookie clustering, management UI, TLS, metrics, and PDB.
+description: RabbitMQ Helm chart for Kubernetes with single-node or cluster mode, quorum queues, Erlang cookie clustering, management UI, TLS, metrics, Gateway API, External Secrets, dual-stack Services, and PDB.
 ---
 
 import DocsTabs from '../../../components/DocsTabs.astro';
@@ -24,6 +24,9 @@ TLS listeners.
 - **Two architectures** — `single-node` (Deployment) or `cluster` (StatefulSet with peer discovery)
 - **Quorum queues by default** — `queueDefaults.type: quorum` for durable, replicated HA queues
 - **Dedicated management ingress** — `management.ingress` is separate from the AMQP service
+- **Gateway API support** — optional HTTPRoute for the management UI
+- **External Secrets Operator** — source username, password, and Erlang cookie from an external provider
+- **Dual-stack Services** — optional Service `ipFamilyPolicy` and `ipFamilies` controls
 - **Partition handling** — `pause_minority` strategy prevents split-brain in cluster mode
 - **PDB support** — optional PodDisruptionBudget to protect cluster quorum during node maintenance
 - **TLS listeners** — configurable AMQP/S and management TLS from an existing Secret
@@ -65,6 +68,8 @@ helm install rabbitmq oci://ghcr.io/helmforgedev/helm/rabbitmq -f values.yaml
     { id: 'cluster', label: 'HA Cluster' },
     { id: 'tls', label: 'With TLS' },
     { id: 'metrics', label: 'With Prometheus' },
+    { id: 'external-secrets', label: 'External Secrets' },
+    { id: 'gateway-api', label: 'Gateway API' },
   ]}
 >
 
@@ -91,7 +96,7 @@ management:
   enabled: true
   ingress:
     enabled: true
-    className: traefik
+    ingressClassName: traefik
     annotations:
       cert-manager.io/cluster-issuer: letsencrypt-prod
     hosts:
@@ -147,7 +152,7 @@ management:
   enabled: true
   ingress:
     enabled: true
-    className: traefik
+    ingressClassName: traefik
     hosts:
       - host: rabbitmq.example.com
         paths:
@@ -188,7 +193,7 @@ management:
   enabled: true
   ingress:
     enabled: true
-    className: traefik
+    ingressClassName: traefik
     useTlsPort: true # route ingress to management HTTPS port (15671)
     hosts:
       - host: rabbitmq.example.com
@@ -233,6 +238,59 @@ management:
 
 </div>
 
+<div data-tab-panel="external-secrets">
+
+```yaml
+# values.yaml — RabbitMQ credentials managed by External Secrets Operator
+auth:
+  username: admin
+  existingSecret: rabbitmq-credentials
+  existingSecretUsernameKey: rabbitmq-username
+  existingSecretPasswordKey: rabbitmq-password
+  existingSecretErlangCookieKey: rabbitmq-erlang-cookie
+
+externalSecrets:
+  enabled: true
+  apiVersion: external-secrets.io/v1
+  refreshInterval: '0'
+  secretStoreRef:
+    name: platform-secrets
+    kind: ClusterSecretStore
+  data:
+    - secretKey: rabbitmq-username
+      remoteRef:
+        key: rabbitmq/admin
+        property: username
+    - secretKey: rabbitmq-password
+      remoteRef:
+        key: rabbitmq/admin
+        property: password
+    - secretKey: rabbitmq-erlang-cookie
+      remoteRef:
+        key: rabbitmq/cluster
+        property: erlangCookie
+```
+
+</div>
+
+<div data-tab-panel="gateway-api">
+
+```yaml
+# values.yaml — expose the RabbitMQ management UI through Gateway API
+management:
+  enabled: true
+
+gateway:
+  enabled: true
+  hostnames:
+    - rabbitmq.example.com
+  parentRefs:
+    - name: public-gateway
+      namespace: gateway-system
+```
+
+</div>
+
 </DocsTabs>
 
 ## Configuration Reference
@@ -252,7 +310,7 @@ management:
 | Parameter          | Type   | Default                      | Description                          |
 | ------------------ | ------ | ---------------------------- | ------------------------------------ |
 | `image.repository` | string | `docker.io/library/rabbitmq` | RabbitMQ image (management variant). |
-| `image.tag`        | string | `"4.2.4-management"`         | Image tag. Includes management UI.   |
+| `image.tag`        | string | `"4.3.1-management"`         | Image tag. Includes management UI.   |
 | `image.pullPolicy` | string | `IfNotPresent`               | Image pull policy.                   |
 | `imagePullSecrets` | array  | `[]`                         | Pull secrets for private registries. |
 
@@ -312,15 +370,16 @@ management:
 
 ### Management UI
 
-| Parameter                        | Type    | Default   | Description                                             |
-| -------------------------------- | ------- | --------- | ------------------------------------------------------- |
-| `management.enabled`             | boolean | `true`    | Enable the management plugin and UI (port 15672/15671). |
-| `management.ingress.enabled`     | boolean | `false`   | Enable Ingress for the management UI.                   |
-| `management.ingress.className`   | string  | `traefik` | Ingress class for the management UI.                    |
-| `management.ingress.annotations` | object  | `{}`      | Annotations for the management Ingress.                 |
-| `management.ingress.hosts`       | array   | `[]`      | Ingress host and path rules.                            |
-| `management.ingress.tls`         | array   | `[]`      | TLS configuration for the management Ingress.           |
-| `management.ingress.useTlsPort`  | boolean | `false`   | Route ingress to the TLS management port (15671).       |
+| Parameter                             | Type    | Default   | Description                                                                             |
+| ------------------------------------- | ------- | --------- | --------------------------------------------------------------------------------------- |
+| `management.enabled`                  | boolean | `true`    | Enable the management plugin and UI (port 15672/15671).                                 |
+| `management.ingress.enabled`          | boolean | `false`   | Enable Ingress for the management UI.                                                   |
+| `management.ingress.ingressClassName` | string  | `traefik` | Ingress class for the management UI.                                                    |
+| `management.ingress.className`        | string  | _unset_   | Deprecated compatibility alias. Set `""` to intentionally omit `spec.ingressClassName`. |
+| `management.ingress.annotations`      | object  | `{}`      | Annotations for the management Ingress.                                                 |
+| `management.ingress.hosts`            | array   | `[]`      | Ingress host and path rules.                                                            |
+| `management.ingress.tls`              | array   | `[]`      | TLS configuration for the management Ingress.                                           |
+| `management.ingress.useTlsPort`       | boolean | `false`   | Route ingress to the TLS management port (15671).                                       |
 
 ### TLS
 
@@ -367,18 +426,44 @@ management:
 
 ### Service
 
-| Parameter                   | Type    | Default     | Description                                            |
-| --------------------------- | ------- | ----------- | ------------------------------------------------------ |
-| `service.type`              | string  | `ClusterIP` | Service type.                                          |
-| `service.amqpPort`          | integer | `5672`      | AMQP listener port.                                    |
-| `service.amqpsPort`         | integer | `5671`      | AMQPS listener port (TLS).                             |
-| `service.managementPort`    | integer | `15672`     | Management UI HTTP port.                               |
-| `service.managementTlsPort` | integer | `15671`     | Management UI HTTPS port.                              |
-| `service.epmdPort`          | integer | `4369`      | Erlang port mapper daemon port.                        |
-| `service.distPort`          | integer | `25672`     | Erlang distribution port (cluster inter-node traffic). |
-| `service.metricsPort`       | integer | `15692`     | Prometheus metrics port.                               |
-| `service.annotations`       | object  | `{}`        | Annotations for the Service.                           |
-| `service.extraPorts`        | array   | `[]`        | Extra ports added to the Service.                      |
+| Parameter                   | Type    | Default     | Description                                               |
+| --------------------------- | ------- | ----------- | --------------------------------------------------------- |
+| `service.type`              | string  | `ClusterIP` | Service type.                                             |
+| `service.amqpPort`          | integer | `5672`      | AMQP listener port.                                       |
+| `service.amqpsPort`         | integer | `5671`      | AMQPS listener port (TLS).                                |
+| `service.managementPort`    | integer | `15672`     | Management UI HTTP port.                                  |
+| `service.managementTlsPort` | integer | `15671`     | Management UI HTTPS port.                                 |
+| `service.epmdPort`          | integer | `4369`      | Erlang port mapper daemon port.                           |
+| `service.distPort`          | integer | `25672`     | Erlang distribution port (cluster inter-node traffic).    |
+| `service.metricsPort`       | integer | `15692`     | Prometheus metrics port.                                  |
+| `service.annotations`       | object  | `{}`        | Annotations for the Service.                              |
+| `service.extraPorts`        | array   | `[]`        | Extra ports added to the Service.                         |
+| `service.ipFamilyPolicy`    | string  | `""`        | Service IP family policy. Empty uses the cluster default. |
+| `service.ipFamilies`        | array   | `[]`        | Ordered Service IP families such as `IPv4` and `IPv6`.    |
+
+### Gateway API
+
+The chart can expose the management UI with Gateway API by rendering an HTTPRoute that targets the management Service
+port. Use this when your cluster standardizes north-south HTTP traffic through Gateway API.
+
+| Parameter            | Type    | Default | Description                                       |
+| -------------------- | ------- | ------- | ------------------------------------------------- |
+| `gateway.enabled`    | boolean | `false` | Render a Gateway API HTTPRoute for management UI. |
+| `gateway.hostnames`  | array   | `[]`    | HTTPRoute hostnames. Empty matches all hostnames. |
+| `gateway.parentRefs` | array   | `[]`    | Parent Gateway references used by the HTTPRoute.  |
+
+### External Secrets Operator
+
+Use External Secrets for RabbitMQ credentials when passwords and Erlang cookies are owned by a secret manager.
+
+| Parameter                               | Type    | Default                  | Description                                              |
+| --------------------------------------- | ------- | ------------------------ | -------------------------------------------------------- |
+| `externalSecrets.enabled`               | boolean | `false`                  | Render an ExternalSecret for RabbitMQ credentials.       |
+| `externalSecrets.apiVersion`            | string  | `external-secrets.io/v1` | ExternalSecret API version.                              |
+| `externalSecrets.refreshInterval`       | string  | `"0"`                    | Refresh interval. `"0"` syncs once.                      |
+| `externalSecrets.secretStoreRef`        | object  | `{}`                     | SecretStore or ClusterSecretStore reference.             |
+| `externalSecrets.target.creationPolicy` | string  | `Owner`                  | Target Secret creation policy.                           |
+| `externalSecrets.data`                  | array   | `[]`                     | Mappings for username, password, and Erlang cookie keys. |
 
 ### Resources and Security
 

--- a/src/pages/docs/charts/redis.mdx
+++ b/src/pages/docs/charts/redis.mdx
@@ -303,7 +303,7 @@ clustered deployments.
 | Parameter          | Type   | Default                   | Description  |
 | ------------------ | ------ | ------------------------- | ------------ |
 | `image.repository` | string | `docker.io/library/redis` | Redis image. |
-| `image.tag`        | string | `"8.6.3"`                 | Image tag.   |
+| `image.tag`        | string | `"8.8.0"`                 | Image tag.   |
 
 ### Authentication
 

--- a/src/pages/docs/charts/strava-statistics.mdx
+++ b/src/pages/docs/charts/strava-statistics.mdx
@@ -1,7 +1,7 @@
 ---
 layout: ../../../layouts/DocsLayout.astro
 title: Statistics for Strava Chart
-description: Statistics for Strava Helm chart for Kubernetes fitness dashboards with SQLite storage, Strava OAuth, activity visualizations, persistence, and ingress.
+description: Statistics for Strava Helm chart for Kubernetes fitness dashboards with SQLite storage, Strava OAuth, activity visualizations, persistence, Ingress, Gateway API, External Secrets, and dual-stack Services.
 ---
 
 import DocsTabs from '../../../components/DocsTabs.astro';
@@ -26,7 +26,9 @@ external database required.
 - **SQLite storage** — embedded database, no external database dependency
 - **OAuth integration** — syncs with a single Strava athlete account via OAuth2
 - **Persistent storage** — PVC-backed data directory for SQLite database and cached files
-- **Ingress support** — TLS via cert-manager with configurable ingress class
+- **Ingress and Gateway API** — expose the dashboard with classic Ingress or HTTPRoute
+- **External Secrets Operator** — render ExternalSecret resources for Strava credentials
+- **Dual-stack Services** — optional `ipFamilyPolicy` and `ipFamilies` controls
 
 ## Strava OAuth Setup
 
@@ -82,6 +84,8 @@ helm install strava-statistics oci://ghcr.io/helmforgedev/helm/strava-statistics
     { id: 'basic', label: 'Basic' },
     { id: 'existing-secret', label: 'With Existing Secret' },
     { id: 'tls', label: 'With TLS' },
+    { id: 'gateway-api', label: 'Gateway API' },
+    { id: 'external-secrets', label: 'External Secrets' },
   ]}
 >
 
@@ -174,6 +178,76 @@ ingress:
 
 </div>
 
+<div data-tab-panel="gateway-api">
+
+```yaml
+# values.yaml — expose Statistics for Strava through Gateway API
+strava:
+  existingSecret: strava-credentials
+  existingSecretClientIdKey: client-id
+  existingSecretClientSecretKey: client-secret
+  existingSecretRefreshTokenKey: refresh-token
+  timezone: America/Sao_Paulo
+
+gatewayAPI:
+  enabled: true
+  httpRoutes:
+    - name: strava-statistics
+      spec:
+        parentRefs:
+          - name: public-gateway
+            namespace: gateway-system
+        hostnames:
+          - strava.example.com
+        rules:
+          - matches:
+              - path:
+                  type: PathPrefix
+                  value: /
+```
+
+</div>
+
+<div data-tab-panel="external-secrets">
+
+```yaml
+# values.yaml — Strava credentials managed by External Secrets Operator
+strava:
+  timezone: America/Sao_Paulo
+  existingSecret: strava-credentials
+  existingSecretClientIdKey: client-id
+  existingSecretClientSecretKey: client-secret
+  existingSecretRefreshTokenKey: refresh-token
+
+externalSecrets:
+  enabled: true
+  apiVersion: external-secrets.io/v1
+  items:
+    - name: strava-credentials
+      spec:
+        secretStoreRef:
+          name: platform-secrets
+          kind: ClusterSecretStore
+        target:
+          name: strava-credentials
+          creationPolicy: Owner
+        data:
+          - secretKey: client-id
+            remoteRef:
+              key: strava/oauth
+              property: clientId
+          - secretKey: client-secret
+            remoteRef:
+              key: strava/oauth
+              property: clientSecret
+          - secretKey: refresh-token
+            remoteRef:
+              key: strava/oauth
+              property: refreshToken
+```
+
+</div>
+
 </DocsTabs>
 
 ## Configuration Reference
@@ -191,7 +265,7 @@ ingress:
 | Parameter          | Type   | Default                                        | Description                          |
 | ------------------ | ------ | ---------------------------------------------- | ------------------------------------ |
 | `image.repository` | string | `docker.io/robiningelbrecht/strava-statistics` | Container image.                     |
-| `image.tag`        | string | `"v4.8.1"`                                     | Image tag.                           |
+| `image.tag`        | string | `"v4.8.5"`                                     | Image tag.                           |
 | `image.pullPolicy` | string | `IfNotPresent`                                 | Image pull policy.                   |
 | `imagePullSecrets` | array  | `[]`                                           | Pull secrets for private registries. |
 
@@ -322,15 +396,22 @@ ingress:
 
 | Parameter               | Type    | Default | Description                      |
 | ----------------------- | ------- | ------- | -------------------------------- |
-| `gatewayApi.enabled`    | boolean | `false` | Enable HTTPRoute resources.      |
-| `gatewayApi.httpRoutes` | array   | `[]`    | HTTPRoute definitions to render. |
+| `gatewayAPI.enabled`    | boolean | `false` | Enable HTTPRoute resources.      |
+| `gatewayAPI.httpRoutes` | array   | `[]`    | HTTPRoute definitions to render. |
+| `gatewayApi.enabled`    | boolean | `false` | Deprecated compatibility alias.  |
+| `gatewayApi.httpRoutes` | array   | `[]`    | Deprecated compatibility alias.  |
+
+<Callout type="info" title="Use gatewayAPI for new values">
+  `gatewayApi` remains as a compatibility alias for older values files. New deployments should use `gatewayAPI`.
+</Callout>
 
 ### External Secrets
 
-| Parameter                 | Type    | Default | Description                           |
-| ------------------------- | ------- | ------- | ------------------------------------- |
-| `externalSecrets.enabled` | boolean | `false` | Enable ExternalSecret resources.      |
-| `externalSecrets.items`   | array   | `[]`    | ExternalSecret definitions to render. |
+| Parameter                    | Type    | Default                  | Description                           |
+| ---------------------------- | ------- | ------------------------ | ------------------------------------- |
+| `externalSecrets.enabled`    | boolean | `false`                  | Enable ExternalSecret resources.      |
+| `externalSecrets.apiVersion` | string  | `external-secrets.io/v1` | ExternalSecret API version.           |
+| `externalSecrets.items`      | array   | `[]`                     | ExternalSecret definitions to render. |
 
 ## Common Issues
 

--- a/src/pages/docs/charts/uptime-kuma.mdx
+++ b/src/pages/docs/charts/uptime-kuma.mdx
@@ -1,7 +1,7 @@
 ---
 layout: ../../../layouts/DocsLayout.astro
 title: Uptime Kuma Chart
-description: Uptime Kuma Helm chart for Kubernetes monitoring with 20+ check types, 90+ notifications, public status pages, SQLite or MariaDB, and S3 backup.
+description: Uptime Kuma Helm chart for Kubernetes monitoring with 20+ check types, 90+ notifications, public status pages, SQLite or MariaDB, Gateway API, External Secrets, dual-stack Services, and S3 backup.
 ---
 
 import DocsTabs from '../../../components/DocsTabs.astro';
@@ -28,6 +28,9 @@ Discord, Slack, email, and more), and publishes customizable public status pages
 - **External database** — connect to an existing MariaDB/MySQL instance
 - **Smart S3 backup** — `tar` for SQLite mode, `mysqldump` for MariaDB mode
 - **Custom CA certificates** — monitor internal HTTPS services with private CA
+- **Gateway API and Ingress** — expose the UI with classic Ingress or HTTPRoute
+- **External Secrets Operator** — source database and S3 credentials from external providers
+- **Dual-stack Services** — optional `ipFamilyPolicy` and `ipFamilies` controls
 
 ## Installation
 
@@ -61,6 +64,8 @@ kubectl port-forward svc/<release>-uptime-kuma 3001:80
     { id: 'external-db', label: 'External Database' },
     { id: 'private-ca', label: 'Private CA Monitoring' },
     { id: 'backup', label: 'With S3 Backup' },
+    { id: 'gateway-api', label: 'Gateway API' },
+    { id: 'external-secrets', label: 'External Secrets' },
   ]}
 >
 
@@ -207,6 +212,91 @@ ingress:
 
 </div>
 
+<div data-tab-panel="gateway-api">
+
+```yaml
+# values.yaml — expose Uptime Kuma through Gateway API
+persistence:
+  enabled: true
+  size: 2Gi
+
+gatewayAPI:
+  enabled: true
+  httpRoutes:
+    - name: uptime-kuma
+      spec:
+        parentRefs:
+          - name: public-gateway
+            namespace: gateway-system
+        hostnames:
+          - status.example.com
+        rules:
+          - matches:
+              - path:
+                  type: PathPrefix
+                  value: /
+```
+
+</div>
+
+<div data-tab-panel="external-secrets">
+
+```yaml
+# values.yaml — external database and S3 credentials managed by External Secrets Operator
+database:
+  type: mariadb
+  external:
+    host: mariadb.database.svc.cluster.local
+    username: uptime_kuma
+    existingSecret: uptime-kuma-db
+    existingSecretPasswordKey: password
+
+backup:
+  enabled: true
+  s3:
+    endpoint: https://s3.amazonaws.com
+    bucket: my-uptime-kuma-backups
+    existingSecret: uptime-kuma-s3
+
+externalSecrets:
+  enabled: true
+  apiVersion: external-secrets.io/v1
+  refreshInterval: 1h
+  items:
+    - name: database
+      spec:
+        secretStoreRef:
+          name: platform-secrets
+          kind: ClusterSecretStore
+        target:
+          name: uptime-kuma-db
+          creationPolicy: Owner
+        data:
+          - secretKey: password
+            remoteRef:
+              key: uptime-kuma/database
+              property: password
+    - name: s3
+      spec:
+        secretStoreRef:
+          name: platform-secrets
+          kind: ClusterSecretStore
+        target:
+          name: uptime-kuma-s3
+          creationPolicy: Owner
+        data:
+          - secretKey: access-key
+            remoteRef:
+              key: uptime-kuma/s3
+              property: accessKey
+          - secretKey: secret-key
+            remoteRef:
+              key: uptime-kuma/s3
+              property: secretKey
+```
+
+</div>
+
 </DocsTabs>
 
 ## Configuration Reference
@@ -224,7 +314,7 @@ ingress:
 | Parameter          | Type   | Default                          | Description                          |
 | ------------------ | ------ | -------------------------------- | ------------------------------------ |
 | `image.repository` | string | `docker.io/louislam/uptime-kuma` | Uptime Kuma container image.         |
-| `image.tag`        | string | `"2.2.1"`                        | Image tag.                           |
+| `image.tag`        | string | `"2.4.0"`                        | Image tag.                           |
 | `image.pullPolicy` | string | `IfNotPresent`                   | Image pull policy.                   |
 | `imagePullSecrets` | array  | `[]`                             | Pull secrets for private registries. |
 
@@ -265,7 +355,8 @@ ingress:
 
 <Callout type="info" title="The mysql subchart is MariaDB-compatible">
   The subchart is named `mysql` in the values, but Uptime Kuma uses it as a MariaDB-compatible backend. Set
-  `database.type: mariadb` alongside `mysql.enabled: true` to activate this mode.
+  `database.type: mariadb` alongside `mysql.enabled: true` to activate this mode. The bundled dependency is the
+  HelmForge MySQL chart `2.0.0`.
 </Callout>
 
 | Parameter             | Type    | Default       | Description                                           |
@@ -320,11 +411,13 @@ The backup strategy adapts to the configured database mode automatically:
 
 ### Service
 
-| Parameter             | Type    | Default     | Description                          |
-| --------------------- | ------- | ----------- | ------------------------------------ |
-| `service.type`        | string  | `ClusterIP` | Kubernetes service type.             |
-| `service.port`        | integer | `80`        | Service port exposed to the cluster. |
-| `service.annotations` | object  | `{}`        | Annotations for the Service.         |
+| Parameter                | Type    | Default     | Description                                                                        |
+| ------------------------ | ------- | ----------- | ---------------------------------------------------------------------------------- |
+| `service.type`           | string  | `ClusterIP` | Kubernetes service type.                                                           |
+| `service.port`           | integer | `80`        | Service port exposed to the cluster.                                               |
+| `service.annotations`    | object  | `{}`        | Annotations for the Service.                                                       |
+| `service.ipFamilyPolicy` | string  | _omitted_   | Service IP family policy: `SingleStack`, `PreferDualStack`, or `RequireDualStack`. |
+| `service.ipFamilies`     | array   | _omitted_   | Ordered Service IP families such as `IPv4` and `IPv6`.                             |
 
 ### Ingress
 
@@ -335,6 +428,27 @@ The backup strategy adapts to the configured database mode automatically:
 | `ingress.annotations`      | object  | `{}`      | Annotations for the Ingress (e.g. cert-manager). |
 | `ingress.hosts`            | array   | `[]`      | Ingress host and path rules.                     |
 | `ingress.tls`              | array   | `[]`      | TLS configuration (secret name and hosts).       |
+
+### Gateway API
+
+Use Gateway API when your cluster standardizes HTTP routing through Gateway resources. The chart renders HTTPRoutes that
+target the Uptime Kuma Service by default.
+
+| Parameter               | Type    | Default | Description                      |
+| ----------------------- | ------- | ------- | -------------------------------- |
+| `gatewayAPI.enabled`    | boolean | `false` | Enable HTTPRoute resources.      |
+| `gatewayAPI.httpRoutes` | array   | `[]`    | HTTPRoute definitions to render. |
+
+### External Secrets Operator
+
+External Secrets can materialize database, S3, or integration credentials without storing them directly in Helm values.
+
+| Parameter                         | Type    | Default                  | Description                                                   |
+| --------------------------------- | ------- | ------------------------ | ------------------------------------------------------------- |
+| `externalSecrets.enabled`         | boolean | `false`                  | Render ExternalSecret resources.                              |
+| `externalSecrets.apiVersion`      | string  | `external-secrets.io/v1` | ExternalSecret API version.                                   |
+| `externalSecrets.refreshInterval` | string  | `1h`                     | Default refresh interval for items that do not set one.       |
+| `externalSecrets.items`           | array   | `[]`                     | ExternalSecret definitions. Each item requires a full `spec`. |
 
 ### Probes
 


### PR DESCRIPTION
## Summary

- Sync OliveTin, RabbitMQ, Redis, Statistics for Strava, and Uptime Kuma docs with the latest chart updates.
- Update image tags, RabbitMQ ingress field guidance, Gateway API, External Secrets, dual-stack Service documentation, and Uptime Kuma MySQL subchart version notes.
- Refresh chart card descriptions on the site to match current capabilities.

## Validation

- `npm run format:check`
- `npm run lint`
- `npm run build`

## HelmForge MCP

- `mcp_health`: PASS
- `check_site_sync`: PASS for olivetin, rabbitmq, redis, strava-statistics, and uptime-kuma
- `analyze_change_set`: PASS