### PR TITLE
docs(adguard-home): sync template standards

### DIFF
--- a/src/pages/playground.astro
+++ b/src/pages/playground.astro
@@ -21,6 +21,7 @@ const configsJson = JSON.stringify(mergedConfigs);
 const scenariosJson = JSON.stringify(scenarios);
 
 const siteSyncPlaygroundConfigs: Record<string, string> = {
+  'adguard-home': 'src/data/playground-configs.ts',
   booklore: 'src/data/playground-configs.ts',
   medikeep: 'src/data/playground-configs.ts',
   memcached: 'src/data/playground-configs.ts',


### PR DESCRIPTION
## Summary

Synchronize the AdGuard Home playground registry after the template standards alignment.

Changes:
- mark `adguard-home` as covered by the curated playground configuration
- satisfy the GR-007 site-sync marker without changing playground fields

Related chart PR: helmforgedev/charts#642

## Validation

- `make site-sync-check CHART=adguard-home`
- `npm run lint`
- `npm run format:check`
- `npm run build`
- `make release-check REPO=site`
- `make attribution-check REPO=site`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for the AdGuard Home chart in the playground, making it available as a configured option.
* **Bug Fixes**
  * Updated the playground chart list so the newly supported chart is included in the stable chart selection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->