### PR TITLE
docs(automatisch): sync template standards

### DIFF
--- a/src/pages/playground.astro
+++ b/src/pages/playground.astro
@@ -28,6 +28,7 @@ const siteSyncPlaygroundConfigs: Record<string, string> = {
   appwrite: 'src/data/playground-configs.ts',
   archivebox: 'src/data/playground-configs.ts',
   authelia: 'src/data/playground-configs.ts',
+  automatisch: 'src/data/playground-configs.ts',
   booklore: 'src/data/playground-configs.ts',
   changedetection: 'src/data/playground-configs.ts',
   medikeep: 'src/data/playground-configs.ts',


### PR DESCRIPTION
## Summary
- register automatisch in the site sync playground registry
- keep the playground/site sync gate aligned with the chart validation PR

## Validation
- make site-sync-check CHART=automatisch
- npm run lint
- npm run format:check
- npm run build
- make release-check REPO=site
- make attribution-check REPO=site

Chart PR: helmforgedev/charts#648
Issue: helmforgedev/charts#633

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the **automatisch** chart to the **site-synced** playground list.
  * This expands the set of playground charts users can select from, and updates which options appear in the site-synced playground selection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->