### PR TITLE
docs(changedetection): sync template standards

### DIFF
--- a/src/pages/playground.astro
+++ b/src/pages/playground.astro
@@ -22,6 +22,7 @@ const scenariosJson = JSON.stringify(scenarios);
 
 const siteSyncPlaygroundConfigs: Record<string, string> = {
   booklore: 'src/data/playground-configs.ts',
+  changedetection: 'src/data/playground-configs.ts',
   medikeep: 'src/data/playground-configs.ts',
   memcached: 'src/data/playground-configs.ts',
   notediscovery: 'src/data/playground-configs.ts',


### PR DESCRIPTION
## Summary
- register changedetection in the site sync playground registry
- keep the playground/site sync gate aligned with the chart validation PR

## Related
- Chart PR: helmforgedev/charts#650
- Issue: helmforgedev/charts#633

## Validation
- make site-sync-check CHART=changedetection
- npm run lint
- npm run format:check
- npm run build
- make release-check REPO=site
- make attribution-check REPO=site

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for the **changedetection** chart in the playground, so it now appears in chart selection and filtering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->