### PR TITLE
docs(chiefonboarding): sync template standards

### DIFF
--- a/src/pages/playground.astro
+++ b/src/pages/playground.astro
@@ -32,6 +32,7 @@ const siteSyncPlaygroundConfigs: Record<string, string> = {
   booklore: 'src/data/playground-configs.ts',
   castopod: 'src/data/playground-configs.ts',
   changedetection: 'src/data/playground-configs.ts',
+  chiefonboarding: 'src/data/playground-configs.ts',
   medikeep: 'src/data/playground-configs.ts',
   memcached: 'src/data/playground-configs.ts',
   notediscovery: 'src/data/playground-configs.ts',


### PR DESCRIPTION
## Summary
- register chiefonboarding in the site sync playground registry
- keep the playground/site sync gate aligned with the chart validation PR

## Validation
- make site-sync-check CHART=chiefonboarding
- npm run lint
- npm run format:check
- npm run build
- make release-check REPO=site
- make attribution-check REPO=site

Chart PR: helmforgedev/charts#651
Issue: helmforgedev/charts#633

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an additional chart to the playground, making it available for browsing when its slug is present in the configured chart list, even if it is not marked as stable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->