### PR TITLE
docs(envoy-gateway): update chart defaults

### DIFF
--- a/src/pages/docs/charts/envoy-gateway.mdx
+++ b/src/pages/docs/charts/envoy-gateway.mdx
@@ -1191,7 +1191,7 @@ clientTrafficPolicy:
 | -------------------------------------- | ----------------------------- | ------------------------------ |
 | `controller.replicaCount`              | Number of controller replicas | `1`                            |
 | `controller.image.repository`          | Controller image              | `docker.io/envoyproxy/gateway` |
-| `controller.image.tag`                 | Controller image tag          | `v1.8.0`                       |
+| `controller.image.tag`                 | Controller image tag          | `v1.8.1`                       |
 | `controller.image.pullPolicy`          | Image pull policy             | `IfNotPresent`                 |
 | `controller.resources.requests.cpu`    | CPU request                   | `100m`                         |
 | `controller.resources.requests.memory` | Memory request                | `128Mi`                        |
@@ -1203,20 +1203,22 @@ clientTrafficPolicy:
 
 ### Proxy Configuration
 
-| Parameter                         | Description                                                     | Default                      |
-| --------------------------------- | --------------------------------------------------------------- | ---------------------------- |
-| `proxy.ipFamily`                  | EnvoyProxy IP family                                            | `""`                         |
-| `proxy.kind`                      | EG proxy kind: Deployment or DaemonSet (managed by EG operator) | `Deployment`                 |
-| `proxy.replicaCount`              | Number of proxy replicas (Deployment only)                      | `1`                          |
-| `proxy.image.repository`          | Proxy image                                                     | `docker.io/envoyproxy/envoy` |
-| `proxy.image.tag`                 | Proxy image tag                                                 | `distroless-v1.37.0`         |
-| `proxy.resources.requests.cpu`    | CPU request                                                     | `100m`                       |
-| `proxy.resources.requests.memory` | Memory request                                                  | `128Mi`                      |
-| `proxy.resources.limits.cpu`      | CPU limit                                                       | `1000m`                      |
-| `proxy.resources.limits.memory`   | Memory limit                                                    | `1Gi`                        |
-| `proxy.autoscaling.enabled`       | Enable HPA                                                      | `false`                      |
-| `proxy.autoscaling.minReplicas`   | Minimum replicas                                                | `2`                          |
-| `proxy.autoscaling.maxReplicas`   | Maximum replicas                                                | `10`                         |
+| Parameter                                | Description                                                     | Default                        |
+| ---------------------------------------- | --------------------------------------------------------------- | ------------------------------ |
+| `proxy.ipFamily`                         | EnvoyProxy IP family                                            | `""`                           |
+| `proxy.kind`                             | EG proxy kind: Deployment or DaemonSet (managed by EG operator) | `Deployment`                   |
+| `proxy.replicaCount`                     | Number of proxy replicas (Deployment only)                      | `1`                            |
+| `proxy.image.repository`                 | Proxy image                                                     | `docker.io/envoyproxy/envoy`   |
+| `proxy.image.tag`                        | Proxy image tag                                                 | `distroless-v1.38.0`           |
+| `proxy.shutdownManager.image.repository` | Shutdown manager sidecar image                                  | `docker.io/envoyproxy/gateway` |
+| `proxy.shutdownManager.image.tag`        | Shutdown manager sidecar image tag                              | `v1.8.1`                       |
+| `proxy.resources.requests.cpu`           | CPU request                                                     | `100m`                         |
+| `proxy.resources.requests.memory`        | Memory request                                                  | `128Mi`                        |
+| `proxy.resources.limits.cpu`             | CPU limit                                                       | `1000m`                        |
+| `proxy.resources.limits.memory`          | Memory limit                                                    | `1Gi`                          |
+| `proxy.autoscaling.enabled`              | Enable HPA                                                      | `false`                        |
+| `proxy.autoscaling.minReplicas`          | Minimum replicas                                                | `2`                            |
+| `proxy.autoscaling.maxReplicas`          | Maximum replicas                                                | `10`                           |
 
 ### Gateway API Examples
 
@@ -1238,7 +1240,7 @@ clientTrafficPolicy:
 
 | Parameter           | Description       | Default  |
 | ------------------- | ----------------- | -------- |
-| `certgen.image.tag` | Certgen image tag | `v1.8.0` |
+| `certgen.image.tag` | Certgen image tag | `v1.8.1` |
 
 ### SecurityPolicy
 
