### PR TITLE
docs(appwrite): sync template standards

### DIFF
--- a/src/pages/playground.astro
+++ b/src/pages/playground.astro
@@ -25,6 +25,7 @@ const siteSyncPlaygroundConfigs: Record<string, string> = {
   apache: 'src/data/playground-schema.ts',
   alfio: 'src/data/playground-configs.ts',
   answer: 'src/data/playground-configs.ts',
+  appwrite: 'src/data/playground-configs.ts',
   booklore: 'src/data/playground-configs.ts',
   changedetection: 'src/data/playground-configs.ts',
   medikeep: 'src/data/playground-configs.ts',


### PR DESCRIPTION
## Summary
- register appwrite in the site sync playground registry
- keep the playground/site sync gate aligned with the chart validation PR

## Validation
- make site-sync-check CHART=appwrite
- npm run lint
- npm run format:check
- npm run build
- make release-check REPO=site
- make attribution-check REPO=site

Chart PR: helmforgedev/charts#645
Issue: helmforgedev/charts#633

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated which playground charts are eligible for site-synced configuration updates, so the correct chart set is considered during sync.
  * This ensures the **appwrite** playground charts receive the expected site-synced settings, improving which charts render with the right configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->