### PR TITLE
docs(metrics-server): sync chart standards

### DIFF
--- a/src/pages/docs/charts/metrics-server.mdx
+++ b/src/pages/docs/charts/metrics-server.mdx
@@ -104,6 +104,8 @@ kubectl describe apiservice v1beta1.metrics.k8s.io
 
 The chart can also run without creating RBAC or the APIService for distributions that already manage those resources,
 but in that mode ownership must be clear to avoid reconciliation conflicts.
+When the cluster already provides `v1beta1.metrics.k8s.io` or `system:aggregated-metrics-reader`, the chart skips those
+cluster-scoped resources instead of attempting to adopt platform-owned objects into the Helm release.
 
 ## Networking
 


### PR DESCRIPTION
## Summary
- document Metrics Server behavior when platform-managed Metrics API resources already exist
- keep site docs aligned with the chart standards backfill

## Validation
- npm run format:check
- npm run lint
- npm run build
- make md-lint REPO=site
- make site-sync-check CHART=metrics-server

Related chart PR: https://github.com/helmforgedev/charts/pull/532