### PR TITLE
docs(druid): sync networkpolicy options

### DIFF
--- a/src/pages/docs/charts/druid.mdx
+++ b/src/pages/docs/charts/druid.mdx
@@ -358,14 +358,6 @@ Historical and middlemanager also have:
 | `service.ipFamilies`               | array   | omitted     | Optional ordered Service IP families.                |
 | `ingress.enabled`                  | boolean | `false`     | Enable Ingress (routes to router on port 8888).      |
 | `ingress.ingressClassName`         | string  | `traefik`   | Ingress class name.                                  |
-| `druid.extraCommonProperties`      | string  | `""`        | Extra runtime properties applied to all components.  |
-| `druid.extraEnv`                   | array   | `[]`        | Extra environment variables for all components.      |
-| `podSecurityContext.fsGroup`       | integer | `1000`      | Shared filesystem group for Druid volumes.           |
-| `securityContext.runAsNonRoot`     | boolean | `true`      | Run Druid containers as a non-root user.             |
-| `networkPolicy.enabled`            | boolean | `false`     | Render NetworkPolicy resources.                      |
-| `networkPolicy.egress.extraTo`     | array   | `[]`        | Additional egress peers wrapped in a generated rule. |
-| `networkPolicy.egress.extraEgress` | array   | `[]`        | Additional complete egress rules appended as-is.     |
-| `extraManifests`                   | array   | `[]`        | Extra Kubernetes manifests.                          |
 
 Dual-stack fields are omitted by default so Services inherit the cluster defaults. Set them only when your
 cluster has IPv6 or dual-stack networking enabled:
@@ -377,6 +369,19 @@ service:
     - IPv4
     - IPv6
 ```
+
+### Advanced Configuration
+
+| Parameter                          | Type    | Default | Description                                          |
+| ---------------------------------- | ------- | ------- | ---------------------------------------------------- |
+| `druid.extraCommonProperties`      | string  | `""`    | Extra runtime properties applied to all components.  |
+| `druid.extraEnv`                   | array   | `[]`    | Extra environment variables for all components.      |
+| `podSecurityContext.fsGroup`       | integer | `1000`  | Shared filesystem group for Druid volumes.           |
+| `securityContext.runAsNonRoot`     | boolean | `true`  | Run Druid containers as a non-root user.             |
+| `networkPolicy.enabled`            | boolean | `false` | Render NetworkPolicy resources.                      |
+| `networkPolicy.egress.extraTo`     | array   | `[]`    | Additional egress peers wrapped in a generated rule. |
+| `networkPolicy.egress.extraEgress` | array   | `[]`    | Additional complete egress rules appended as-is.     |
+| `extraManifests`                   | array   | `[]`    | Extra Kubernetes manifests.                          |
 
 ### Gateway API
 

--- a/src/pages/docs/charts/druid.mdx
+++ b/src/pages/docs/charts/druid.mdx
@@ -350,20 +350,22 @@ Historical and middlemanager also have:
 
 ### Service and Ingress
 
-| Parameter                      | Type    | Default     | Description                                         |
-| ------------------------------ | ------- | ----------- | --------------------------------------------------- |
-| `service.type`                 | string  | `ClusterIP` | Service type (routes to router/web console).        |
-| `service.port`                 | integer | `80`        | Service port.                                       |
-| `service.ipFamilyPolicy`       | string  | omitted     | Optional Service IP family policy.                  |
-| `service.ipFamilies`           | array   | omitted     | Optional ordered Service IP families.               |
-| `ingress.enabled`              | boolean | `false`     | Enable Ingress (routes to router on port 8888).     |
-| `ingress.ingressClassName`     | string  | `traefik`   | Ingress class name.                                 |
-| `druid.extraCommonProperties`  | string  | `""`        | Extra runtime properties applied to all components. |
-| `druid.extraEnv`               | array   | `[]`        | Extra environment variables for all components.     |
-| `podSecurityContext.fsGroup`   | integer | `1000`      | Shared filesystem group for Druid volumes.          |
-| `securityContext.runAsNonRoot` | boolean | `true`      | Run Druid containers as a non-root user.            |
-| `networkPolicy.enabled`        | boolean | `false`     | Render NetworkPolicy resources.                     |
-| `extraManifests`               | array   | `[]`        | Extra Kubernetes manifests.                         |
+| Parameter                          | Type    | Default     | Description                                          |
+| ---------------------------------- | ------- | ----------- | ---------------------------------------------------- |
+| `service.type`                     | string  | `ClusterIP` | Service type (routes to router/web console).         |
+| `service.port`                     | integer | `80`        | Service port.                                        |
+| `service.ipFamilyPolicy`           | string  | omitted     | Optional Service IP family policy.                   |
+| `service.ipFamilies`               | array   | omitted     | Optional ordered Service IP families.                |
+| `ingress.enabled`                  | boolean | `false`     | Enable Ingress (routes to router on port 8888).      |
+| `ingress.ingressClassName`         | string  | `traefik`   | Ingress class name.                                  |
+| `druid.extraCommonProperties`      | string  | `""`        | Extra runtime properties applied to all components.  |
+| `druid.extraEnv`                   | array   | `[]`        | Extra environment variables for all components.      |
+| `podSecurityContext.fsGroup`       | integer | `1000`      | Shared filesystem group for Druid volumes.           |
+| `securityContext.runAsNonRoot`     | boolean | `true`      | Run Druid containers as a non-root user.             |
+| `networkPolicy.enabled`            | boolean | `false`     | Render NetworkPolicy resources.                      |
+| `networkPolicy.egress.extraTo`     | array   | `[]`        | Additional egress peers wrapped in a generated rule. |
+| `networkPolicy.egress.extraEgress` | array   | `[]`        | Additional complete egress rules appended as-is.     |
+| `extraManifests`                   | array   | `[]`        | Extra Kubernetes manifests.                          |
 
 Dual-stack fields are omitted by default so Services inherit the cluster defaults. Set them only when your
 cluster has IPv6 or dual-stack networking enabled:
@@ -465,7 +467,8 @@ chown writable Druid directories.
 
 NetworkPolicy is opt-in because enforcement depends on the cluster CNI. When enabled, ingress defaults to
 same-namespace traffic on Druid component ports. Egress rules are optional and can allow DNS, same-namespace
-dependencies, HTTP, HTTPS, and extra peers:
+dependencies, HTTP, HTTPS, additional peers through `networkPolicy.egress.extraTo`, and complete custom egress rules
+through `networkPolicy.egress.extraEgress`:
 
 ```yaml
 networkPolicy:
