### PR TITLE
docs(mysql): sync chart standards

### DIFF
--- a/src/pages/docs/charts/mysql.mdx
+++ b/src/pages/docs/charts/mysql.mdx
@@ -65,6 +65,14 @@ helm install my-mysql oci://ghcr.io/helmforgedev/helm/mysql -f values.yaml
   before storing critical data.
 </Callout>
 
+## Security Scan
+
+| Framework          | Score   |
+| ------------------ | ------- |
+| MITRE + NSA + SOC2 | **87%** |
+
+Security posture: acceptable.
+
 ## Deployment Examples
 
 <DocsTabs
@@ -322,13 +330,14 @@ platform integration inside the pod needs Kubernetes API credentials.
 
 ### Core and Image
 
-| Parameter          | Type   | Default                   | Description                                             |
-| ------------------ | ------ | ------------------------- | ------------------------------------------------------- |
-| `architecture`     | string | `standalone`              | Deployment architecture: `standalone` or `replication`. |
-| `image.repository` | string | `docker.io/library/mysql` | MySQL runtime image repository.                         |
-| `image.tag`        | string | `"9.7.0"`                 | MySQL runtime image tag.                                |
-| `clusterDomain`    | string | `cluster.local`           | Kubernetes cluster DNS domain.                          |
-| `commonLabels`     | object | `{}`                      | Extra labels added to all resources.                    |
+| Parameter          | Type   | Default                   | Description                                                |
+| ------------------ | ------ | ------------------------- | ---------------------------------------------------------- |
+| `architecture`     | string | `standalone`              | Deployment architecture: `standalone` or `replication`.    |
+| `image.repository` | string | `docker.io/library/mysql` | MySQL runtime image repository.                            |
+| `image.tag`        | string | `"9.7.0"`                 | MySQL runtime image tag.                                   |
+| `clusterDomain`    | string | `cluster.local`           | Kubernetes cluster DNS domain.                             |
+| `commonLabels`     | object | `{}`                      | Extra labels added to all resources.                       |
+| `extraManifests`   | array  | `[]`                      | Extra Kubernetes manifests rendered after chart resources. |
 
 ### Authentication
 


### PR DESCRIPTION
## Summary
- Sync MySQL chart documentation with the chart standards backfill.
- Add Security Scan score evidence to the docs page.
- Document `extraManifests` in the values reference.

## Validation
- `npx prettier --write src/pages/docs/charts/mysql.mdx`
- `npm run format:check`
- `npm run lint`
- `npm run build`
- `make md-lint REPO=site`
- `make site-sync-check CHART=mysql`
- `make release-check REPO=site`
- `make attribution-check REPO=site`

## Related
- Chart PR: https://github.com/helmforgedev/charts/pull/536