### PR TITLE
docs(elasticsearch): sync chart standards

### DIFF
--- a/src/pages/docs/charts/elasticsearch.mdx
+++ b/src/pages/docs/charts/elasticsearch.mdx
@@ -301,7 +301,7 @@ monitoring:
 | `namespaceOverride`                           | `""`                        | Override namespace for chart-managed resources           |
 | `clusterProfile`                              | `dev`                       | Cluster preset: `dev`, `staging`, `production-ha`        |
 | `clusterName`                                 | `helmforge-cluster`         | Elasticsearch cluster name                               |
-| `image.tag`                                   | `9.4.1`                     | Elasticsearch version                                    |
+| `image.tag`                                   | `9.4.2`                     | Elasticsearch version                                    |
 | `master.replicaCount`                         | profile-driven              | Number of master-eligible nodes (must be odd)            |
 | `master.heapSize`                             | auto (50% mem)              | JVM heap for master nodes                                |
 | `data.replicaCount`                           | profile-driven              | Number of data nodes                                     |
@@ -317,7 +317,7 @@ monitoring:
 | `dataTiers.warm.enabled`                      | `false`                     | Enable dedicated warm tier nodes                         |
 | `monitoring.enabled`                          | `false`                     | Enable Prometheus exporter sidecar                       |
 | `kibana.enabled`                              | `false`                     | Deploy optional Kibana                                   |
-| `kibana.image.tag`                            | `9.4.1`                     | Kibana version aligned with Elasticsearch                |
+| `kibana.image.tag`                            | `9.4.2`                     | Kibana version aligned with Elasticsearch                |
 | `service.ipFamilyPolicy`                      | `null`                      | Service dual-stack policy for HTTP and headless Services |
 | `service.ipFamilies`                          | `[]`                        | Service IP families for HTTP and headless Services       |
 | `serviceAccount.create`                       | `false`                     | Create a dedicated ServiceAccount                        |
@@ -334,8 +334,8 @@ namespaceOverride: search-runtime
 
 ## Upgrade Notes
 
-`docker.io/library/elasticsearch:9.4.0` is an upstream image update from
-`9.3.4`. Review the upstream Elasticsearch release notes before upgrading
+`docker.io/library/elasticsearch:9.4.2` is an upstream image update from
+`9.4.1`. Review the upstream Elasticsearch release notes before upgrading
 production clusters, take a snapshot backup, and verify Kibana compatibility,
 plugins, ILM policies, and index templates in a staging environment before
 reusing existing PVCs.

--- a/src/pages/playground.astro
+++ b/src/pages/playground.astro
@@ -660,6 +660,98 @@ const chartConfigs: Record<string, ChartConfig> = {
       ],
     },
   ],
+  elasticsearch: [
+    {
+      name: 'General',
+      fields: [
+        {
+          label: 'Profile',
+          key: 'clusterProfile',
+          type: 'select',
+          default: 'dev',
+          options: ['dev', 'staging', 'production-ha'],
+          description: 'Cluster topology preset',
+        },
+        {
+          label: 'Cluster Name',
+          key: 'clusterName',
+          type: 'text',
+          default: 'helmforge-cluster',
+          description: 'Elasticsearch cluster name',
+        },
+      ],
+    },
+    {
+      name: 'Security',
+      collapsible: true,
+      gateField: 'security.enabled',
+      fields: [
+        {
+          label: 'cert-manager TLS',
+          key: 'security.tls.certManager.enabled',
+          type: 'toggle',
+          default: 'false',
+          description: 'Issue certificates with cert-manager',
+        },
+        {
+          label: 'TLS Secret',
+          key: 'security.existingTlsSecret',
+          type: 'text',
+          default: '',
+          description: 'Existing Secret with ca.crt, tls.crt, and tls.key',
+        },
+      ],
+    },
+    {
+      name: 'Backup',
+      collapsible: true,
+      gateField: 'backup.enabled',
+      fields: [
+        {
+          label: 'Schedule',
+          key: 'backup.schedule',
+          type: 'text',
+          default: '0 2 * * *',
+          description: 'Snapshot cron schedule',
+        },
+        {
+          label: 'Bucket',
+          key: 'backup.s3.bucket',
+          type: 'text',
+          default: 'elasticsearch-backups',
+          description: 'S3 snapshot bucket',
+        },
+        {
+          label: 'Credentials Secret',
+          key: 'backup.s3.existingSecret',
+          type: 'text',
+          default: 'elasticsearch-s3',
+          description: 'Secret containing S3 access credentials',
+        },
+      ],
+    },
+    {
+      name: 'Monitoring',
+      collapsible: true,
+      gateField: 'monitoring.enabled',
+      fields: [
+        {
+          label: 'ServiceMonitor',
+          key: 'monitoring.serviceMonitor.enabled',
+          type: 'toggle',
+          default: 'false',
+          description: 'Create Prometheus Operator ServiceMonitor',
+        },
+        {
+          label: 'Grafana Dashboards',
+          key: 'monitoring.grafana.dashboards',
+          type: 'toggle',
+          default: 'false',
+          description: 'Create Grafana dashboard ConfigMaps',
+        },
+      ],
+    },
+  ],
   opencut: [
     {
       name: 'General',


### PR DESCRIPTION
## Summary
- sync Elasticsearch docs with chart version 9.4.2 and current upgrade notes
- add Elasticsearch playground controls for profile, TLS, backup and monitoring options
- keep site artifacts aligned with the chart standards backfill

## Validation
- npm run format:check
- npm run lint
- npm run build
- make md-lint REPO=site
- make site-sync-check CHART=elasticsearch

Related chart PR: https://github.com/helmforgedev/charts/pull/531