### PR TITLE
docs(cloudflared): sync playground coverage

### DIFF
--- a/src/pages/playground.astro
+++ b/src/pages/playground.astro
@@ -34,6 +34,7 @@ const siteSyncPlaygroundConfigs: Record<string, string> = {
   changedetection: 'src/data/playground-configs.ts',
   chiefonboarding: 'src/data/playground-configs.ts',
   ckan: 'src/data/playground-configs.ts',
+  cloudflared: 'src/data/playground-configs.ts',
   medikeep: 'src/data/playground-configs.ts',
   memcached: 'src/data/playground-configs.ts',
   notediscovery: 'src/data/playground-configs.ts',


### PR DESCRIPTION
## Summary
- add cloudflared to the Helm values playground eligibility map required by the chart sync check

## Validation
- make site-sync-check CHART=cloudflared
- npm run lint
- npm run format:check
- npm run build
- make release-check REPO=site
- make attribution-check REPO=site

Chart PR: helmforgedev/charts#653
Issue: helmforgedev/charts#633

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for the **cloudflared** chart in the playground chart list, making it available alongside other supported charts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->