### PR TITLE
docs(drupal): update image tag default

### DIFF
--- a/src/pages/docs/charts/drupal.mdx
+++ b/src/pages/docs/charts/drupal.mdx
@@ -22,7 +22,7 @@ This chart uses `docker.io/library/drupal` because Drupal does not currently pub
 
 HelmForge pins:
 
-- `docker.io/library/drupal:11.3.10-php8.5-apache-bookworm`
+- `docker.io/library/drupal:11.3.11-php8.5-apache-bookworm`
 
 That choice is intentional:
 
@@ -35,6 +35,13 @@ That choice is intentional:
 
 - [Drupal official website](https://new.drupal.org/home)
 - [Drupal system requirements](https://www.drupal.org/docs/getting-started/system-requirements)
+
+## Release Notes
+
+This chart tracks Drupal `11.3.11`, an upstream Drupal 11 patch and bugfix
+release. The bundled HelmForge MySQL dependency is aligned to the current
+`2.0.0` chart while preserving the same Drupal installer values for the default
+bundled database path.
 
 ## Installation
 
@@ -213,7 +220,7 @@ The chart still has an installer-oriented surface, but it now covers production 
 | ----------------------- | -------------------------------- | ----------------------------------------------- |
 | `replicaCount`          | `1`                              | Number of Drupal replicas                       |
 | `image.repository`      | `docker.io/library/drupal`       | Docker Official Drupal image repository         |
-| `image.tag`             | `11.3.10-php8.5-apache-bookworm` | Pinned Drupal image tag                         |
+| `image.tag`             | `11.3.11-php8.5-apache-bookworm` | Pinned Drupal image tag                         |
 | `image.pullPolicy`      | `IfNotPresent`                   | Container pull policy                           |
 | `imagePullSecrets`      | `[]`                             | Optional image pull secrets                     |
 | `drupal.siteName`       | `Drupal`                         | Suggested site name shown in install guidance   |
@@ -240,8 +247,8 @@ The chart still has an installer-oriented surface, but it now covers production 
 | `mysql.auth.rootPassword`                  | `""`                  | Optional root password override                         |
 | `mysql.auth.existingSecret`                | `""`                  | Existing secret for MySQL passwords                     |
 | `mysql.auth.existingSecretUserPasswordKey` | `mysql-user-password` | Secret key used for the app user password               |
-| `mysql.primary.persistence.enabled`        | `true`                | Enable MySQL persistence                                |
-| `mysql.primary.persistence.size`           | `8Gi`                 | MySQL PVC size                                          |
+| `mysql.standalone.persistence.enabled`     | `true`                | Enable bundled standalone MySQL persistence             |
+| `mysql.standalone.persistence.size`        | `8Gi`                 | Bundled standalone MySQL PVC size                       |
 | `persistence.enabled`                      | `true`                | Enable persistence for `/var/www/html/sites`            |
 | `persistence.storageClass`                 | `""`                  | Explicit storage class for the sites PVC                |
 | `persistence.accessMode`                   | `ReadWriteOnce`       | Access mode for the sites PVC                           |


### PR DESCRIPTION
## Summary

- update the Drupal docs to show the new default image tag `11.3.11-php8.5-apache-bookworm`
- add a short release/dependency note for Drupal `11.3.11` and the companion MySQL chart dependency update
- document the MySQL 2.x `mysql.standalone.persistence.*` keys used by the companion chart PR

## Related

- Supports helmforgedev/charts#452
- Companion to helmforgedev/charts#470

## Merge order

This PR must be merged only after helmforgedev/charts#470 is merged and the updated Drupal chart default is released.

## Local validation

- `npm run lint`
- `npm run format:check`
- `npm run build`
- `make md-lint REPO=site`