### PR TITLE
docs(castopod): sync template standards

### DIFF
--- a/src/pages/playground.astro
+++ b/src/pages/playground.astro
@@ -30,6 +30,7 @@ const siteSyncPlaygroundConfigs: Record<string, string> = {
   authelia: 'src/data/playground-configs.ts',
   automatisch: 'src/data/playground-configs.ts',
   booklore: 'src/data/playground-configs.ts',
+  castopod: 'src/data/playground-configs.ts',
   changedetection: 'src/data/playground-configs.ts',
   medikeep: 'src/data/playground-configs.ts',
   memcached: 'src/data/playground-configs.ts',


### PR DESCRIPTION
## Summary
- register castopod in the site sync playground registry
- keep the playground/site sync gate aligned with the chart validation PR

## Validation
- make site-sync-check CHART=castopod
- npm run lint
- npm run format:check
- npm run build
- make release-check REPO=site
- make attribution-check REPO=site

Chart PR: helmforgedev/charts#649
Issue: helmforgedev/charts#633

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for the **castopod** chart in the playground, so it’s now included in chart selection and can appear based on the playground’s maturity filtering rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->