### PR TITLE
docs(ddns-updater): sync playground coverage

### DIFF
--- a/src/pages/playground.astro
+++ b/src/pages/playground.astro
@@ -37,6 +37,7 @@ const siteSyncPlaygroundConfigs: Record<string, string> = {
   cloudflared: 'src/data/playground-configs.ts',
   countly: 'src/data/playground-configs.ts',
   cronicle: 'src/data/playground-configs.ts',
+  'ddns-updater': 'src/data/playground-configs.ts',
   medikeep: 'src/data/playground-configs.ts',
   memcached: 'src/data/playground-configs.ts',
   notediscovery: 'src/data/playground-configs.ts',


### PR DESCRIPTION
## Summary
- add ddns-updater to the playground chart config mapping after the chart template behavior update

## Validation
- npm run lint
- npm run format:check
- npm run build
- make site-sync-check CHART=ddns-updater
- make release-check REPO=site
- make attribution-check REPO=site

Chart PR: helmforgedev/charts#657
Issue: helmforgedev/charts#633

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for the `ddns-updater` chart in the playground, allowing it to appear in the available chart list when applicable.
* **Bug Fixes**
  * Improved chart inclusion behavior so playground results now reflect the configured site sync entries more accurately.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->