### PR TITLE
docs(archivebox): sync template standards

### DIFF
--- a/src/pages/playground.astro
+++ b/src/pages/playground.astro
@@ -22,10 +22,11 @@ const scenariosJson = JSON.stringify(scenarios);
 
 const siteSyncPlaygroundConfigs: Record<string, string> = {
   'adguard-home': 'src/data/playground-configs.ts',
-  apache: 'src/data/playground-schema.ts',
   alfio: 'src/data/playground-configs.ts',
   answer: 'src/data/playground-configs.ts',
+  apache: 'src/data/playground-schema.ts',
   appwrite: 'src/data/playground-configs.ts',
+  archivebox: 'src/data/playground-configs.ts',
   booklore: 'src/data/playground-configs.ts',
   changedetection: 'src/data/playground-configs.ts',
   medikeep: 'src/data/playground-configs.ts',


### PR DESCRIPTION
## Summary
- register archivebox in the site sync playground registry
- keep the playground/site sync gate aligned with the chart validation PR

## Validation
- make site-sync-check CHART=archivebox
- npm run lint
- npm run format:check
- npm run build
- make release-check REPO=site
- make attribution-check REPO=site

Chart PR: helmforgedev/charts#646
Issue: helmforgedev/charts#633

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for the `archivebox` chart in the playground, enabling it to be eligible for sync alongside the other available chart options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->