### PR TITLE
docs(discount-bandit): sync network policy coverage

### DIFF
--- a/src/pages/docs/charts/discount-bandit.mdx
+++ b/src/pages/docs/charts/discount-bandit.mdx
@@ -315,17 +315,26 @@ externalSecrets:
 
 ### Networking
 
-| Parameter                      | Default     | Description                                                              |
-| ------------------------------ | ----------- | ------------------------------------------------------------------------ |
-| `service.type`                 | `ClusterIP` | Kubernetes Service type.                                                 |
-| `service.port`                 | `80`        | Service HTTP port.                                                       |
-| `service.ipFamilyPolicy`       | `""`        | Optional Service IP family policy.                                       |
-| `service.ipFamilies`           | `[]`        | Optional Service IP families for dual-stack clusters.                    |
-| `ingress.enabled`              | `false`     | Render classic Kubernetes Ingress.                                       |
-| `gatewayAPI.enabled`           | `false`     | Render Gateway API `HTTPRoute`.                                          |
-| `gatewayAPI.parentRefs`        | `[]`        | Platform-owned Gateway references. Required when Gateway API is enabled. |
-| `networkPolicy.enabled`        | `false`     | Render NetworkPolicy.                                                    |
-| `networkPolicy.egress.enabled` | `false`     | Restrict egress when enabled.                                            |
+| Parameter                                         | Default     | Description                                                                |
+| ------------------------------------------------- | ----------- | -------------------------------------------------------------------------- |
+| `service.type`                                    | `ClusterIP` | Kubernetes Service type.                                                   |
+| `service.port`                                    | `80`        | Service HTTP port.                                                         |
+| `service.ipFamilyPolicy`                          | `""`        | Optional Service IP family policy.                                         |
+| `service.ipFamilies`                              | `[]`        | Optional Service IP families for dual-stack clusters.                      |
+| `ingress.enabled`                                 | `false`     | Render classic Kubernetes Ingress.                                         |
+| `gatewayAPI.enabled`                              | `false`     | Render Gateway API `HTTPRoute`.                                            |
+| `gatewayAPI.parentRefs`                           | `[]`        | Platform-owned Gateway references. Required when Gateway API is enabled.   |
+| `networkPolicy.enabled`                           | `false`     | Render NetworkPolicy.                                                      |
+| `networkPolicy.ingress.allowSameNamespace`        | `true`      | Allow ingress from pods in the same namespace.                             |
+| `networkPolicy.ingress.extraFrom`                 | `[]`        | Additional NetworkPolicy ingress peers.                                    |
+| `networkPolicy.egress.enabled`                    | `false`     | Restrict egress when enabled.                                              |
+| `networkPolicy.egress.allowDNS`                   | `true`      | Allow DNS egress to kube-system.                                           |
+| `networkPolicy.egress.allowHTTPS`                 | `true`      | Allow HTTPS egress for crawlers, notifications, and exchange-rate lookups. |
+| `networkPolicy.egress.allowHTTP`                  | `false`     | Allow HTTP egress for stores that do not support HTTPS.                    |
+| `networkPolicy.egress.allowSameNamespaceDatabase` | `true`      | Allow egress to same-namespace database pods.                              |
+| `networkPolicy.egress.databasePort`               | `3306`      | Database port allowed when same-namespace database egress is enabled.      |
+| `networkPolicy.egress.extraTo`                    | `[]`        | Additional egress peers rendered under a generated `to` rule.              |
+| `networkPolicy.egress.extraEgress`                | `[]`        | Additional complete NetworkPolicy egress rules.                            |
 
 ### Runtime and Operations
 

--- a/src/pages/playground.astro
+++ b/src/pages/playground.astro
@@ -38,6 +38,7 @@ const siteSyncPlaygroundConfigs: Record<string, string> = {
   countly: 'src/data/playground-configs.ts',
   cronicle: 'src/data/playground-configs.ts',
   'ddns-updater': 'src/data/playground-configs.ts',
+  'discount-bandit': 'src/data/playground-configs.ts',
   medikeep: 'src/data/playground-configs.ts',
   memcached: 'src/data/playground-configs.ts',
   notediscovery: 'src/data/playground-configs.ts',


### PR DESCRIPTION
## Summary
- add Discount Bandit to the playground chart registry
- document the canonical `networkPolicy.egress.extraEgress` value in the chart page configuration reference

## Validation
- make site-sync-check CHART=discount-bandit
- npm run lint
- npm run format:check
- npm run build
- make release-check REPO=site
- make attribution-check REPO=site

Chart PR: helmforgedev/charts#658
Issue: helmforgedev/charts#633

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the **discount-bandit** chart to the playground, making it available for selection where supported.

* **Documentation**
  * Expanded the chart’s networking configuration reference with more complete details for service IP families, ingress/gateway options, and network policy settings.
  * Added documentation for additional ingress and egress controls, including namespace access, DNS/HTTP/HTTPS rules, database access, and custom rule extensions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->