### PR TITLE
docs(answer): sync template standards

### DIFF
--- a/src/pages/playground.astro
+++ b/src/pages/playground.astro
@@ -24,6 +24,7 @@ const siteSyncPlaygroundConfigs: Record<string, string> = {
   'adguard-home': 'src/data/playground-configs.ts',
   apache: 'src/data/playground-schema.ts',
   alfio: 'src/data/playground-configs.ts',
+  answer: 'src/data/playground-configs.ts',
   booklore: 'src/data/playground-configs.ts',
   changedetection: 'src/data/playground-configs.ts',
   medikeep: 'src/data/playground-configs.ts',


### PR DESCRIPTION
## Summary
- register answer in the site sync playground registry
- keep the playground/site sync gate aligned with the chart validation PR

## Validation
- make site-sync-check CHART=answer
- npm run lint
- npm run format:check
- npm run build
- make release-check REPO=site
- make attribution-check REPO=site

Chart PR: helmforgedev/charts#644
Issue: helmforgedev/charts#633

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated playground chart filtering so the “answer” chart is now included in site sync results.
  * Improved the set of charts shown in the playground when syncing site data, helping ensure expected content appears.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->