### PR TITLE
docs(zookeeper): sync dual-stack guidance

### DIFF
--- a/src/pages/docs/charts/zookeeper.mdx
+++ b/src/pages/docs/charts/zookeeper.mdx
@@ -189,10 +189,11 @@ Dual-stack Service fields are available:
 ```yaml
 service:
   ipFamilyPolicy: PreferDualStack
-  ipFamilies:
-    - IPv4
-    - IPv6
 ```
+
+With `PreferDualStack`, omit `service.ipFamilies` when the same values may run on single-stack and dual-stack clusters.
+Kubernetes rejects an explicit family that the cluster does not advertise. Set `service.ipFamilies` only when the
+target cluster is configured for the requested families.
 
 ## Observability
 
@@ -249,6 +250,8 @@ with the PDB enabled.
 | `persistence.enabled`         | `true`                        | Persist ZooKeeper data.                               |
 | `metrics.enabled`             | `false`                       | Enable Prometheus metrics provider.                   |
 | `podDisruptionBudget.enabled` | `true`                        | Render PDB for ensemble availability.                 |
+| `service.ipFamilyPolicy`      | `null`                        | Optional Service IP family policy.                    |
+| `service.ipFamilies`          | `[]`                          | Optional ordered Service IP families.                 |
 | `externalSecrets.enabled`     | `false`                       | Render ExternalSecret resources.                      |
 
 ## Links


### PR DESCRIPTION
## Summary
- Align ZooKeeper chart documentation with the portable dual-stack guidance used by the chart CI scenario.
- Document `service.ipFamilyPolicy` and `service.ipFamilies` in the values table.

## Validation
- `npm run lint`
- `npm run format:check`
- `npm run build`
- `make md-lint REPO=site`
- `make release-check REPO=site`
- `make attribution-check REPO=site`
- `make site-sync-check CHART=zookeeper`

## Related
- Charts PR: helmforgedev/charts#528