@@ -477,6 +480,14 @@ networkPolicy:
     allowDNS: true
     allowSameNamespace: true
     allowHTTPS: true
+    extraEgress:
+      - to:
+          - namespaceSelector:
+              matchLabels:
+                kubernetes.io/metadata.name: observability
+        ports:
+          - protocol: TCP
+            port: 4317
 ```
 
 ## More Information

--- a/src/pages/docs/charts/druid.mdx
+++ b/src/pages/docs/charts/druid.mdx
@@ -350,14 +350,14 @@ Historical and middlemanager also have:
 
 ### Service and Ingress
 
-| Parameter                          | Type    | Default     | Description                                          |
-| ---------------------------------- | ------- | ----------- | ---------------------------------------------------- |
-| `service.type`                     | string  | `ClusterIP` | Service type (routes to router/web console).         |
-| `service.port`                     | integer | `80`        | Service port.                                        |
-| `service.ipFamilyPolicy`           | string  | omitted     | Optional Service IP family policy.                   |
-| `service.ipFamilies`               | array   | omitted     | Optional ordered Service IP families.                |
-| `ingress.enabled`                  | boolean | `false`     | Enable Ingress (routes to router on port 8888).      |
-| `ingress.ingressClassName`         | string  | `traefik`   | Ingress class name.                                  |
+| Parameter                  | Type    | Default     | Description                                     |
+| -------------------------- | ------- | ----------- | ----------------------------------------------- |
+| `service.type`             | string  | `ClusterIP` | Service type (routes to router/web console).    |
+| `service.port`             | integer | `80`        | Service port.                                   |
+| `service.ipFamilyPolicy`   | string  | omitted     | Optional Service IP family policy.              |
+| `service.ipFamilies`       | array   | omitted     | Optional ordered Service IP families.           |
+| `ingress.enabled`          | boolean | `false`     | Enable Ingress (routes to router on port 8888). |
+| `ingress.ingressClassName` | string  | `traefik`   | Ingress class name.                             |
 
 Dual-stack fields are omitted by default so Services inherit the cluster defaults. Set them only when your
 cluster has IPv6 or dual-stack networking enabled:

--- a/src/pages/playground.astro
+++ b/src/pages/playground.astro
@@ -41,6 +41,7 @@ const siteSyncPlaygroundConfigs: Record<string, string> = {
   'discount-bandit': 'src/data/playground-configs.ts',
   docmost: 'src/data/playground-configs.ts',
   dolibarr: 'src/data/playground-configs.ts',
+  druid: 'src/data/playground-configs.ts',
   medikeep: 'src/data/playground-configs.ts',
   memcached: 'src/data/playground-configs.ts',
   notediscovery: 'src/data/playground-configs.ts',


### PR DESCRIPTION
## Summary
- document `networkPolicy.egress.extraEgress` for the Druid chart
- add `druid` to the playground coverage allowlist required by site sync

## Validation
- make site-sync-check CHART=druid
- npm run lint
- npm run format:check
- npm run build
- make release-check REPO=site
- make attribution-check REPO=site

Chart PR: helmforgedev/charts#661
Issue: helmforgedev/charts#633

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Simplified the Druid chart docs by separating core `service.*` and `ingress.*` settings from advanced options.
  * Added an **Advanced Configuration** section covering runtime/env options, security settings, NetworkPolicy controls, and extra manifests.
  * Refined NetworkPolicy wording and examples to distinguish `networkPolicy.egress.extraTo` from `networkPolicy.egress.extraEgress` (including an updated YAML sample).

* **Bug Fixes**
  * Updated the playground to load the correct Druid chart configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->