### PR TITLE
docs(ntfy): add playground config

### DIFF
--- a/src/pages/docs/charts/ntfy.mdx
+++ b/src/pages/docs/charts/ntfy.mdx
@@ -1,7 +1,7 @@
 ---
 layout: ../../../layouts/DocsLayout.astro
 title: ntfy Chart
-description: ntfy Helm chart for Kubernetes push notifications with HTTP pub-sub, metrics, attachments, access control, persistence, and ingress.
+description: ntfy Helm chart for Kubernetes push notifications with HTTP pub-sub, metrics, attachments, access control, persistence, ingress, and Gateway API.
 ---
 
 import DocsTabs from '../../../components/DocsTabs.astro';
@@ -28,6 +28,7 @@ third-party service — all traffic stays on your infrastructure.
 - **Behind-proxy mode** — correct client IP identification via `X-Forwarded-For`
 - **Prometheus metrics** — optional `/metrics` endpoint with ServiceMonitor support
 - **Persistent storage** — PVC-backed SQLite cache and authentication databases
+- **Gateway API** — optional HTTPRoute rendering for modern ingress controllers
 
 ## Installation
 
@@ -53,6 +54,7 @@ helm install ntfy oci://ghcr.io/helmforgedev/helm/ntfy
     { id: 'auth', label: 'With Authentication' },
     { id: 'attachments', label: 'With Attachments' },
     { id: 'metrics', label: 'With Metrics' },
+    { id: 'gateway', label: 'Gateway API' },
   ]}
 >
 
@@ -188,6 +190,29 @@ ingress:
 
 </div>
 
+<div data-tab-panel="gateway">
+
+```yaml
+# values.yaml — ntfy exposed with Gateway API
+ntfy:
+  baseUrl: 'https://ntfy.example.com'
+  behindProxy: true
+
+persistence:
+  enabled: true
+  size: 2Gi
+
+gateway:
+  enabled: true
+  parentRefs:
+    - name: public
+      namespace: gateway-system
+  hostnames:
+    - ntfy.example.com
+```
+
+</div>
+
 </DocsTabs>
 
 ## Configuration Reference
@@ -205,7 +230,7 @@ ingress:
 | Parameter          | Type   | Default                        | Description                          |
 | ------------------ | ------ | ------------------------------ | ------------------------------------ |
 | `image.repository` | string | `docker.io/binwiederhier/ntfy` | ntfy container image.                |
-| `image.tag`        | string | `"v2.21.0"`                    | Image tag.                           |
+| `image.tag`        | string | `"v2.24.0"`                    | Image tag.                           |
 | `image.pullPolicy` | string | `IfNotPresent`                 | Image pull policy.                   |
 | `imagePullSecrets` | array  | `[]`                           | Pull secrets for private registries. |
 
@@ -266,6 +291,17 @@ default to survive pod restarts without losing message history and user accounts
 | `ingress.annotations`      | object  | `{}`      | Annotations for the Ingress (e.g. cert-manager). |
 | `ingress.hosts`            | array   | `[]`      | Ingress host and path rules.                     |
 | `ingress.tls`              | array   | `[]`      | TLS configuration (secret name and hosts).       |
+
+### Gateway API
+
+| Parameter             | Type    | Default      | Description                                                              |
+| --------------------- | ------- | ------------ | ------------------------------------------------------------------------ |
+| `gateway.enabled`     | boolean | `false`      | Render an HTTPRoute. Requires Gateway API CRDs and a compatible Gateway. |
+| `gateway.annotations` | object  | `{}`         | Annotations for the HTTPRoute.                                           |
+| `gateway.parentRefs`  | array   | `[]`         | Gateway parent references. Required when `gateway.enabled=true`.         |
+| `gateway.hostnames`   | array   | `[]`         | Hostnames matched by the HTTPRoute.                                      |
+| `gateway.path`        | string  | `/`          | Path value matched by the HTTPRoute.                                     |
+| `gateway.pathType`    | string  | `PathPrefix` | Path match type.                                                         |
 
 ### Probes
 

