### PR TITLE
docs(envoy-gateway): sync networkpolicy options

### DIFF
--- a/src/pages/docs/charts/envoy-gateway.mdx
+++ b/src/pages/docs/charts/envoy-gateway.mdx
@@ -857,7 +857,7 @@ When `security.networkPolicies=true`, the chart creates NetworkPolicies for:
 **Controller Policy**:
 
 - **Ingress**: Allow from proxy pods only
-- **Egress**: Allow to Kubernetes API (443, 6443) and DNS (53)
+- **Egress**: Allow to Kubernetes API (443, 6443), DNS (53), and optional complete custom rules from `security.networkPolicy.extraEgress`
 
 **Proxy Policy**:
 
@@ -874,6 +874,23 @@ When `security.networkPolicies=true`, the chart creates NetworkPolicies for:
 ```bash
 helm install envoy-gateway helmforge/envoy-gateway \
   --set security.networkPolicies=true
+```
+
+Append custom controller egress rules when the controller must reach platform services such as an observability
+collector:
+
+```yaml
+security:
+  networkPolicies: true
+  networkPolicy:
+    extraEgress:
+      - to:
+          - namespaceSelector:
+              matchLabels:
+                kubernetes.io/metadata.name: observability
+        ports:
+          - protocol: TCP
+            port: 4317
 ```
 
 View policies:
@@ -1302,10 +1319,11 @@ All `redis.*` values are forwarded to the redis chart — refer to its documenta
 
 ### Security
 
-| Parameter                       | Description                 | Default |
-| ------------------------------- | --------------------------- | ------- |
-| `security.networkPolicies`      | Enable NetworkPolicies      | `false` |
-| `security.podSecurityStandards` | Enable PodSecurityStandards | `true`  |
+| Parameter                            | Description                                                | Default |
+| ------------------------------------ | ---------------------------------------------------------- | ------- |
+| `security.networkPolicies`           | Enable NetworkPolicies                                     | `false` |
+| `security.networkPolicy.extraEgress` | Additional complete egress rules for the controller policy | `[]`    |
+| `security.podSecurityStandards`      | Enable PodSecurityStandards                                | `true`  |
 
 ### High Availability
 

--- a/src/pages/playground.astro
+++ b/src/pages/playground.astro
@@ -43,6 +43,7 @@ const siteSyncPlaygroundConfigs: Record<string, string> = {
   dolibarr: 'src/data/playground-configs.ts',
   druid: 'src/data/playground-configs.ts',
   drupal: 'src/data/playground-configs.ts',
+  'envoy-gateway': 'src/data/playground-configs.ts',
   medikeep: 'src/data/playground-configs.ts',
   memcached: 'src/data/playground-configs.ts',
   notediscovery: 'src/data/playground-configs.ts',


### PR DESCRIPTION
## Summary
- document `security.networkPolicy.extraEgress` for the Envoy Gateway chart
- add `envoy-gateway` to the playground coverage allowlist required by site sync

## Validation
- make site-sync-check CHART=envoy-gateway
- npm run lint
- npm run format:check
- npm run build
- make release-check REPO=site
- make attribution-check REPO=site

Chart PR: helmforgedev/charts#663
Issue: helmforgedev/charts#633

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Envoy Gateway to the playground chart list, making it available in the charts browsing experience.

* **Documentation**
  * Expanded Envoy Gateway security docs with guidance for customizing NetworkPolicy egress rules.
  * Added an example showing how to allow controller access to an external observability service.
  * Updated the configuration reference to include the new egress customization option.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->