### PR TITLE
docs(drupal): sync playground coverage

### DIFF
--- a/src/pages/playground.astro
+++ b/src/pages/playground.astro
@@ -42,6 +42,7 @@ const siteSyncPlaygroundConfigs: Record<string, string> = {
   docmost: 'src/data/playground-configs.ts',
   dolibarr: 'src/data/playground-configs.ts',
   druid: 'src/data/playground-configs.ts',
+  drupal: 'src/data/playground-configs.ts',
   medikeep: 'src/data/playground-configs.ts',
   memcached: 'src/data/playground-configs.ts',
   notediscovery: 'src/data/playground-configs.ts',


### PR DESCRIPTION
## Summary
- add `drupal` to the playground coverage allowlist required by the chart site-sync gate

## Validation
- make site-sync-check CHART=drupal
- npm run lint
- npm run format:check
- npm run build
- make release-check REPO=site
- make attribution-check REPO=site

Chart PR: helmforgedev/charts#662
Issue: helmforgedev/charts#633

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for the Drupal chart in the playground, making it available in the synced chart selection flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->