### PR TITLE
docs(ghost): update chart defaults

### DIFF
--- a/src/pages/docs/charts/ghost.mdx
+++ b/src/pages/docs/charts/ghost.mdx
@@ -203,7 +203,7 @@ backup:
 | Parameter          | Type   | Default                   | Description                          |
 | ------------------ | ------ | ------------------------- | ------------------------------------ |
 | `image.repository` | string | `docker.io/library/ghost` | Ghost container image.               |
-| `image.tag`        | string | `"6.37.1"`                | Image tag.                           |
+| `image.tag`        | string | `"6.44.1"`                | Image tag.                           |
 | `image.pullPolicy` | string | `IfNotPresent`            | Image pull policy.                   |
 | `imagePullSecrets` | array  | `[]`                      | Pull secrets for private registries. |
 

--- a/src/pages/playground.astro
+++ b/src/pages/playground.astro
@@ -152,6 +152,27 @@ const chartConfigs: Record<string, ChartConfig> = {
           default: 'https://s3.amazonaws.com',
           description: 'S3-compatible endpoint URL',
         },
+        {
+          label: 'Credentials Secret',
+          key: 'backup.s3.existingSecret',
+          type: 'text',
+          default: 'ghost-s3-credentials',
+          description: 'Secret containing S3 credentials',
+        },
+        {
+          label: 'Access Key Field',
+          key: 'backup.s3.existingSecretAccessKeyKey',
+          type: 'text',
+          default: 'access-key',
+          description: 'Secret key for the S3 access key',
+        },
+        {
+          label: 'Secret Key Field',
+          key: 'backup.s3.existingSecretSecretKeyKey',
+          type: 'text',
+          default: 'secret-key',
+          description: 'Secret key for the S3 secret key',
+        },
       ],
     },
     {

--- a/src/pages/playground.astro
+++ b/src/pages/playground.astro
@@ -79,6 +79,97 @@ const chartConfigs: Record<string, ChartConfig> = {
       ],
     },
   ],
+  ghost: [
+    {
+      name: 'General',
+      fields: [
+        {
+          label: 'Public URL',
+          key: 'ghost.url',
+          type: 'text',
+          default: '',
+          description: 'Canonical Ghost URL',
+        },
+        {
+          label: 'Image Tag',
+          key: 'image.tag',
+          type: 'text',
+          default: '6.44.1',
+          description: 'Ghost image tag',
+        },
+        {
+          label: 'MySQL Subchart',
+          key: 'mysql.enabled',
+          type: 'toggle',
+          default: 'true',
+          description: 'Deploy HelmForge MySQL',
+        },
+      ],
+    },
+    {
+      name: 'Content',
+      collapsible: true,
+      fields: [
+        {
+          label: 'Persistence',
+          key: 'persistence.enabled',
+          type: 'toggle',
+          default: 'true',
+          description: 'Persist Ghost content',
+        },
+        {
+          label: 'PVC Size',
+          key: 'persistence.size',
+          type: 'text',
+          default: '10Gi',
+          description: 'Content storage size',
+        },
+      ],
+    },
+    {
+      name: 'Backup',
+      collapsible: true,
+      gateField: 'backup.enabled',
+      fields: [
+        {
+          label: 'Schedule',
+          key: 'backup.schedule',
+          type: 'text',
+          default: '0 3 * * *',
+          description: 'Backup cron schedule',
+        },
+        {
+          label: 'Bucket',
+          key: 'backup.s3.bucket',
+          type: 'text',
+          default: 'ghost-backups',
+          description: 'S3 backup bucket',
+        },
+      ],
+    },
+    {
+      name: 'Ingress',
+      collapsible: true,
+      gateField: 'ingress.enabled',
+      fields: [
+        {
+          label: 'Hostname',
+          key: 'ingress.hosts[0].host',
+          type: 'text',
+          default: 'blog.example.com',
+          description: 'Ingress host',
+        },
+        {
+          label: 'Ingress Class',
+          key: 'ingress.ingressClassName',
+          type: 'select',
+          default: 'nginx',
+          options: ['nginx', 'traefik'],
+          description: 'Ingress controller class',
+        },
+      ],
+    },
+  ],
   immich: [
     {
       name: 'General',

--- a/src/pages/playground.astro
+++ b/src/pages/playground.astro
@@ -145,6 +145,13 @@ const chartConfigs: Record<string, ChartConfig> = {
           default: 'ghost-backups',
           description: 'S3 backup bucket',
         },
+        {
+          label: 'Endpoint',
+          key: 'backup.s3.endpoint',
+          type: 'text',
+          default: 'https://s3.amazonaws.com',
+          description: 'S3-compatible endpoint URL',
+        },
       ],
     },
     {
@@ -163,7 +170,7 @@ const chartConfigs: Record<string, ChartConfig> = {
           label: 'Ingress Class',
           key: 'ingress.ingressClassName',
           type: 'select',
-          default: 'nginx',
+          default: 'traefik',
           options: ['nginx', 'traefik'],
           description: 'Ingress controller class',
         },


### PR DESCRIPTION
## Summary
- Update the Ghost chart docs default image tag from 6.37.1 to 6.44.1.
- Add Ghost to the playground configuration so GR-007 site sync is covered for the chart update.

## Validation
- `npm run format:check -- src/pages/playground.astro src/pages/docs/charts/ghost.mdx`
- `npm run lint`
- `npm run build`
- `make site-sync-check CHART=ghost`

Companion chart PR: helmforgedev/charts#475.