### PR TITLE
docs(docmost): sync playground coverage

### DIFF
--- a/src/pages/playground.astro
+++ b/src/pages/playground.astro
@@ -39,6 +39,7 @@ const siteSyncPlaygroundConfigs: Record<string, string> = {
   cronicle: 'src/data/playground-configs.ts',
   'ddns-updater': 'src/data/playground-configs.ts',
   'discount-bandit': 'src/data/playground-configs.ts',
+  docmost: 'src/data/playground-configs.ts',
   medikeep: 'src/data/playground-configs.ts',
   memcached: 'src/data/playground-configs.ts',
   notediscovery: 'src/data/playground-configs.ts',


### PR DESCRIPTION
## Summary
- add Docmost to the playground chart registry required by site sync

## Validation
- make site-sync-check CHART=docmost
- npm run lint
- npm run format:check
- npm run build
- make release-check REPO=site
- make attribution-check REPO=site

Chart PR: helmforgedev/charts#659
Issue: helmforgedev/charts#633

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded the playground’s chart selection to include the `docmost` chart, making it available in more filter results when browsing stable or supported charts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->