### PR TITLE
docs(ckan): sync template standards

### DIFF
--- a/src/pages/playground.astro
+++ b/src/pages/playground.astro
@@ -33,6 +33,7 @@ const siteSyncPlaygroundConfigs: Record<string, string> = {
   castopod: 'src/data/playground-configs.ts',
   changedetection: 'src/data/playground-configs.ts',
   chiefonboarding: 'src/data/playground-configs.ts',
+  ckan: 'src/data/playground-configs.ts',
   medikeep: 'src/data/playground-configs.ts',
   memcached: 'src/data/playground-configs.ts',
   notediscovery: 'src/data/playground-configs.ts',


### PR DESCRIPTION
## Summary
- register ckan in the site sync playground registry
- keep the playground/site sync gate aligned with the chart validation PR

## Validation
- make site-sync-check CHART=ckan
- npm run lint
- npm run format:check
- npm run build
- make release-check REPO=site
- make attribution-check REPO=site

Chart PR: helmforgedev/charts#652
Issue: helmforgedev/charts#633