### PR TITLE
docs(minecraft): sync chart standards

### DIFF
--- a/src/pages/docs/charts/minecraft.mdx
+++ b/src/pages/docs/charts/minecraft.mdx
@@ -29,7 +29,7 @@ cross-play, mod and plugin management, Aikar-optimized JVM flags, and RCON-backe
 - **Mod/plugin management** — Modrinth, CurseForge, Spiget, and direct URL downloads
 - **Resource packs** — configure server-side resource packs with SHA-1 verification
 - **Prometheus metrics** — mc-monitor sidecar with optional ServiceMonitor
-- **Pinned upstream image** — defaults to `2026.5.2`, with Java-specific tags available when needed
+- **Pinned upstream image** — defaults to `2026.5.4`, with Java-specific tags available when needed
 
 ## Installation
 
@@ -49,12 +49,12 @@ helm install minecraft oci://ghcr.io/helmforgedev/helm/minecraft --set server.eu
 
 | Minecraft Version | Required Java | Example `image.tag` |
 | ----------------- | ------------- | ------------------- |
-| 1.21.5+           | Java 25       | `2026.5.2`          |
-| 1.20.x - 1.21.4   | Java 21       | `2026.5.2-java21`   |
-| 1.17.x - 1.19.x   | Java 17       | `2026.5.2-java17`   |
+| 1.21.5+           | Java 25       | `2026.5.4`          |
+| 1.20.x - 1.21.4   | Java 21       | `2026.5.4-java21`   |
+| 1.17.x - 1.19.x   | Java 17       | `2026.5.4-java17`   |
 
-The chart defaults to the dated upstream image tag `2026.5.2`. Pin `image.tag`
-to a Java-specific variant, such as `2026.5.2-java21`, when running older
+The chart defaults to the dated upstream image tag `2026.5.4`. Pin `image.tag`
+to a Java-specific variant, such as `2026.5.4-java21`, when running older
 Minecraft versions or modpacks that require a specific Java runtime.
 
 ## Server Type Reference
@@ -183,15 +183,19 @@ jvm:
   useAikarFlags: true
 
 auth:
-  onlineMode: true # false required if using Floodgate for Bedrock auth
+  onlineMode: true # use Floodgate when Bedrock players should join without Java accounts
 
 geyser:
   enabled: true
   port: 19132
 
 mods:
-  # Download GeyserMC and Floodgate from Modrinth
-  modrinthProjects: 'geyser,floodgate'
+  # Download GeyserMC as a Paper plugin from Modrinth.
+  # Use geyser:beta when upstream has not promoted a compatible release yet.
+  modrinthProjects: 'geyser:beta'
+  # Add the platform-specific Floodgate plugin when Bedrock users should join
+  # without Java accounts.
+  # downloadUrls: 'https://example.com/path/to/floodgate-spigot.jar'
 
 persistence:
   enabled: true
@@ -296,7 +300,7 @@ service:
 | Parameter          | Type   | Default                           | Description                                                         |
 | ------------------ | ------ | --------------------------------- | ------------------------------------------------------------------- |
 | `image.repository` | string | `docker.io/itzg/minecraft-server` | Minecraft server container image.                                   |
-| `image.tag`        | string | `"2026.5.2"`                      | Image tag. Use Java-specific variants for older Minecraft versions. |
+| `image.tag`        | string | `"2026.5.4"`                      | Image tag. Use Java-specific variants for older Minecraft versions. |
 | `image.pullPolicy` | string | `IfNotPresent`                    | Image pull policy.                                                  |
 | `imagePullSecrets` | array  | `[]`                              | Pull secrets for private registries.                                |
 
@@ -363,8 +367,8 @@ service:
 
 <Callout type="warning" title="GeyserMC requires server.type: PAPER or compatible plugin server">
   GeyserMC is a Paper/Spigot plugin — it cannot run on VANILLA or FORGE servers. Bedrock clients connect on UDP port
-  19132. You also need the `Floodgate` plugin to allow Bedrock players to join without a Java Edition account if
-  `auth.onlineMode: true`.
+  19132. Add a platform-specific Floodgate plugin through `mods.downloadUrls` or your own plugin delivery workflow when
+  Bedrock players should join without a Java Edition account.
 </Callout>
 
 | Parameter        | Type    | Default | Description                             |
@@ -438,7 +442,7 @@ upload — ensuring the world is in a consistent state before the backup is take
 | `backup.backoffLimit`                  | integer | `1`                                        | Job retry limit.                                             |
 | `backup.archivePrefix`                 | string  | `minecraft`                                | Prefix for backup archive filenames.                         |
 | `backup.excludes`                      | string  | `"*.jar cache logs"`                       | Space-separated patterns excluded from the archive.          |
-| `backup.images.worker`                 | string  | `docker.io/itzg/minecraft-server:2026.5.2` | Image for RCON and tar operations.                           |
+| `backup.images.worker`                 | string  | `docker.io/itzg/minecraft-server:2026.5.4` | Image for RCON and tar operations.                           |
 | `backup.images.uploader`               | string  | `docker.io/helmforge/mc:1.0.0`             | Image for S3 upload.                                         |
 | `backup.resources`                     | object  | `{}`                                       | Resources for backup containers.                             |
 | `backup.s3.endpoint`                   | string  | `""`                                       | S3-compatible endpoint URL.                                  |
@@ -507,10 +511,13 @@ upload — ensuring the world is in a consistent state before the backup is take
 
 ## Upgrade Notes
 
-`docker.io/itzg/minecraft-server:2026.5.2` is an upstream image update from
-`2026.4.2`. Review the upstream release notes before upgrading production
-servers, take a world backup, and verify plugins, mods, datapacks, and pinned
-`server.version` values in a staging environment before reusing existing PVCs.
+`docker.io/itzg/minecraft-server:2026.5.4` updates the upstream server image from
+`2026.5.2`. The upstream releases include env-file loading at startup, server
+library cleanup on Paper installs, helper/monitor/RCON dependency updates, and a
+fix for deriving `MC_IMAGE_HELPER_OPTS` from `PROXY_*` variables. Review the
+upstream release notes before upgrading production servers, take a world backup,
+and verify plugins, mods, datapacks, proxy settings, and pinned `server.version`
+values in a staging environment before reusing existing PVCs.
 
 ## More Information
 


### PR DESCRIPTION
## Summary
- Sync Minecraft chart docs with image tag `2026.5.4`
- Clarify GeyserMC/Floodgate delivery guidance for Paper cross-play
- Align backup worker defaults and upgrade notes with the chart

## Validation
- npm run format:check
- npm run lint
- npm run build
- make md-lint REPO=site
- make site-sync-check CHART=minecraft
- make release-check REPO=site
- make attribution-check REPO=site

Chart PR: helmforgedev/charts#533