### PR TITLE
docs(tomcat): sync chart standards

### DIFF
--- a/src/pages/docs/charts/tomcat.mdx
+++ b/src/pages/docs/charts/tomcat.mdx
@@ -8,6 +8,15 @@ description: Apache Tomcat Helm chart with official image, health webapp, writab
 
 Apache Tomcat chart for Kubernetes using the official `docker.io/library/tomcat` image. The chart supports immutable application images, mounted WARs, optional writable webapps, JMX, and modern ingress patterns.
 
+## Security Scan
+
+| Framework          | Score   |
+| ------------------ | ------- |
+| MITRE + NSA + SOC2 | **95%** |
+
+Security posture is strong. Remaining findings are documented product exceptions for opt-in NetworkPolicy ingress and
+egress boundaries.
+
 ## Key Features
 
 - Official Tomcat image pinned to `11.0.22-jdk17-temurin-noble`


### PR DESCRIPTION
## Summary
- add the Tomcat security scan evidence to the chart page
- keep the site docs aligned with the chart README standards backfill
- document the current NetworkPolicy boundary exceptions behind the 95% score

## Validation
- npm run format:check
- npm run lint
- npm run build
- make release-check REPO=site
- make attribution-check REPO=site