### PR TITLE
docs(metabase): document wait image overrides

### DIFF
--- a/src/pages/docs/charts/metabase.mdx
+++ b/src/pages/docs/charts/metabase.mdx
@@ -212,6 +212,28 @@ ingress:
 | `image.pullPolicy` | string | `IfNotPresent`                | Image pull policy.                   |
 | `imagePullSecrets` | array  | `[]`                          | Pull secrets for private registries. |
 
+### Air-Gapped and Proxied Registries
+
+The chart uses a `wait-for-db` init container before starting Metabase. Configure `waitForDatabase.image.*` when your
+cluster must pull helper images from an internal registry or proxy.
+
+```yaml
+image:
+  repository: registry.example.com/proxy/metabase/metabase
+  tag: v0.62.1
+
+waitForDatabase:
+  image:
+    repository: registry.example.com/proxy/library/busybox
+    tag: '1.37'
+```
+
+| Parameter                          | Type   | Default                     | Description                                   |
+| ---------------------------------- | ------ | --------------------------- | --------------------------------------------- |
+| `waitForDatabase.image.repository` | string | `docker.io/library/busybox` | Wait-for-db init container image repository.  |
+| `waitForDatabase.image.tag`        | string | `"1.37"`                    | Wait-for-db init container image tag.         |
+| `waitForDatabase.image.pullPolicy` | string | `IfNotPresent`              | Wait-for-db init container image pull policy. |
+
 ### Metabase Configuration
 
 | Parameter                      | Type    | Default                 | Description                                                           |
@@ -437,11 +459,12 @@ externalSecrets:
 
 ### Extra
 
-| Parameter           | Type  | Default | Description                                              |
-| ------------------- | ----- | ------- | -------------------------------------------------------- |
-| `extraVolumes`      | array | `[]`    | Extra volumes to attach to the pod.                      |
-| `extraVolumeMounts` | array | `[]`    | Extra volume mounts for the container.                   |
-| `extraManifests`    | array | `[]`    | Extra Kubernetes manifests deployed alongside the chart. |
+| Parameter             | Type  | Default | Description                                              |
+| --------------------- | ----- | ------- | -------------------------------------------------------- |
+| `extraVolumes`        | array | `[]`    | Extra volumes to attach to the pod.                      |
+| `extraVolumeMounts`   | array | `[]`    | Extra volume mounts for the container.                   |
+| `extraInitContainers` | array | `[]`    | Additional init containers rendered after `wait-for-db`. |
+| `extraManifests`      | array | `[]`    | Extra Kubernetes manifests deployed alongside the chart. |
 
 ## Common Issues
 

--- a/src/pages/playground.astro
+++ b/src/pages/playground.astro
@@ -1799,6 +1799,7 @@ const chartConfigs: Record<string, ChartConfig> = {
         },
       ],
     },
+
     {
       name: 'Ingress',
       collapsible: true,
@@ -9543,6 +9544,34 @@ const chartConfigs: Record<string, ChartConfig> = {
           type: 'text',
           default: '',
           description: 'Memory limit',
+        },
+      ],
+    },
+    {
+      name: 'Images',
+      collapsible: true,
+      fields: [
+        {
+          label: 'Wait Image Repository',
+          key: 'waitForDatabase.image.repository',
+          type: 'text',
+          default: 'docker.io/library/busybox',
+          description: 'wait-for-db init image repository',
+        },
+        {
+          label: 'Wait Image Tag',
+          key: 'waitForDatabase.image.tag',
+          type: 'text',
+          default: '1.37',
+          description: 'wait-for-db init image tag',
+        },
+        {
+          label: 'Wait Pull Policy',
+          key: 'waitForDatabase.image.pullPolicy',
+          type: 'select',
+          default: 'IfNotPresent',
+          options: ['IfNotPresent', 'Always', 'Never'],
+          description: 'wait-for-db init image pull policy',
         },
       ],
     },

--- a/src/scripts/playground.ts
+++ b/src/scripts/playground.ts
@@ -899,7 +899,9 @@ function coerceValue(key: string, value: string): boolean | number | string {
 }
 
 function shouldPreserveString(key: string): boolean {
-  return /\.extraEnv\[\d+\]\.value$/.test(key) || /\.env\[\d+\]\.value$/.test(key);
+  return (
+    /(^|\.)extraEnv\[\d+\]\.value$/.test(key) || /(^|\.)env\[\d+\]\.value$/.test(key) || /(^|\.)image\.tag$/.test(key)
+  );
 }
 
 function parseKeyPath(key: string): Array<string | number> {


### PR DESCRIPTION
## Summary
- Document `waitForDatabase.image.*` for Metabase air-gapped/proxied registry deployments
- Document `extraInitContainers` for custom init workflows such as preparing JDBC drivers
- Add Metabase playground controls for the wait-for-db init image

## Companion chart PR
- Requires helmforgedev/charts#576, which adds the rendered `waitForDatabase.image.*` and `extraInitContainers` values
- Merge this site sync after or together with the chart PR so published docs do not lead the released chart

## Validation
- `npm run format:check`
- `npm run lint`
- `npm run build`
- `make md-lint REPO=site`
- `make release-check REPO=site`
- `make attribution-check REPO=site`
- `make ci-watch REPO=site`
- `make review-threads REPO=site`

Related to helmforgedev/charts#541