### PR TITLE
docs(cronicle): sync playground coverage

### DIFF
--- a/src/pages/playground.astro
+++ b/src/pages/playground.astro
@@ -36,6 +36,7 @@ const siteSyncPlaygroundConfigs: Record<string, string> = {
   ckan: 'src/data/playground-configs.ts',
   cloudflared: 'src/data/playground-configs.ts',
   countly: 'src/data/playground-configs.ts',
+  cronicle: 'src/data/playground-configs.ts',
   medikeep: 'src/data/playground-configs.ts',
   memcached: 'src/data/playground-configs.ts',
   notediscovery: 'src/data/playground-configs.ts',


### PR DESCRIPTION
## Summary
- add cronicle to the Helm values playground eligibility map required by the chart sync check

## Validation
- make site-sync-check CHART=cronicle
- npm run lint
- npm run format:check
- npm run build
- make release-check REPO=site
- make attribution-check REPO=site

Chart PR: helmforgedev/charts#656
Issue: helmforgedev/charts#633

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for the `cronicle` chart in the playground’s sync/config selection, making it available alongside other eligible chart slugs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->