### PR TITLE
docs(countly): sync playground coverage

### DIFF
--- a/src/pages/playground.astro
+++ b/src/pages/playground.astro
@@ -35,6 +35,7 @@ const siteSyncPlaygroundConfigs: Record<string, string> = {
   chiefonboarding: 'src/data/playground-configs.ts',
   ckan: 'src/data/playground-configs.ts',
   cloudflared: 'src/data/playground-configs.ts',
+  countly: 'src/data/playground-configs.ts',
   medikeep: 'src/data/playground-configs.ts',
   memcached: 'src/data/playground-configs.ts',
   notediscovery: 'src/data/playground-configs.ts',


### PR DESCRIPTION
## Summary
- add countly to the Helm values playground eligibility map required by the chart sync check

## Validation
- make site-sync-check CHART=countly
- npm run lint
- npm run format:check
- npm run build
- make release-check REPO=site
- make attribution-check REPO=site

Chart PR: helmforgedev/charts#655
Issue: helmforgedev/charts#633

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the Countly chart to the playground’s available chart list, making it visible even when it isn’t marked as stable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->