### PR TITLE
docs(adguard-home): update image tag default

### DIFF
--- a/src/pages/docs/charts/adguard-home.mdx
+++ b/src/pages/docs/charts/adguard-home.mdx
@@ -273,7 +273,7 @@ ingress:
 | Parameter          | Type   | Default                         | Description         |
 | ------------------ | ------ | ------------------------------- | ------------------- |
 | `image.repository` | string | `docker.io/adguard/adguardhome` | AdGuard Home image. |
-| `image.tag`        | string | `"v0.107.76"`                   | Image tag.          |
+| `image.tag`        | string | `"v0.107.77"`                   | Image tag.          |
 
 ### Configuration
 


### PR DESCRIPTION
## Summary

- update the AdGuard Home chart docs to show the new default image tag `v0.107.77`

## Related

- Supports helmforgedev/charts#451
- Companion to helmforgedev/charts#469

## Merge order

This PR must be merged only after helmforgedev/charts#469 is merged and the updated chart default is released.

## Local validation

- `npm run lint`
- `npm run format:check`
- `npm run build`
- `make md-lint REPO=site`