### PR TITLE
docs(homarr): sync v1.67.0 defaults

### DIFF
--- a/src/pages/docs/charts/homarr.mdx
+++ b/src/pages/docs/charts/homarr.mdx
@@ -48,6 +48,12 @@ helm install homarr helmforge/homarr -f values.yaml
 helm install homarr oci://ghcr.io/helmforgedev/helm/homarr -f values.yaml
 ```
 
+## Upgrade Notes
+
+The chart defaults to Homarr `v1.67.0`. This skips the `v1.65.0` MySQL migration regression; upstream fixed that issue in
+`v1.66.1`, and `v1.67.0` keeps the fix while adding the latest Homarr improvements. Review the upstream Homarr release
+notes before upgrading production environments.
+
 ## Deployment Examples
 
 <DocsTabs
@@ -221,7 +227,7 @@ ingress:
 | Parameter          | Type   | Default                      | Description        |
 | ------------------ | ------ | ---------------------------- | ------------------ |
 | `image.repository` | string | `ghcr.io/homarr-labs/homarr` | Homarr image.      |
-| `image.tag`        | string | `"v1.62.0"`                  | Image tag.         |
+| `image.tag`        | string | `"v1.67.0"`                  | Image tag.         |
 | `image.pullPolicy` | string | `IfNotPresent`               | Image pull policy. |
 
 ### Homarr Configuration

--- a/src/pages/playground.astro
+++ b/src/pages/playground.astro
@@ -4663,6 +4663,13 @@ const chartConfigs: Record<string, ChartConfig> = {
       name: 'General',
       fields: [
         {
+          label: 'Image Tag',
+          key: 'image.tag',
+          type: 'text',
+          default: 'v1.67.0',
+          description: 'Homarr image tag',
+        },
+        {
           label: 'Storage Size',
           key: 'persistence.size',
           type: 'text',


### PR DESCRIPTION
## Summary
- Sync Homarr docs with the chart default image tag `v1.67.0`
- Add a short upgrade note covering the upstream MySQL migration regression fixed in Homarr `v1.66.1`
- Expose the Homarr image tag in the playground defaults

## Validation
- `npm run format:check`
- `npm run lint`
- `npm run build`
- `make md-lint REPO=site`
- `make release-check REPO=site`
- `make attribution-check REPO=site`

Related to helmforgedev/charts#519