### PR TITLE
docs(authelia): sync template standards

### DIFF
--- a/src/pages/playground.astro
+++ b/src/pages/playground.astro
@@ -27,6 +27,7 @@ const siteSyncPlaygroundConfigs: Record<string, string> = {
   apache: 'src/data/playground-schema.ts',
   appwrite: 'src/data/playground-configs.ts',
   archivebox: 'src/data/playground-configs.ts',
+  authelia: 'src/data/playground-configs.ts',
   booklore: 'src/data/playground-configs.ts',
   changedetection: 'src/data/playground-configs.ts',
   medikeep: 'src/data/playground-configs.ts',


### PR DESCRIPTION
## Summary
- register authelia in the site sync playground registry
- keep the playground/site sync gate aligned with the chart validation PR

## Validation
- make site-sync-check CHART=authelia
- npm run lint
- npm run format:check
- npm run build
- make release-check REPO=site
- make attribution-check REPO=site

Chart PR: helmforgedev/charts#647
Issue: helmforgedev/charts#633

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for an additional playground configuration, expanding the set of eligible chart slugs shown in the playground’s chart selector.
  * Updated the playground’s chart filtering logic so the new configuration can appear when charts meet the existing eligibility rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->