### PR TITLE
docs(apache): sync template standards

### DIFF
--- a/src/data/playground-configs.ts
+++ b/src/data/playground-configs.ts
@@ -258,6 +258,28 @@ export const chartConfigs: Record<string, ChartConfig> = {
           default: 'true',
           description: 'Allow general outbound traffic',
         },
+        {
+          label: 'Extra Egress CIDR',
+          key: 'networkPolicy.egress.extraEgress[0].to[0].ipBlock.cidr',
+          type: 'text',
+          default: '',
+          description: 'Optional extra egress CIDR',
+        },
+        {
+          label: 'Extra Egress Protocol',
+          key: 'networkPolicy.egress.extraEgress[0].ports[0].protocol',
+          type: 'select',
+          default: '',
+          options: ['', 'TCP', 'UDP', 'SCTP'],
+          description: 'Optional extra egress protocol',
+        },
+        {
+          label: 'Extra Egress Port',
+          key: 'networkPolicy.egress.extraEgress[0].ports[0].port',
+          type: 'number',
+          default: '',
+          description: 'Optional extra egress port',
+        },
       ],
     },
     {

--- a/src/pages/docs/charts/apache.mdx
+++ b/src/pages/docs/charts/apache.mdx
@@ -10,7 +10,7 @@ Apache HTTP Server chart for Kubernetes using the official `docker.io/library/ht
 
 ## Key Features
 
-- Official `httpd` image pinned to Apache HTTP Server `2.4.67`
+- Official `httpd` image pinned to Apache HTTP Server `2.4.68`
 - Non-root runtime on port `8080` with a read-only root filesystem
 - Generated Apache configuration for security headers, health checks, logging, and static content
 - Inline content, existing ConfigMap content, and extra virtual host snippets
@@ -118,6 +118,13 @@ networkPolicy:
     enabled: true
     allowDns: true
     allowInternet: false
+    extraEgress:
+      - to:
+          - ipBlock:
+              cidr: 10.0.0.0/8
+        ports:
+          - protocol: TCP
+            port: 443
 ```
 
 Use immutable content names instead of mutating a live ConfigMap. That keeps rollbacks deterministic and avoids confusing pod checksums.
@@ -247,6 +254,7 @@ networkPolicy:
 ```
 
 Set `networkPolicy.egress.allowInternet=true` only when Apache needs outbound access for reverse proxy targets or remote content integrations.
+Use `networkPolicy.egress.extraEgress` for complete additional egress rules with `to` and `ports`.
 
 ## Configuration Reference
 
@@ -260,7 +268,7 @@ Set `networkPolicy.egress.allowInternet=true` only when Apache needs outbound ac
 | `commonLabels`           | `{}`                      | Labels added to chart resources.       |
 | `serverName`             | `localhost`               | Apache `ServerName` value.             |
 | `image.repository`       | `docker.io/library/httpd` | Official Apache HTTP Server image.     |
-| `image.tag`              | `2.4.67`                  | Apache image tag.                      |
+| `image.tag`              | `2.4.68`                  | Apache image tag.                      |
 | `image.pullPolicy`       | `IfNotPresent`            | Image pull policy.                     |
 | `imagePullSecrets`       | `[]`                      | Image pull secrets.                    |
 | `containerPorts.http`    | `8080`                    | Non-root Apache listener port.         |
@@ -333,7 +341,8 @@ Set `networkPolicy.egress.allowInternet=true` only when Apache needs outbound ac
 | `networkPolicy.egress.enabled`            | `true`  | Restrict outbound traffic when policy is enabled. |
 | `networkPolicy.egress.allowDns`           | `true`  | Allow DNS egress.                                 |
 | `networkPolicy.egress.allowInternet`      | `true`  | Allow IPv4 and IPv6 internet egress.              |
-| `networkPolicy.egress.extraRules`         | `[]`    | Additional egress rules.                          |
+| `networkPolicy.egress.extraRules`         | `[]`    | Legacy additional egress rules.                   |
+| `networkPolicy.egress.extraEgress`        | `[]`    | Additional complete egress rule objects.          |
 
 ### Probes, Resources, And Scheduling
 

--- a/src/pages/playground.astro
+++ b/src/pages/playground.astro
@@ -22,6 +22,7 @@ const scenariosJson = JSON.stringify(scenarios);
 
 const siteSyncPlaygroundConfigs: Record<string, string> = {
   'adguard-home': 'src/data/playground-configs.ts',
+  apache: 'src/data/playground-schema.ts',
   booklore: 'src/data/playground-configs.ts',
   changedetection: 'src/data/playground-configs.ts',
   medikeep: 'src/data/playground-configs.ts',

--- a/src/scripts/playground.ts
+++ b/src/scripts/playground.ts
@@ -70,6 +70,16 @@ const linkedFieldValues: Record<string, Record<string, string>> = {
   },
 };
 
+const coupledRuleKeysBySlug: Record<string, string[][]> = {
+  apache: [
+    [
+      'networkPolicy.egress.extraEgress[0].to[0].ipBlock.cidr',
+      'networkPolicy.egress.extraEgress[0].ports[0].protocol',
+      'networkPolicy.egress.extraEgress[0].ports[0].port',
+    ],
+  ],
+};
+
 const giteaPostgresqlPassword = 'change-me-gitea-postgresql';
 
 function getGroups(slug: string): GroupConfig[] {
@@ -759,25 +769,21 @@ function getChangedValues(): { key: string; value: string; defaultValue: string 
     changes.unshift({ key: 'tunnel.quickTunnel.enabled', value: 'false', defaultValue: 'true' });
   }
 
-  pruneIncompleteApacheExtraEgress(changes);
+  pruneIncompleteCoupledRules(changes);
 
   return changes;
 }
 
-function pruneIncompleteApacheExtraEgress(changes: { key: string; value: string; defaultValue: string }[]): void {
-  if (selectedSlug !== 'apache') return;
+function pruneIncompleteCoupledRules(changes: { key: string; value: string; defaultValue: string }[]): void {
+  for (const keys of coupledRuleKeysBySlug[selectedSlug] ?? []) {
+    const ruleKeys = new Set(keys);
+    const emittedRuleKeys = changes.filter((change) => ruleKeys.has(change.key)).map((change) => change.key);
 
-  const ruleKeys = new Set([
-    'networkPolicy.egress.extraEgress[0].to[0].ipBlock.cidr',
-    'networkPolicy.egress.extraEgress[0].ports[0].protocol',
-    'networkPolicy.egress.extraEgress[0].ports[0].port',
-  ]);
-  const emittedRuleKeys = changes.filter((change) => ruleKeys.has(change.key)).map((change) => change.key);
+    if (emittedRuleKeys.length === 0 || emittedRuleKeys.length === ruleKeys.size) continue;
 
-  if (emittedRuleKeys.length === 0 || emittedRuleKeys.length === ruleKeys.size) return;
-
-  for (let index = changes.length - 1; index >= 0; index -= 1) {
-    if (ruleKeys.has(changes[index].key)) changes.splice(index, 1);
+    for (let index = changes.length - 1; index >= 0; index -= 1) {
+      if (ruleKeys.has(changes[index].key)) changes.splice(index, 1);
+    }
   }
 }
 

--- a/src/scripts/playground.ts
+++ b/src/scripts/playground.ts
@@ -759,7 +759,26 @@ function getChangedValues(): { key: string; value: string; defaultValue: string 
     changes.unshift({ key: 'tunnel.quickTunnel.enabled', value: 'false', defaultValue: 'true' });
   }
 
+  pruneIncompleteApacheExtraEgress(changes);
+
   return changes;
+}
+
+function pruneIncompleteApacheExtraEgress(changes: { key: string; value: string; defaultValue: string }[]): void {
+  if (selectedSlug !== 'apache') return;
+
+  const ruleKeys = new Set([
+    'networkPolicy.egress.extraEgress[0].to[0].ipBlock.cidr',
+    'networkPolicy.egress.extraEgress[0].ports[0].protocol',
+    'networkPolicy.egress.extraEgress[0].ports[0].port',
+  ]);
+  const emittedRuleKeys = changes.filter((change) => ruleKeys.has(change.key)).map((change) => change.key);
+
+  if (emittedRuleKeys.length === 0 || emittedRuleKeys.length === ruleKeys.size) return;
+
+  for (let index = changes.length - 1; index >= 0; index -= 1) {
+    if (ruleKeys.has(changes[index].key)) changes.splice(index, 1);
+  }
 }
 
 function buildSetFlags(): string[] {


### PR DESCRIPTION
## Summary
- update the documented Apache image tag to 2.4.68
- document networkPolicy.egress.extraEgress in examples and the configuration reference
- expose Apache in the playground registry for site-sync coverage
- add curated Apache playground fields for networkPolicy.egress.extraEgress
- guard Apache playground extraEgress serialization so partial rules are not emitted

## Validation
- make site-sync-check CHART=apache
- npm run lint
- npm run format:check
- npm run build
- make release-check REPO=site
- make attribution-check REPO=site

Chart PR: helmforgedev/charts#641 (merged)
Issue: helmforgedev/charts#633

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the Apache chart to the playground’s selectable/syncable charts list.
  * Extended Apache NetworkPolicy egress with optional `networkPolicy.egress.extraEgress` inputs (extra CIDR, protocol, and port).
* **Bug Fixes**
  * Prevented partial `extraEgress` inputs from being applied during playground sync.
* **Documentation**
  * Updated Apache chart docs to pin the official `httpd` image to version `2.4.68`.
  * Expanded NetworkPolicy egress documentation with an `extraEgress` example and config reference updates, marking `extraRules` as legacy.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->