### PR TITLE
docs(medikeep): sync site with chart standards alignment

### DIFF
--- a/src/pages/docs/charts/medikeep.mdx
+++ b/src/pages/docs/charts/medikeep.mdx
@@ -50,7 +50,7 @@ Exposure and operations:
 - `ingress.enabled`, `ingress.ingressClassName`, `ingress.annotations`, `ingress.hosts`, `ingress.tls`.
 - `gatewayAPI.enabled`, `gatewayAPI.httpRoutes`.
 - `externalSecrets.enabled`, `externalSecrets.items`.
-- `networkPolicy.enabled`, `networkPolicy.ingressFrom`, `networkPolicy.egress`.
+- `networkPolicy.enabled`, `networkPolicy.ingressFrom`, `networkPolicy.egress.enabled`, `networkPolicy.egress.allowDNS`, `networkPolicy.egress.extraTo`, `networkPolicy.egress.extraEgress`.
 - `probes.startup`, `probes.liveness`, `probes.readiness`.
 - `resources`, `podSecurityContext`, `securityContext`, `waitForDatabase`.
 - `serviceAccount`, `pdb`, `nodeSelector`, `tolerations`, `affinity`, `topologySpreadConstraints`.
@@ -145,11 +145,6 @@ gatewayAPI:
           namespace: gateway-system
       hostnames:
         - medikeep.example.com
-      rules:
-        - matches:
-            - path:
-                type: PathPrefix
-                value: /
 ```
 
 ## External Secrets


### PR DESCRIPTION
Syncs MediKeep site documentation with chart PR helmforgedev/charts#632.

## Changes

- Add \
etworkPolicy.egress.extraEgress\ to configuration reference
- Remove hardcoded \ules\ from Gateway API example (chart generates default backendRef)

## Cross-Reference

Chart PR: helmforgedev/charts#632

## Quality Evidence

- \
pm run build\: 153 pages indexed, zero errors