### PR TITLE
docs(valkey): sync security context defaults

### DIFF
--- a/src/pages/docs/charts/valkey.mdx
+++ b/src/pages/docs/charts/valkey.mdx
@@ -16,6 +16,7 @@ Valkey is an open-source in-memory key-value datastore. The HelmForge chart supp
 - Optional TLS file wiring
 - Topology-specific Services, StatefulSets, and Valkey Cluster bootstrap Job
 - Valkey exporter sidecar, ServiceMonitor, PDB, dual-stack Services, and extension hooks
+- Restricted-compatible pod and container security contexts for Valkey, metrics, tests, and cluster bootstrap workloads
 
 <a id="install"></a>
 
@@ -212,6 +213,15 @@ tls:
 Keep `tls.insecureSkipVerify=false` in production. Enable it only for CI or controlled self-signed test certificates
 when chart-rendered `valkey-cli` clients cannot validate release-specific hostnames.
 
+## Security Contexts
+
+The chart sets pod-level `RuntimeDefault` seccomp and non-root container security contexts by default. The Valkey
+containers use UID/GID `999`, the metrics exporter sidecar uses UID/GID `65534`, and the cluster initialization Job uses
+the Valkey UID/GID `999`.
+
+These defaults cover the container-level fields required by Kubernetes Pod Security Admission `restricted`, including
+`runAsNonRoot`, `allowPrivilegeEscalation=false`, and `capabilities.drop=["ALL"]`.
+
 ## Networking
 
 The chart renders topology-specific Services and supports Kubernetes dual-stack fields:
@@ -267,26 +277,31 @@ client understands Sentinel discovery or Cluster redirects.
 
 ## Values
 
-| Parameter                        | Default                   | Description                                                      |
-| -------------------------------- | ------------------------- | ---------------------------------------------------------------- |
-| `architecture`                   | `standalone`              | Topology: `standalone`, `replication`, `sentinel`, or `cluster`. |
-| `image.repository`               | `docker.io/valkey/valkey` | Official Valkey image.                                           |
-| `auth.enabled`                   | `true`                    | Enable password authentication.                                  |
-| `auth.existingSecret`            | `""`                      | Existing password Secret.                                        |
-| `tls.enabled`                    | `false`                   | Enable TLS file wiring.                                          |
-| `tls.existingSecret`             | `""`                      | Existing Secret with TLS files.                                  |
-| `tls.certFilename`               | `tls.crt`                 | Certificate filename mounted from `tls.existingSecret`.          |
-| `tls.keyFilename`                | `tls.key`                 | Private key filename mounted from `tls.existingSecret`.          |
-| `tls.caFilename`                 | `ca.crt`                  | CA filename mounted from `tls.existingSecret`.                   |
-| `tls.insecureSkipVerify`         | `false`                   | Skip TLS hostname verification for chart-rendered CLI clients.   |
-| `standalone.persistence.enabled` | `true`                    | Persist standalone data.                                         |
-| `replication.replicaCount`       | `2`                       | Replica count for replication modes.                             |
-| `sentinel.replicaCount`          | `3`                       | Number of Sentinel pods.                                         |
-| `cluster.nodes`                  | `6`                       | Total cluster pods.                                              |
-| `service.type`                   | `ClusterIP`               | Client Service type where applicable.                            |
-| `service.ipFamilyPolicy`         | `null`                    | Service IP family policy for dual-stack clusters.                |
-| `service.ipFamilies`             | `[]`                      | Optional explicit Service IP families.                           |
-| `metrics.enabled`                | `false`                   | Enable Valkey exporter sidecar.                                  |
+| Parameter                                   | Default                   | Description                                                      |
+| ------------------------------------------- | ------------------------- | ---------------------------------------------------------------- |
+| `architecture`                              | `standalone`              | Topology: `standalone`, `replication`, `sentinel`, or `cluster`. |
+| `image.repository`                          | `docker.io/valkey/valkey` | Official Valkey image.                                           |
+| `auth.enabled`                              | `true`                    | Enable password authentication.                                  |
+| `auth.existingSecret`                       | `""`                      | Existing password Secret.                                        |
+| `tls.enabled`                               | `false`                   | Enable TLS file wiring.                                          |
+| `tls.existingSecret`                        | `""`                      | Existing Secret with TLS files.                                  |
+| `tls.certFilename`                          | `tls.crt`                 | Certificate filename mounted from `tls.existingSecret`.          |
+| `tls.keyFilename`                           | `tls.key`                 | Private key filename mounted from `tls.existingSecret`.          |
+| `tls.caFilename`                            | `ca.crt`                  | CA filename mounted from `tls.existingSecret`.                   |
+| `tls.insecureSkipVerify`                    | `false`                   | Skip TLS hostname verification for chart-rendered CLI clients.   |
+| `standalone.persistence.enabled`            | `true`                    | Persist standalone data.                                         |
+| `replication.replicaCount`                  | `2`                       | Replica count for replication modes.                             |
+| `sentinel.replicaCount`                     | `3`                       | Number of Sentinel pods.                                         |
+| `cluster.nodes`                             | `6`                       | Total cluster pods.                                              |
+| `cluster.initJob.securityContext.runAsUser` | `999`                     | Cluster bootstrap Job container user ID.                         |
+| `service.type`                              | `ClusterIP`               | Client Service type where applicable.                            |
+| `service.ipFamilyPolicy`                    | `null`                    | Service IP family policy for dual-stack clusters.                |
+| `service.ipFamilies`                        | `[]`                      | Optional explicit Service IP families.                           |
+| `metrics.enabled`                           | `false`                   | Enable Valkey exporter sidecar.                                  |
+| `metrics.securityContext.runAsUser`         | `65534`                   | Metrics exporter container user ID.                              |
+| `metrics.securityContext.capabilities.drop` | `["ALL"]`                 | Linux capabilities dropped from the metrics exporter.            |
+| `podSecurityContext.seccompProfile.type`    | `RuntimeDefault`          | Pod-level seccomp profile for chart-managed pods.                |
+| `securityContext.capabilities.drop`         | `["ALL"]`                 | Linux capabilities dropped from Valkey containers.               |
 
 ## Links
 


### PR DESCRIPTION
## Summary
- document the Valkey restricted-compatible security context defaults
- add the new metrics sidecar and cluster init Job security context values to the Valkey values reference

## Validation
- `npm run lint`
- `npm run format:check`
- `npm run build`
- `make md-lint REPO=site`
- `make release-check REPO=site`
- `make attribution-check REPO=site`

Chart PR: helmforgedev/charts#574