### PR TITLE
docs(strapi): update base image references

### DIFF
--- a/src/pages/docs/charts/strapi.mdx
+++ b/src/pages/docs/charts/strapi.mdx
@@ -114,18 +114,18 @@ image:
 
 ### Image Specifications
 
-| Specification      | Value                          |
-| ------------------ | ------------------------------ |
-| **Registry**       | docker.io                      |
-| **Repository**     | helmforge/strapi-base          |
-| **Current Tag**    | 5.47.1                         |
-| **Strapi Version** | 5.47.1                         |
-| **Base Image**     | node:22-alpine                 |
-| **User**           | strapi (UID 1000, GID 1000)    |
-| **Working Dir**    | /opt/app                       |
-| **Exposed Port**   | 1337                           |
-| **Architectures**  | linux/amd64, linux/arm64       |
-| **Size**           | ~297MB                         |
+| Specification      | Value                       |
+| ------------------ | --------------------------- |
+| **Registry**       | docker.io                   |
+| **Repository**     | helmforge/strapi-base       |
+| **Current Tag**    | 5.47.1                      |
+| **Strapi Version** | 5.47.1                      |
+| **Base Image**     | node:22-alpine              |
+| **User**           | strapi (UID 1000, GID 1000) |
+| **Working Dir**    | /opt/app                    |
+| **Exposed Port**   | 1337                        |
+| **Architectures**  | linux/amd64, linux/arm64    |
+| **Size**           | ~297MB                      |
 
 ### Included Features
 

--- a/src/pages/docs/charts/strapi.mdx
+++ b/src/pages/docs/charts/strapi.mdx
@@ -731,7 +731,7 @@ kubectl port-forward svc/strapi 1337:80 -n strapi
 | -------------------------- | ----------------------- | ----------------------------------------------------- |
 | `replicaCount`             | `1`                     | Number of replicas (requires S3/Cloudinary if > 1)    |
 | `image.repository`         | `helmforge/strapi-base` | Strapi application image (HelmForge production-ready) |
-| `image.tag`                | `5.47.1`                | HelmForge Strapi base image version                   |
+| `image.tag`                | `5.47.1`                | HelmForge Strapi base image tag                       |
 | `strapi.url`               | `""`                    | Public URL (auto-detected from ingress)               |
 | `strapi.nodeEnv`           | `production`            | Node environment                                      |
 | `strapi.telemetryDisabled` | `true`                  | Disable Strapi telemetry                              |

--- a/src/pages/docs/charts/strapi.mdx
+++ b/src/pages/docs/charts/strapi.mdx
@@ -56,11 +56,11 @@ helm install strapi oci://ghcr.io/helmforgedev/helm/strapi
 
 The chart uses **HelmForge's production-ready Strapi base image** instead of the generic Strapi image. This provides significant advantages for Kubernetes deployments:
 
-**Image:** `docker.io/helmforge/strapi-base:v0.0.3`
+**Image:** `docker.io/helmforge/strapi-base:5.47.1`
 
 ### Key Features
 
-- **Strapi 5.42.0** — Latest stable version with security patches
+- **Strapi 5.47.1** — Latest stable version with security patches
 - **All official plugins included** — Upload providers, email, database plugins pre-installed
 - **Multi-database support** — SQLite, PostgreSQL, and MySQL drivers included
 - **Health check endpoint** — HTTP `/_health` endpoint returns HTTP 200 with JSON body containing status, uptime, database connectivity, and version
@@ -76,7 +76,7 @@ The chart uses **HelmForge's production-ready Strapi base image** instead of the
 ```yaml
 image:
   repository: docker.io/helmforge/strapi-base
-  tag: 'v0.0.3'
+  tag: '5.47.1'
 ```
 
 This provides a working Strapi instance with default configuration, perfect for:
@@ -92,7 +92,7 @@ For production deployments with custom content types and configurations:
 
 ```dockerfile
 # Dockerfile
-FROM docker.io/helmforge/strapi-base:v0.0.3
+FROM docker.io/helmforge/strapi-base:5.47.1
 
 # Copy your Strapi project
 COPY --chown=strapi:strapi . /opt/app
@@ -118,14 +118,14 @@ image:
 | ------------------ | ------------------------------ |
 | **Registry**       | docker.io                      |
 | **Repository**     | helmforge/strapi-base          |
-| **Current Tag**    | v0.0.3                         |
-| **Strapi Version** | 5.42.0                         |
+| **Current Tag**    | 5.47.1                         |
+| **Strapi Version** | 5.47.1                         |
 | **Base Image**     | node:22-alpine                 |
 | **User**           | strapi (UID 1000, GID 1000)    |
 | **Working Dir**    | /opt/app                       |
 | **Exposed Port**   | 1337                           |
 | **Architectures**  | linux/amd64, linux/arm64       |
-| **Size**           | ~350MB (amd64), ~320MB (arm64) |
+| **Size**           | ~297MB                         |
 
 ### Included Features
 
@@ -178,7 +178,7 @@ Simplest deployment for development or testing:
 ```yaml
 image:
   repository: docker.io/helmforge/strapi-base
-  tag: 'v0.0.3'
+  tag: '5.47.1'
 
 persistence:
   enabled: true
@@ -203,7 +203,7 @@ replicaCount: 3
 
 image:
   repository: docker.io/helmforge/strapi-base
-  tag: 'v0.0.3'
+  tag: '5.47.1'
 
 # S3 uploads enable multi-replica scaling
 strapi:
@@ -731,7 +731,7 @@ kubectl port-forward svc/strapi 1337:80 -n strapi
 | -------------------------- | ----------------------- | ----------------------------------------------------- |
 | `replicaCount`             | `1`                     | Number of replicas (requires S3/Cloudinary if > 1)    |
 | `image.repository`         | `helmforge/strapi-base` | Strapi application image (HelmForge production-ready) |
-| `image.tag`                | `v0.0.3`                | HelmForge Strapi base image version                   |
+| `image.tag`                | `5.47.1`                | HelmForge Strapi base image version                   |
 | `strapi.url`               | `""`                    | Public URL (auto-detected from ingress)               |
 | `strapi.nodeEnv`           | `production`            | Node environment                                      |
 | `strapi.telemetryDisabled` | `true`                  | Disable Strapi telemetry                              |
@@ -805,7 +805,7 @@ replicaCount: 1
 
 image:
   repository: docker.io/helmforge/strapi-base
-  tag: 'v0.0.3'
+  tag: '5.47.1'
   pullPolicy: IfNotPresent
 
 database:
@@ -840,7 +840,7 @@ replicaCount: 2
 
 image:
   repository: docker.io/helmforge/strapi-base
-  tag: 'v0.0.3'
+  tag: '5.47.1'
 
 database:
   mode: external
@@ -885,7 +885,7 @@ replicaCount: 3
 
 image:
   repository: docker.io/helmforge/strapi-base
-  tag: 'v0.0.3'
+  tag: '5.47.1'
 
 postgresql:
   enabled: true


### PR DESCRIPTION
## Summary
- Update the Strapi chart documentation to reference `helmforge/strapi-base:5.47.1`.
- Align Strapi version references and Dockerfile examples with the new base image.
- Refresh image metadata and deployment examples on the chart page.

## Related
- Supports the Strapi chart update to `helmforge/strapi-base:5.47.1`.
- Runtime image fix: helmforgedev/strapi-base#5

## Validation
- `npm run build`
- `make md-lint REPO=site`
- `make release-check REPO=site`
- `make attribution-check REPO=site`
- `make site-sync-check CHART=strapi`