### PR TITLE
docs(olivetin): sync chart standards

### DIFF
--- a/src/pages/docs/charts/olivetin.mdx
+++ b/src/pages/docs/charts/olivetin.mdx
@@ -31,6 +31,14 @@ clean web UI, without giving users direct shell access.
 - **Icon and title customization** — human-friendly labels for each action
 - **Lightweight** — minimal resource footprint
 
+## Security Scan
+
+| Framework          | Score   |
+| ------------------ | ------- |
+| MITRE + NSA + SOC2 | **95%** |
+
+Security posture: acceptable.
+
 ## Installation
 
 **HTTPS repository:**
@@ -285,6 +293,14 @@ externalSecrets:
 | `image.pullPolicy` | string | `IfNotPresent`                 | Image pull policy.                   |
 | `imagePullSecrets` | array  | `[]`                           | Pull secrets for private registries. |
 
+### Config Bootstrap
+
+| Parameter              | Type    | Default             | Description                                      |
+| ---------------------- | ------- | ------------------- | ------------------------------------------------ |
+| `configInit.enabled`   | boolean | `true`              | Prepare writable OliveTin runtime files.         |
+| `configInit.resources` | object  | requests/limits set | Resource guardrails for the init container.      |
+| `configInit.image.tag` | string  | `"1.37"`            | BusyBox tag used by the config bootstrap helper. |
+
 ### OliveTin Configuration
 
 | Parameter           | Type    | Default                 | Description                                                   |
@@ -399,19 +415,20 @@ External Secrets can materialize credentials for custom actions without committi
 
 ### Resources and Security
 
-| Parameter            | Type   | Default | Description                         |
-| -------------------- | ------ | ------- | ----------------------------------- |
-| `resources`          | object | `{}`    | CPU and memory requests and limits. |
-| `podSecurityContext` | object | `{}`    | Pod-level security context.         |
-| `securityContext`    | object | `{}`    | Container-level security context.   |
+| Parameter            | Type   | Default             | Description                         |
+| -------------------- | ------ | ------------------- | ----------------------------------- |
+| `resources`          | object | requests/limits set | CPU and memory requests and limits. |
+| `podSecurityContext` | object | hardened defaults   | Pod-level security context.         |
+| `securityContext`    | object | hardened defaults   | Container-level security context.   |
 
 ### Service Account
 
-| Parameter                    | Type    | Default | Description                         |
-| ---------------------------- | ------- | ------- | ----------------------------------- |
-| `serviceAccount.create`      | boolean | `false` | Create a dedicated ServiceAccount.  |
-| `serviceAccount.name`        | string  | `""`    | Override the ServiceAccount name.   |
-| `serviceAccount.annotations` | object  | `{}`    | Annotations for the ServiceAccount. |
+| Parameter                                     | Type    | Default | Description                         |
+| --------------------------------------------- | ------- | ------- | ----------------------------------- |
+| `serviceAccount.create`                       | boolean | `false` | Create a dedicated ServiceAccount.  |
+| `serviceAccount.name`                         | string  | `""`    | Override the ServiceAccount name.   |
+| `serviceAccount.annotations`                  | object  | `{}`    | Annotations for the ServiceAccount. |
+| `serviceAccount.automountServiceAccountToken` | boolean | `false` | Mount the API token into pods.      |
 
 ### Scheduling
 

--- a/src/pages/playground.astro
+++ b/src/pages/playground.astro
@@ -521,6 +521,89 @@ const chartConfigs: Record<string, ChartConfig> = {
       ],
     },
   ],
+  olivetin: [
+    {
+      name: 'Actions',
+      fields: [
+        {
+          label: 'HTTP Port',
+          key: 'olivetin.port',
+          type: 'number',
+          default: '1337',
+          description: 'OliveTin web UI port',
+        },
+        {
+          label: 'Config Template',
+          key: 'configTpl.enabled',
+          type: 'toggle',
+          default: 'false',
+          description: 'Render the config with Helm tpl',
+        },
+      ],
+    },
+    {
+      name: 'Config Bootstrap',
+      collapsible: true,
+      fields: [
+        {
+          label: 'Init Container',
+          key: 'configInit.enabled',
+          type: 'toggle',
+          default: 'true',
+          description: 'Copy the read-only config into a writable volume',
+        },
+        {
+          label: 'Init Image Tag',
+          key: 'configInit.image.tag',
+          type: 'text',
+          default: '1.37.0',
+          description: 'BusyBox image tag for config bootstrap',
+        },
+      ],
+    },
+    {
+      name: 'Ingress',
+      collapsible: true,
+      gateField: 'ingress.enabled',
+      fields: [
+        {
+          label: 'Hostname',
+          key: 'ingress.hosts[0].host',
+          type: 'text',
+          default: 'olivetin.example.com',
+          description: 'Ingress host for OliveTin',
+        },
+        {
+          label: 'Ingress Class',
+          key: 'ingress.ingressClassName',
+          type: 'select',
+          default: 'traefik',
+          options: ['traefik', 'nginx'],
+          description: 'Ingress controller class',
+        },
+      ],
+    },
+    {
+      name: 'Security',
+      collapsible: true,
+      fields: [
+        {
+          label: 'ServiceAccount',
+          key: 'serviceAccount.create',
+          type: 'toggle',
+          default: 'false',
+          description: 'Create a dedicated ServiceAccount',
+        },
+        {
+          label: 'API Token Mount',
+          key: 'serviceAccount.automountServiceAccountToken',
+          type: 'toggle',
+          default: 'false',
+          description: 'Mount a Kubernetes API token into the pod',
+        },
+      ],
+    },
+  ],
   'envoy-gateway': [
     {
       name: 'Controller',


### PR DESCRIPTION
## Summary
- sync OliveTin chart documentation with the standards backfill
- document the 95% security scan result and hardened runtime defaults
- add OliveTin controls to the playground for config bootstrap, ingress, and ServiceAccount token mounting

## Validation
- npm run format:check
- npm run lint
- npm run build
- make site-sync-check CHART=olivetin
- make md-lint REPO=site
- make release-check REPO=site
- make attribution-check REPO=site

## Related
- Paired chart PR: https://github.com/helmforgedev/charts/pull/538