@@ -1327,15 +1329,49 @@ All `redis.*` values are forwarded to the redis chart — refer to its documenta
 | `gatewayClass.name`   | GatewayClass name   | `envoy-gateway` |
 | `gatewayClass.create` | Create GatewayClass | `true`          |
 
+### Cleanup
+
+| Parameter                           | Description                                                 | Default                       |
+| ----------------------------------- | ----------------------------------------------------------- | ----------------------------- |
+| `cleanup.enabled`                   | Run a pre-delete cleanup Job for chart-managed GatewayClass | `true`                        |
+| `cleanup.image.repository`          | kubectl image used by the cleanup hook                      | `docker.io/helmforge/kubectl` |
+| `cleanup.image.tag`                 | kubectl image tag                                           | `1.35.3`                      |
+| `cleanup.image.pullPolicy`          | Cleanup image pull policy                                   | `IfNotPresent`                |
+| `cleanup.timeoutSeconds`            | Timeout for Gateway and GatewayClass cleanup operations     | `90`                          |
+| `cleanup.resources.requests.cpu`    | CPU request for the cleanup hook                            | `10m`                         |
+| `cleanup.resources.requests.memory` | Memory request for the cleanup hook                         | `32Mi`                        |
+| `cleanup.resources.limits.cpu`      | CPU limit for the cleanup hook                              | `100m`                        |
+| `cleanup.resources.limits.memory`   | Memory limit for the cleanup hook                           | `128Mi`                       |
+
+The cleanup hook runs before uninstall so chart-managed Gateways are deleted
+while the Envoy Gateway controller is still present. It then removes the
+chart-managed GatewayClass only after verifying that no remaining Gateways still
+reference that class. If user-managed Gateways still reference the class, the
+hook exits with a clear error and Helm leaves the release installed for manual
+cleanup.
+
 ---
 
 ## Upgrade Notes
 
-`docker.io/envoyproxy/gateway:v1.8.0` is the upstream minor update from
-`v1.7.3`. The upstream image tag is published with the `v` prefix. Review the
-upstream Envoy Gateway `v1.8.0` release notes, verify Gateway API and Envoy
-Gateway CRDs in staging, and test existing Gateway, HTTPRoute, EnvoyProxy, and
-policy resources before upgrading production controllers.
+`docker.io/envoyproxy/gateway:v1.8.1` is the upstream patch update from
+`v1.8.0`. The upstream image tag is published with the `v` prefix. This chart
+also updates the managed Envoy proxy image to
+`docker.io/envoyproxy/envoy:distroless-v1.38.0`, matching the upstream v1.8
+compatibility matrix.
+
+Envoy Gateway v1.8.1 includes security fixes for GatewayNamespaceMode xDS
+authentication, Lua validator sandbox path normalization, Wasm HTTP fetch gzip
+decompression limits, ReferenceGrant bypass handling, and related controller
+runtime issues. The chart now also pins the EG-managed `shutdown-manager`
+sidecar to `docker.io/envoyproxy/gateway:v1.8.1` through the EnvoyProxy strategic
+merge patch, avoiding the upstream-generated `gateway-dev:latest` runtime image.
+It also moves Gateway API safe-upgrades ValidatingAdmissionPolicy resources from
+the CRD bundle into the gateway Helm templates upstream. Before upgrading
+production controllers, review ownership of existing
+`safe-upgrades.gateway.networking.k8s.io` ValidatingAdmissionPolicy resources,
+verify Gateway API and Envoy Gateway CRDs in staging, and test existing Gateway,
+HTTPRoute, EnvoyProxy, and policy resources.
 
 ---
 
@@ -2153,9 +2189,9 @@ Complete architectural redesign for EG v1.7.3 with operator-managed proxy provis
 
 **Versions Updated**:
 
-- EG: v1.7.3 (was v1.0.0)
-- Envoy: distroless-v1.37.0 (was v1.29.0)
-- Redis: helmforge/redis subchart v1.6.9 (replaces inline StatefulSet)
+- EG: v1.8.1 (was v1.0.0)
+- Envoy: distroless-v1.38.0 (was v1.29.0)
+- Redis: helmforge/redis subchart v1.6.18 (replaces inline StatefulSet)
 - Gateway API CRDs: v1.2.1 (was v1.0.0)
 - PrometheusRule: 6 alerts (was 7)
 

--- a/src/pages/playground.astro
+++ b/src/pages/playground.astro
@@ -402,6 +402,145 @@ const chartConfigs: Record<string, ChartConfig> = {
       ],
     },
   ],
