### PR TITLE
docs(dolibarr): sync playground coverage

### DIFF
--- a/src/pages/playground.astro
+++ b/src/pages/playground.astro
@@ -40,6 +40,7 @@ const siteSyncPlaygroundConfigs: Record<string, string> = {
   'ddns-updater': 'src/data/playground-configs.ts',
   'discount-bandit': 'src/data/playground-configs.ts',
   docmost: 'src/data/playground-configs.ts',
+  dolibarr: 'src/data/playground-configs.ts',
   medikeep: 'src/data/playground-configs.ts',
   memcached: 'src/data/playground-configs.ts',
   notediscovery: 'src/data/playground-configs.ts',


### PR DESCRIPTION
## Summary
- add `dolibarr` to the playground coverage allowlist required by the chart site-sync gate

## Validation
- make site-sync-check CHART=dolibarr
- npm run lint
- npm run format:check
- npm run build
- make release-check REPO=site
- make attribution-check REPO=site

Chart PR: helmforgedev/charts#660
Issue: helmforgedev/charts#633

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for the `dolibarr` chart in the playground, making it available alongside other approved charts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->