### PR TITLE
docs(ddns-updater): sync chart standards

### DIFF
--- a/e2e/playground.spec.ts
+++ b/e2e/playground.spec.ts
@@ -178,6 +178,20 @@ test.describe('Playground', () => {
     await expect(code).not.toContainText('networkPolicy.egress.allowInternet=false');
   });
 
+  test('ddns-updater ingress emits chart values contract fields', async ({ page }) => {
+    await page.goto('/playground');
+    await page.locator('.playground-chart-btn[data-slug="ddns-updater"]').click();
+
+    await page.locator('[data-section-toggle="Ingress"]').click();
+    const code = page.locator('#playground-code');
+
+    await expect(code).toContainText('ingress.enabled=true');
+    await expect(code).toContainText('ingress.hosts[0].host=ddns.example.com');
+    await expect(code).toContainText('ingress.hosts[0].paths[0].path=/');
+    await expect(code).toContainText('ingress.hosts[0].paths[0].pathType=Prefix');
+    await expect(code).not.toContainText('ingress.hostname');
+  });
+
   test('copy button is enabled after selection', async ({ page }) => {
     await page.goto('/playground');
     const copyBtn = page.locator('#playground-copy');

--- a/src/pages/docs/charts/ddns-updater.mdx
+++ b/src/pages/docs/charts/ddns-updater.mdx
@@ -1,7 +1,7 @@
 ---
 layout: ../../../layouts/DocsLayout.astro
 title: DDNS Updater Chart
-description: DDNS Updater Helm chart for Kubernetes dynamic DNS with Cloudflare, Route53, DuckDNS, Namecheap, web UI, persistence, and existingSecret support.
+description: DDNS Updater Helm chart for Kubernetes dynamic DNS with Cloudflare, Route53, DuckDNS, Namecheap, web UI, persistence, existingSecret support, and restricted pod defaults.
 ---
 
 import DocsTabs from '../../../components/DocsTabs.astro';
@@ -27,6 +27,7 @@ a responsive web dashboard and persistent update history.
 - **Persistent history** — `updates.json` stored in a PVC survives pod restarts
 - **existingSecret** — bring your own `config.json` Secret for GitOps and production use
 - **Configurable IP detection** — HTTP, DNS, or combined public IP fetching strategies
+- **Restricted runtime** — non-root container, read-only root filesystem, dropped capabilities, and ServiceAccount token automount disabled
 
 ## Installation
 
@@ -203,7 +204,7 @@ ingress:
 | Parameter          | Type   | Default                         | Description                          |
 | ------------------ | ------ | ------------------------------- | ------------------------------------ |
 | `image.repository` | string | `docker.io/qmcgaw/ddns-updater` | DDNS Updater container image.        |
-| `image.tag`        | string | `"v2.9.0"`                      | Image tag.                           |
+| `image.tag`        | string | `"2.10.0"`                      | Image tag.                           |
 | `image.pullPolicy` | string | `IfNotPresent`                  | Image pull policy.                   |
 | `imagePullSecrets` | array  | `[]`                            | Pull secrets for private registries. |
 
@@ -280,11 +281,23 @@ ingress:
 
 ### Resources and Security
 
-| Parameter            | Type   | Default | Description                         |
-| -------------------- | ------ | ------- | ----------------------------------- |
-| `resources`          | object | `{}`    | CPU and memory requests and limits. |
-| `podSecurityContext` | object | `{}`    | Pod-level security context.         |
-| `securityContext`    | object | `{}`    | Container-level security context.   |
+| Parameter                   | Type   | Default                     | Description                       |
+| --------------------------- | ------ | --------------------------- | --------------------------------- |
+| `resources.requests.cpu`    | string | `10m`                       | Default CPU request.              |
+| `resources.requests.memory` | string | `32Mi`                      | Default memory request.           |
+| `resources.limits.cpu`      | string | `100m`                      | Default CPU limit.                |
+| `resources.limits.memory`   | string | `128Mi`                     | Default memory limit.             |
+| `podSecurityContext`        | object | non-root seccomp defaults   | Pod-level security context.       |
+| `securityContext`           | object | non-root read-only defaults | Container-level security context. |
+
+### Service Account
+
+| Parameter                                     | Type    | Default | Description                           |
+| --------------------------------------------- | ------- | ------- | ------------------------------------- |
+| `serviceAccount.create`                       | boolean | `false` | Create a dedicated ServiceAccount.    |
+| `serviceAccount.automountServiceAccountToken` | boolean | `false` | Mount Kubernetes API token into pods. |
+| `serviceAccount.name`                         | string  | `""`    | Override the ServiceAccount name.     |
+| `serviceAccount.annotations`                  | object  | `{}`    | Annotations for the ServiceAccount.   |
 
 ### Scheduling
 

--- a/src/pages/playground.astro
+++ b/src/pages/playground.astro
@@ -4143,6 +4143,27 @@ const chartConfigs: Record<string, ChartConfig> = {
       name: 'General',
       fields: [
         {
+          label: 'Existing Config Secret',
+          key: 'config.existingSecret',
+          type: 'text',
+          default: '',
+          description: 'Secret with config.json',
+        },
+        {
+          label: 'Secret Key',
+          key: 'config.existingSecretKey',
+          type: 'text',
+          default: 'config.json',
+          description: 'Key inside the Secret',
+        },
+        {
+          label: 'Update Period',
+          key: 'ddns.period',
+          type: 'text',
+          default: '5m',
+          description: 'Interval between IP checks',
+        },
+        {
           label: 'Storage Size',
           key: 'persistence.size',
           type: 'text',
@@ -4159,7 +4180,7 @@ const chartConfigs: Record<string, ChartConfig> = {
           label: 'CPU Request',
           key: 'resources.requests.cpu',
           type: 'text',
-          default: '50m',
+          default: '10m',
           description: 'CPU request',
         },
         {
@@ -4174,7 +4195,7 @@ const chartConfigs: Record<string, ChartConfig> = {
           label: 'Memory Limit',
           key: 'resources.limits.memory',
           type: 'text',
-          default: '64Mi',
+          default: '128Mi',
           description: 'Memory limit',
         },
       ],
@@ -4186,7 +4207,7 @@ const chartConfigs: Record<string, ChartConfig> = {
       fields: [
         {
           label: 'Hostname',
-          key: 'ingress.hostname',
+          key: 'ingress.hosts[0].host',
           type: 'text',
           default: 'ddns.example.com',
           description: 'Ingress hostname',
@@ -4198,6 +4219,21 @@ const chartConfigs: Record<string, ChartConfig> = {
           default: 'traefik',
           options: ['traefik', 'nginx'],
           description: 'Ingress controller class',
+        },
+        {
+          label: 'Path',
+          key: 'ingress.hosts[0].paths[0].path',
+          type: 'text',
+          default: '/',
+          description: 'Ingress path',
+        },
+        {
+          label: 'Path Type',
+          key: 'ingress.hosts[0].paths[0].pathType',
+          type: 'select',
+          default: 'Prefix',
+          options: ['Prefix', 'Exact', 'ImplementationSpecific'],
+          description: 'Ingress path matching',
         },
       ],
     },


### PR DESCRIPTION
## Summary
- Sync the ddns-updater documentation page with the chart standards backfill.
- Document restricted runtime defaults and service account token automount behavior.
- Fix the playground ddns-updater ingress controls to emit the chart values contract.

## Validation
- make site-sync-check CHART=ddns-updater
- npm run lint
- npm run format:check
- npm run build
- npx playwright test e2e/playground.spec.ts --project=chromium --workers=1 (16 passed)
- make release-check REPO=site
- make attribution-check REPO=site