### PR TITLE
docs(alfio): sync template standards

### DIFF
--- a/src/pages/playground.astro
+++ b/src/pages/playground.astro
@@ -23,6 +23,7 @@ const scenariosJson = JSON.stringify(scenarios);
 const siteSyncPlaygroundConfigs: Record<string, string> = {
   'adguard-home': 'src/data/playground-configs.ts',
   apache: 'src/data/playground-schema.ts',
+  alfio: 'src/data/playground-configs.ts',
   booklore: 'src/data/playground-configs.ts',
   changedetection: 'src/data/playground-configs.ts',
   medikeep: 'src/data/playground-configs.ts',


### PR DESCRIPTION
## Summary
- register alfio in the site sync playground registry
- keep the playground/site sync gate aligned with the chart validation PR

## Validation
- make site-sync-check CHART=alfio
- npm run lint
- npm run format:check
- npm run build
- make release-check REPO=site
- make attribution-check REPO=site

Chart PR: helmforgedev/charts#643
Issue: helmforgedev/charts#633

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded the playground’s sync/config workflow to include an additional chart, improving what appears in the filtered playground list.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->