### PR TITLE
docs(listmonk): sync chart standards

### DIFF
--- a/e2e/playground.spec.ts
+++ b/e2e/playground.spec.ts
@@ -71,6 +71,48 @@ test.describe('Playground', () => {
     }
   });
 
+  test('activation values refresh already rendered controls', async ({ page }) => {
+    await page.goto('/playground');
+    await page.locator('.playground-chart-btn[data-slug="listmonk"]').click();
+
+    await page.locator('select[data-field-key="database.mode"]').selectOption('external');
+    await expect(page.locator('button[data-field-key="postgresql.enabled"]')).toHaveClass(/bg-border/);
+    await expect(page.locator('#playground-code')).toContainText('database.mode=external');
+    await expect(page.locator('#playground-code')).toContainText('postgresql.enabled=false');
+    await expect(page.locator('#playground-code')).toContainText('database.external.name=listmonk');
+    await expect(page.locator('#playground-code')).toContainText('database.external.username=listmonk');
+
+    await page.locator('button[data-field-key="postgresql.enabled"]').click();
+    await expect(page.locator('select[data-field-key="database.mode"]')).toHaveValue('auto');
+    await expect(page.locator('#playground-code')).not.toContainText('database.mode=external');
+    await expect(page.locator('#playground-code')).not.toContainText('postgresql.enabled=false');
+
+    await page.locator('button[data-field-key="postgresql.enabled"]').click();
+    await expect(page.locator('select[data-field-key="database.mode"]')).toHaveValue('external');
+    await expect(page.locator('#playground-code')).toContainText('database.mode=external');
+    await expect(page.locator('#playground-code')).toContainText('postgresql.enabled=false');
+    await expect(page.locator('#playground-code')).toContainText('database.external.name=listmonk');
+
+    await page.locator('select[data-field-key="database.mode"]').selectOption('auto');
+    await expect(page.locator('button[data-field-key="postgresql.enabled"]')).toHaveClass(/bg-primary/);
+
+    await page.locator('[data-section-toggle="External Database"]').click();
+    await page.locator('input[data-field-key="database.external.host"]').fill('postgres.example.com');
+    await page.locator('input[data-field-key="database.external.existingSecret"]').fill('listmonk-db');
+
+    await expect(page.locator('select[data-field-key="database.mode"]')).toHaveValue('external');
+    await expect(page.locator('button[data-field-key="postgresql.enabled"]')).toHaveClass(/bg-border/);
+    await expect(page.locator('#playground-code')).toContainText('database.mode=external');
+    await expect(page.locator('#playground-code')).toContainText('postgresql.enabled=false');
+    await expect(page.locator('#playground-code')).toContainText('database.external.host=postgres.example.com');
+    await expect(page.locator('#playground-code')).toContainText('database.external.existingSecret=listmonk-db');
+
+    await page.locator('select[data-field-key="database.mode"]').selectOption('postgresql');
+    await expect(page.locator('button[data-field-key="postgresql.enabled"]')).toHaveClass(/bg-primary/);
+    await expect(page.locator('#playground-code')).not.toContainText('database.mode=external');
+    await expect(page.locator('#playground-code')).not.toContainText('database.external.');
+  });
+
   test('copy button is enabled after selection', async ({ page }) => {
     await page.goto('/playground');
     const copyBtn = page.locator('#playground-copy');

--- a/src/pages/docs/charts/listmonk.mdx
+++ b/src/pages/docs/charts/listmonk.mdx
@@ -29,6 +29,27 @@ SMTP provider to send emails.
 - **Idempotent bootstrap** — init container applies schema migrations on every pod start
 - **S3 backup** — scheduled PostgreSQL `pg_dump` to S3-compatible storage
 
+## Operational Patterns
+
+The chart supports four primary operating modes: bundled PostgreSQL for simple installs, managed external PostgreSQL for
+platform databases, TLS ingress for public administration, and an optional database backup CronJob for S3-compatible
+object storage. Uploaded media is stored on a separate PVC, so database backups and uploads backups must be planned
+together for disaster recovery.
+
+## Security Scan
+
+Security Scan: Kubescape on rendered default manifests.
+
+| Framework | Score   |
+| --------- | ------- |
+| MITRE     | 100.00% |
+| NSA       | 70.00%  |
+| SOC2      | 90.00%  |
+| Aggregate | 86.67%  |
+
+Default findings map to production controls that should be provided through values or platform policy: resource limits,
+container hardening context, service account token policy, and namespace network policy.
+
 ## Installation
 
 **HTTPS repository:**

--- a/src/pages/playground.astro
+++ b/src/pages/playground.astro
@@ -13,6 +13,10 @@ interface PlaygroundField {
   type: 'text' | 'number' | 'select' | 'toggle';
   default: string;
   options?: string[];
+  valueActivationValues?: Record<string, Record<string, string>>;
+  toggleActivationValues?: Record<string, Record<string, string>>;
+  activationExpandSections?: Record<string, string[]>;
+  activationResetSections?: Record<string, string[]>;
   description: string;
 }
 
@@ -21,6 +25,7 @@ interface PlaygroundGroup {
   name: string;
   collapsible?: boolean;
   gateField?: string; // e.g. "backup.enabled" — toggles section visibility AND sets this value
+  activationValues?: Record<string, string>;
   fields: PlaygroundField[];
 }
 
@@ -5316,6 +5321,43 @@ const chartConfigs: Record<string, ChartConfig> = {
       name: 'General',
       fields: [
         {
+          label: 'Database Mode',
+          key: 'database.mode',
+          type: 'select',
+          default: 'auto',
+          options: ['auto', 'postgresql', 'external'],
+          valueActivationValues: {
+            auto: { 'postgresql.enabled': 'true' },
+            postgresql: { 'postgresql.enabled': 'true' },
+            external: { 'postgresql.enabled': 'false' },
+          },
+          activationExpandSections: {
+            external: ['External Database'],
+          },
+          activationResetSections: {
+            auto: ['External Database'],
+            postgresql: ['External Database'],
+          },
+          description: 'Bundled or external PostgreSQL selection',
+        },
+        {
+          label: 'Bundled PostgreSQL',
+          key: 'postgresql.enabled',
+          type: 'toggle',
+          default: 'true',
+          toggleActivationValues: {
+            true: { 'database.mode': 'auto' },
+            false: { 'database.mode': 'external' },
+          },
+          activationExpandSections: {
+            false: ['External Database'],
+          },
+          activationResetSections: {
+            true: ['External Database'],
+          },
+          description: 'Deploy HelmForge PostgreSQL subchart',
+        },
+        {
           label: 'Uploads Storage',
           key: 'storage.size',
           type: 'text',
@@ -5332,23 +5374,69 @@ const chartConfigs: Record<string, ChartConfig> = {
           label: 'CPU Request',
           key: 'resources.requests.cpu',
           type: 'text',
-          default: '100m',
+          default: '',
           description: 'CPU request',
         },
         {
           label: 'Memory Request',
           key: 'resources.requests.memory',
           type: 'text',
-          default: '128Mi',
+          default: '',
           description: 'Memory request',
         },
-        { label: 'CPU Limit', key: 'resources.limits.cpu', type: 'text', default: '500m', description: 'CPU limit' },
+        { label: 'CPU Limit', key: 'resources.limits.cpu', type: 'text', default: '', description: 'CPU limit' },
         {
           label: 'Memory Limit',
           key: 'resources.limits.memory',
           type: 'text',
-          default: '256Mi',
+          default: '',
           description: 'Memory limit',
+        },
+      ],
+    },
+    {
+      name: 'External Database',
+      collapsible: true,
+      activationValues: {
+        'database.mode': 'external',
+        'postgresql.enabled': 'false',
+      },
+      fields: [
+        {
+          label: 'Host',
+          key: 'database.external.host',
+          type: 'text',
+          default: '',
+          description: 'External PostgreSQL host',
+        },
+        {
+          label: 'Database',
+          key: 'database.external.name',
+          type: 'text',
+          default: 'listmonk',
+          description: 'External database name',
+        },
+        {
+          label: 'Username',
+          key: 'database.external.username',
+          type: 'text',
+          default: 'listmonk',
+          description: 'External database user',
+        },
+        {
+          label: 'Password Secret',
+          key: 'database.external.existingSecret',
+          type: 'text',
+          default: '',
+          description: 'Secret containing database-password',
+        },
+        {
+          label: 'SSL Mode',
+          key: 'database.external.sslMode',
+          type: 'select',
+          default: 'disable',
+          options: ['disable', 'require', 'verify-ca', 'verify-full'],
+          description: 'PostgreSQL SSL mode',
         },
       ],
     },
@@ -5359,7 +5447,7 @@ const chartConfigs: Record<string, ChartConfig> = {
       fields: [
         {
           label: 'Hostname',
-          key: 'ingress.hostname',
+          key: 'ingress.hosts[0].host',
           type: 'text',
           default: 'listmonk.example.com',
           description: 'Ingress hostname',
@@ -5371,6 +5459,35 @@ const chartConfigs: Record<string, ChartConfig> = {
           default: 'traefik',
           options: ['traefik', 'nginx'],
           description: 'Ingress controller class',
+        },
+        {
+          label: 'Path',
+          key: 'ingress.hosts[0].paths[0].path',
+          type: 'text',
+          default: '/',
+          description: 'Ingress path',
+        },
+        {
+          label: 'Path Type',
+          key: 'ingress.hosts[0].paths[0].pathType',
+          type: 'select',
+          default: 'Prefix',
+          options: ['Prefix', 'Exact'],
+          description: 'Ingress path type',
+        },
+        {
+          label: 'TLS Secret',
+          key: 'ingress.tls[0].secretName',
+          type: 'text',
+          default: '',
+          description: 'TLS Secret name',
+        },
+        {
+          label: 'TLS Host',
+          key: 'ingress.tls[0].hosts[0]',
+          type: 'text',
+          default: '',
+          description: 'TLS host entry',
         },
       ],
     },
@@ -5399,6 +5516,13 @@ const chartConfigs: Record<string, ChartConfig> = {
           type: 'text',
           default: '',
           description: 'Target bucket name',
+        },
+        {
+          label: 'S3 Secret',
+          key: 'backup.s3.existingSecret',
+          type: 'text',
+          default: '',
+          description: 'Secret with S3 access-key and secret-key',
         },
       ],
     },
@@ -6514,28 +6638,52 @@ const scenarios: Record<string, { label: string; description: string; values: Re
   ],
   listmonk: [
     {
-      label: 'Development',
-      description: 'Single instance for testing',
+      label: 'Bundled PostgreSQL',
+      description: 'Private install with uploads persistence and bundled PostgreSQL',
       values: {
-        'storage.size': '2Gi',
-        'ingress.enabled': 'false',
+        'database.mode': 'auto',
+        'postgresql.enabled': 'true',
+        'storage.size': '5Gi',
         'resources.requests.cpu': '100m',
         'resources.requests.memory': '128Mi',
+        'resources.limits.memory': '512Mi',
       },
     },
     {
-      label: 'Production',
-      description: 'With ingress, backups, and more resources',
+      label: 'TLS and Backup',
+      description: 'Ingress with TLS and S3-compatible PostgreSQL backup',
       values: {
         'storage.size': '10Gi',
         'ingress.enabled': 'true',
-        'ingress.hostname': 'listmonk.example.com',
+        'ingress.hosts[0].host': 'listmonk.example.com',
+        'ingress.hosts[0].paths[0].path': '/',
+        'ingress.hosts[0].paths[0].pathType': 'Prefix',
+        'ingress.ingressClassName': 'nginx',
+        'ingress.tls[0].secretName': 'listmonk-tls',
+        'ingress.tls[0].hosts[0]': 'listmonk.example.com',
         'resources.requests.cpu': '250m',
         'resources.requests.memory': '256Mi',
         'resources.limits.cpu': '1000m',
-        'resources.limits.memory': '512Mi',
+        'resources.limits.memory': '1Gi',
         'backup.enabled': 'true',
         'backup.schedule': '0 3 * * *',
+        'backup.s3.endpoint': 'https://s3.amazonaws.com',
+        'backup.s3.bucket': 'listmonk-backups',
+        'backup.s3.existingSecret': 'listmonk-s3-credentials',
+      },
+    },
+    {
+      label: 'External Database',
+      description: 'Listmonk connected to managed PostgreSQL',
+      values: {
+        'database.mode': 'external',
+        'postgresql.enabled': 'false',
+        'database.external.host': 'postgres.example.com',
+        'database.external.name': 'listmonk',
+        'database.external.username': 'listmonk',
+        'database.external.existingSecret': 'listmonk-db-credentials',
+        'database.external.sslMode': 'require',
+        'storage.size': '10Gi',
       },
     },
   ],

--- a/src/scripts/playground.ts
+++ b/src/scripts/playground.ts
@@ -4,6 +4,10 @@ interface FieldConfig {
   type: 'text' | 'number' | 'select' | 'toggle';
   default: string;
   options?: string[];
+  valueActivationValues?: Record<string, Record<string, string>>;
+  toggleActivationValues?: Record<string, Record<string, string>>;
+  activationExpandSections?: Record<string, string[]>;
+  activationResetSections?: Record<string, string[]>;
   description: string;
 }
 
@@ -11,6 +15,7 @@ interface GroupConfig {
   name: string;
   collapsible?: boolean;
   gateField?: string;
+  activationValues?: Record<string, string>;
   fields: FieldConfig[];
 }
 
@@ -58,6 +63,16 @@ function getGroups(slug: string): GroupConfig[] {
 
 function getScenarios(slug: string): Scenario[] {
   return scenarios[slug] ?? [];
+}
+
+function getFieldDefault(key: string): string | undefined {
+  for (const group of getGroups(selectedSlug)) {
+    for (const field of group.fields) {
+      if (field.key === key) return field.default;
+    }
+  }
+
+  return undefined;
 }
 
 function createToggleButton(isOn: boolean): HTMLButtonElement {
@@ -244,12 +259,25 @@ function toggleSection(group: GroupConfig) {
     for (const field of group.fields) {
       currentValues[field.key] = field.default;
     }
+    for (const key of Object.keys(group.activationValues ?? {})) {
+      currentValues[key] = getFieldDefault(key) ?? '';
+    }
   } else {
     // Expand: set gate to true
     expandedSections.add(group.name);
     if (group.gateField) {
       currentValues[group.gateField] = 'true';
     }
+    for (const [key, value] of Object.entries(group.activationValues ?? {})) {
+      currentValues[key] = value;
+    }
+  }
+
+  if (Object.keys(group.activationValues ?? {}).length > 0) {
+    buildControls();
+    updateOutput();
+    updateUrlState();
+    return;
   }
 
   // Update the group visuals
@@ -326,6 +354,20 @@ function buildFieldControl(field: FieldConfig): HTMLElement {
     });
     select.addEventListener('change', () => {
       currentValues[field.key] = select.value;
+      const activationValues = field.valueActivationValues?.[select.value];
+      const expandSections = field.activationExpandSections?.[select.value];
+      const resetSections = field.activationResetSections?.[select.value];
+      if (activationValues || expandSections || resetSections) {
+        for (const [key, value] of Object.entries(activationValues ?? {})) {
+          currentValues[key] = value;
+        }
+        expandConfiguredSections(expandSections);
+        resetAndCollapseSections(resetSections);
+        buildControls();
+        updateOutput();
+        updateUrlState();
+        return;
+      }
       updateOutput();
     });
     controlDiv.appendChild(select);
@@ -335,8 +377,23 @@ function buildFieldControl(field: FieldConfig): HTMLElement {
     btn.dataset.fieldKey = field.key;
     btn.addEventListener('click', () => {
       const wasOn = currentValues[field.key] === 'true';
-      currentValues[field.key] = wasOn ? 'false' : 'true';
-      updateToggleVisual(btn, !wasOn);
+      const nextValue = wasOn ? 'false' : 'true';
+      currentValues[field.key] = nextValue;
+      const activationValues = field.toggleActivationValues?.[nextValue];
+      const expandSections = field.activationExpandSections?.[nextValue];
+      const resetSections = field.activationResetSections?.[nextValue];
+      if (activationValues || expandSections || resetSections) {
+        for (const [key, value] of Object.entries(activationValues ?? {})) {
+          currentValues[key] = value;
+        }
+        expandConfiguredSections(expandSections);
+        resetAndCollapseSections(resetSections);
+        buildControls();
+        updateOutput();
+        updateUrlState();
+        return;
+      }
+      updateToggleVisual(btn, nextValue === 'true');
       updateOutput();
     });
     controlDiv.appendChild(btn);
@@ -371,6 +428,38 @@ function buildFieldControl(field: FieldConfig): HTMLElement {
   div.appendChild(labelDiv);
   div.appendChild(controlDiv);
   return div;
+}
+
+function expandConfiguredSections(sectionNames?: string[]) {
+  if (!sectionNames?.length) return;
+
+  const sections = new Set(sectionNames);
+  for (const group of getGroups(selectedSlug)) {
+    if (!sections.has(group.name)) continue;
+    expandedSections.add(group.name);
+    for (const [key, value] of Object.entries(group.activationValues ?? {})) {
+      currentValues[key] = value;
+    }
+    if (group.gateField) {
+      currentValues[group.gateField] = 'true';
+    }
+  }
+}
+
+function resetAndCollapseSections(sectionNames?: string[]) {
+  if (!sectionNames?.length) return;
+
+  const sections = new Set(sectionNames);
+  for (const group of getGroups(selectedSlug)) {
+    if (!sections.has(group.name)) continue;
+    if (group.gateField) {
+      currentValues[group.gateField] = 'false';
+    }
+    for (const field of group.fields) {
+      currentValues[field.key] = field.default;
+    }
+    expandedSections.delete(group.name);
+  }
 }
 
 function applyScenario(scenario: Scenario) {


### PR DESCRIPTION
## Summary
- Sync the Listmonk docs page with the chart standards backfill.
- Fix the playground to emit valid Listmonk ingress host/path/TLS values.
- Add scenarios for bundled PostgreSQL, TLS backup, and external PostgreSQL.
- Document the local Kubescape scores and operational patterns.

## Validation
- npm run format -- src/pages/playground.astro src/pages/docs/charts/listmonk.mdx
- npm run lint
- npm run build
- npm run format:check
- npm run seo:verify-sitemap
- make site-sync-check CHART=listmonk
- make release-check REPO=site
- make attribution-check REPO=site

## Related
- Companion chart PR: helmforgedev/charts#496