+  'envoy-gateway': [
+    {
+      name: 'Controller',
+      fields: [
+        {
+          label: 'Controller Replicas',
+          key: 'controller.replicaCount',
+          type: 'number',
+          default: '1',
+          description: 'Envoy Gateway controller replicas',
+        },
+        {
+          label: 'Controller Tag',
+          key: 'controller.image.tag',
+          type: 'text',
+          default: 'v1.8.1',
+          description: 'Envoy Gateway controller image tag',
+        },
+      ],
+    },
+    {
+      name: 'Gateway API',
+      collapsible: true,
+      fields: [
+        {
+          label: 'Create Gateway',
+          key: 'gateway.create',
+          type: 'toggle',
+          default: 'true',
+          description: 'Create the default Gateway resource',
+        },
+        {
+          label: 'Examples',
+          key: 'gatewayAPI.examples.enabled',
+          type: 'toggle',
+          default: 'true',
+          description: 'Create example Gateway, HTTPRoute, and backend',
+        },
+        {
+          label: 'GatewayClass',
+          key: 'gatewayClass.name',
+          type: 'text',
+          default: 'envoy-gateway',
+          description: 'GatewayClass name',
+        },
+      ],
+    },
+    {
+      name: 'Proxy',
+      collapsible: true,
+      fields: [
+        {
+          label: 'Proxy Kind',
+          key: 'proxy.kind',
+          type: 'select',
+          default: 'Deployment',
+          options: ['Deployment', 'DaemonSet'],
+          description: 'Envoy proxy workload kind managed by EG',
+        },
+        {
+          label: 'Proxy Replicas',
+          key: 'proxy.replicaCount',
+          type: 'number',
+          default: '1',
+          description: 'Proxy replicas in Deployment mode',
+        },
+        {
+          label: 'Envoy Tag',
+          key: 'proxy.image.tag',
+          type: 'text',
+          default: 'distroless-v1.38.0',
+          description: 'Managed Envoy proxy image tag',
+        },
+        {
+          label: 'Shutdown Tag',
+          key: 'proxy.shutdownManager.image.tag',
+          type: 'text',
+          default: 'v1.8.1',
+          description: 'Shutdown manager sidecar image tag',
+        },
+      ],
+    },
+    {
+      name: 'Rate Limiting',
+      collapsible: true,
+      gateField: 'rateLimiting.enabled',
+      fields: [
+        {
+          label: 'Redis Subchart',
+          key: 'redis.enabled',
+          type: 'toggle',
+          default: 'true',
+          description: 'Deploy helmforge/redis for rate limiting',
+        },
+        {
+          label: 'API Preset',
+          key: 'rateLimiting.presets.api',
+          type: 'toggle',
+          default: 'false',
+          description: 'Apply the API rate limit preset',
+        },
+      ],
+    },
+    {
+      name: 'Operations',
+      collapsible: true,
+      fields: [
+        {
+          label: 'Monitoring',
+          key: 'monitoring.enabled',
+          type: 'toggle',
+          default: 'false',
+          description: 'Enable metrics and access log configuration',
+        },
+        {
+          label: 'Access Logs',
+          key: 'monitoring.accessLogs.format',
+          type: 'select',
+          default: 'json',
+          options: ['json', 'text'],
+          description: 'Envoy access log format',
+        },
+        {
+          label: 'NetworkPolicies',
+          key: 'security.networkPolicies',
+          type: 'toggle',
+          default: 'false',
+          description: 'Create controller and rate limit NetworkPolicies',
+        },
+        {
+          label: 'Cleanup Hook',
+          key: 'cleanup.enabled',
+          type: 'toggle',
+          default: 'true',
+          description: 'Run pre-delete cleanup for GatewayClass finalizers',
+        },
+      ],
+    },
+  ],
   opencut: [
     {
       name: 'General',


### PR DESCRIPTION
## Summary- Update the Envoy Gateway chart docs for v1.8.1 defaults and the Envoy v1.38.1 data-plane image.- Document the pinned shutdown-manager sidecar image and GatewayClass cleanup hook behavior.- Add Envoy Gateway to the values playground with controller, Gateway API, proxy, rate limiting, monitoring, NetworkPolicy, and cleanup controls.## Companion- Supports helmforgedev/charts#453.- Companion chart PR: helmforgedev/charts#472.- Merge order: merge only after helmforgedev/charts#472 is merged and released.## Local validation- `npm run format:check`- `npm run lint`- `npm run build`- `make md-lint REPO=site`- `make site-sync-check CHART=envoy-gateway`- `make release-check REPO=site`- `make attribution-check REPO=site`