### PR TITLE
docs(mongodb): sync chart standards

### DIFF
--- a/src/data/charts.ts
+++ b/src/data/charts.ts
@@ -51,7 +51,7 @@ export const charts: Chart[] = [
   {
     name: 'MongoDB',
     slug: 'mongodb',
-    description: 'MongoDB with standalone and replica set configurations.',
+    description: 'MongoDB with standalone, replica set, sharded cluster, External Secrets, metrics, and S3 backup.',
     maturity: 'stable',
     backup: true,
   },

--- a/src/pages/docs/charts/mongodb.mdx
+++ b/src/pages/docs/charts/mongodb.mdx
@@ -179,9 +179,7 @@ persistence:
 architecture: sharded
 
 auth:
-  enabled: true
-  existingSecret: mongodb-root-credentials
-  existingKeySecret: mongodb-replica-key # shared across all replica sets in the cluster
+  enabled: false
 
 sharded:
   mongos:
@@ -209,6 +207,12 @@ config:
   directly for administrative operations.
 </Callout>
 
+<Callout type="warning" title="Sharded auth requires operator bootstrap">
+  The chart validates sharded mode as an unauthenticated lab topology. The official MongoDB container initializes
+  `MONGO_INITDB_ROOT_*` as a standalone process, which conflicts with `--configsvr` and `--shardsvr`. Production sharded
+  authentication requires an operator-managed bootstrap flow outside the chart's automatic root-user path.
+</Callout>
+
 </div>
 
 </DocsTabs>
@@ -220,7 +224,7 @@ config:
 | Parameter          | Type   | Default                   | Description    |
 | ------------------ | ------ | ------------------------- | -------------- |
 | `image.repository` | string | `docker.io/library/mongo` | MongoDB image. |
-| `image.tag`        | string | `"8.3.1"`                 | Image tag.     |
+| `image.tag`        | string | `"8.3.2"`                 | Image tag.     |
 
 ### Authentication
 
@@ -270,6 +274,30 @@ config:
   memory limit should use `cacheSizeGB: 1.5` (leaving headroom for OS and index overhead).
 </Callout>
 
+### Service
+
+| Parameter                | Type    | Default     | Description                                                                  |
+| ------------------------ | ------- | ----------- | ---------------------------------------------------------------------------- |
+| `service.type`           | string  | `ClusterIP` | Client Service type.                                                         |
+| `service.port`           | integer | `27017`     | Client Service port.                                                         |
+| `service.ipFamilyPolicy` | string  | `""`        | Service IP family policy: SingleStack, PreferDualStack, or RequireDualStack. |
+| `service.ipFamilies`     | array   | `[]`        | Optional Service IP family override.                                         |
+
+### External Secrets
+
+Use External Secrets when root credentials are owned by an external secret
+manager. Set `auth.existingSecret` to the same target Secret name so the
+StatefulSet consumes the synchronized Secret instead of rendering a competing
+chart-managed Secret.
+
+| Parameter                             | Type    | Default       | Description                                            |
+| ------------------------------------- | ------- | ------------- | ------------------------------------------------------ |
+| `externalSecrets.enabled`             | boolean | `false`       | Render an ExternalSecret for MongoDB credentials.      |
+| `externalSecrets.refreshInterval`     | string  | `1h`          | ExternalSecret refresh interval.                       |
+| `externalSecrets.secretStoreRef.name` | string  | `""`          | SecretStore or ClusterSecretStore name.                |
+| `externalSecrets.secretStoreRef.kind` | string  | `SecretStore` | Secret store kind.                                     |
+| `externalSecrets.data`                | array   | `[]`          | Data mappings for root credentials and backup secrets. |
+
 ### Metrics
 
 | Parameter                        | Type    | Default | Description                                |
@@ -298,7 +326,7 @@ Backup uses `mongodump` (not `pg_dump`). All databases are dumped and archived.
 
 ## Upgrade Notes
 
-MongoDB `8.3.1` is an upstream minor release update from `8.2.7`. Review the
+MongoDB `8.3.2` is an upstream minor release update from `8.2.7`. Review the
 MongoDB 8.3 release notes before upgrading production clusters, take a backup,
 and verify existing PVC data files are compatible with the target `mongod`
 version. Keep replica set keyFiles and root credentials stable across

--- a/src/pages/playground.astro
+++ b/src/pages/playground.astro
@@ -1219,11 +1219,11 @@ const chartConfigs: Record<string, ChartConfig> = {
           description: 'Deployment architecture',
         },
         {
-          label: 'Replica Count',
-          key: 'replicaCount',
+          label: 'Replica Set Members',
+          key: 'replicaSet.members',
           type: 'number',
-          default: '1',
-          description: 'Number of replicas',
+          default: '3',
+          description: 'Data-bearing members in replica set mode',
         },
         {
           label: 'Storage Size',
@@ -1263,6 +1263,50 @@ const chartConfigs: Record<string, ChartConfig> = {
       ],
     },
     {
+      name: 'Network',
+      collapsible: true,
+      fields: [
+        {
+          label: 'Service Type',
+          key: 'service.type',
+          type: 'select',
+          default: 'ClusterIP',
+          options: ['ClusterIP', 'NodePort', 'LoadBalancer'],
+          description: 'Client Service type',
+        },
+        {
+          label: 'Dual Stack',
+          key: 'service.ipFamilyPolicy',
+          type: 'select',
+          default: '',
+          options: ['', 'SingleStack', 'PreferDualStack', 'RequireDualStack'],
+          description: 'Service IP family policy',
+        },
+      ],
+    },
+    {
+      name: 'External Secrets',
+      collapsible: true,
+      gateField: 'externalSecrets.enabled',
+      fields: [
+        {
+          label: 'SecretStore Name',
+          key: 'externalSecrets.secretStoreRef.name',
+          type: 'text',
+          default: 'vault',
+          description: 'SecretStore or ClusterSecretStore name',
+        },
+        {
+          label: 'SecretStore Kind',
+          key: 'externalSecrets.secretStoreRef.kind',
+          type: 'select',
+          default: 'ClusterSecretStore',
+          options: ['SecretStore', 'ClusterSecretStore'],
+          description: 'External Secrets store kind',
+        },
+      ],
+    },
+    {
       name: 'S3 Backup',
       collapsible: true,
       gateField: 'backup.enabled',
@@ -1278,7 +1322,7 @@ const chartConfigs: Record<string, ChartConfig> = {
           label: 'S3 Endpoint',
           key: 'backup.s3.endpoint',
           type: 'text',
-          default: 's3.amazonaws.com',
+          default: 'https://s3.amazonaws.com',
           description: 'S3-compatible endpoint',
         },
         {


### PR DESCRIPTION
## Summary
- sync MongoDB docs with chart appVersion 8.3.2 and standards backfill
- document sharded authentication bootstrap limits, service IP family values, and External Secrets usage
- update catalog and playground defaults for replica set, service, External Secrets, and backup endpoint settings

## Validation
- npm run format:check
- npm run lint
- npm run build
- make md-lint REPO=site
- make site-sync-check CHART=mongodb
- make release-check REPO=site
- make attribution-check REPO=site