--- a/src/pages/playground.astro
+++ b/src/pages/playground.astro
@@ -1499,6 +1499,125 @@ const chartConfigs: Record<string, ChartConfig> = {
       ],
     },
   ],
+  ntfy: [
+    {
+      name: 'General',
+      fields: [
+        {
+          label: 'Base URL',
+          key: 'ntfy.baseUrl',
+          type: 'text',
+          default: '',
+          description: 'Public URL used by clients',
+        },
+        {
+          label: 'Default Access',
+          key: 'ntfy.authDefaultAccess',
+          type: 'select',
+          default: 'read-write',
+          options: ['read-write', 'read-only', 'write-only', 'deny-all'],
+          description: 'Anonymous topic access policy',
+        },
+        {
+          label: 'Behind Proxy',
+          key: 'ntfy.behindProxy',
+          type: 'toggle',
+          default: 'true',
+          description: 'Trust reverse proxy headers',
+        },
+      ],
+    },
+    {
+      name: 'Persistence',
+      collapsible: true,
+      fields: [
+        {
+          label: 'Persistence',
+          key: 'persistence.enabled',
+          type: 'toggle',
+          default: 'true',
+          description: 'Persist cache and auth data',
+        },
+        {
+          label: 'Storage Size',
+          key: 'persistence.size',
+          type: 'text',
+          default: '2Gi',
+          description: 'PVC storage size',
+        },
+      ],
+    },
+    {
+      name: 'Ingress',
+      collapsible: true,
+      gateField: 'ingress.enabled',
+      fields: [
+        {
+          label: 'Hostname',
+          key: 'ingress.hosts[0].host',
+          type: 'text',
+          default: 'ntfy.example.com',
+          description: 'Ingress host',
+        },
+        {
+          label: 'Ingress Class',
+          key: 'ingress.ingressClassName',
+          type: 'select',
+          default: 'traefik',
+          options: ['traefik', 'nginx'],
+          description: 'Ingress controller class',
+        },
+      ],
+    },
+    {
+      name: 'Gateway API',
+      collapsible: true,
+      gateField: 'gateway.enabled',
+      fields: [
+        {
+          label: 'Gateway Name',
+          key: 'gateway.parentRefs[0].name',
+          type: 'text',
+          default: 'public',
+          description: 'Gateway parent reference',
+        },
+        {
+          label: 'Gateway Namespace',
+          key: 'gateway.parentRefs[0].namespace',
+          type: 'text',
+          default: 'gateway-system',
+          description: 'Gateway namespace',
+        },
+        {
+          label: 'Hostname',
+          key: 'gateway.hostnames[0]',
+          type: 'text',
+          default: 'ntfy.example.com',
+          description: 'HTTPRoute hostname',
+        },
+      ],
+    },
+    {
+      name: 'Metrics',
+      collapsible: true,
+      fields: [
+        {
+          label: 'Metrics Endpoint',
+          key: 'ntfy.enableMetrics',
+          type: 'toggle',
+          default: 'false',
+          description: 'Enable /metrics',
+        },
+        {
+          label: 'ServiceMonitor',
+          key: 'metrics.serviceMonitor.enabled',
+          type: 'toggle',
+          default: 'false',
+          description: 'Create ServiceMonitor',
+        },
+      ],
+    },
+  ],
   wordpress: [
     {
       name: 'General',


### PR DESCRIPTION
## Summary
- Add ntfy to the playground chart configuration.
- Cover base URL, access policy, proxy mode, persistence, Ingress, Gateway API, and metrics toggles.

Complements helmforgedev/charts#482

## Validation
- `make site-sync-check CHART=ntfy JSON=1`
- `npm run lint`
- `npm run format:check`
- `npm run build`
- `make release-check REPO=site JSON=1`
- `make attribution-check REPO=site JSON=1`