### PR TITLE
docs(fastmcp-server): sync networkpolicy options

### DIFF
--- a/src/pages/docs/charts/fastmcp-server.mdx
+++ b/src/pages/docs/charts/fastmcp-server.mdx
@@ -164,6 +164,13 @@ ingress:
 
 networkPolicy:
   enabled: true
+  extraEgress:
+    - to:
+        - ipBlock:
+            cidr: 10.0.0.0/8
+      ports:
+        - protocol: TCP
+          port: 443
 
 resources:
   requests:
@@ -198,6 +205,23 @@ auth:
 ```
 
 When using JWT with NetworkPolicy or cluster egress controls, allow the JWKS endpoint.
+
+## Network Policy
+
+`networkPolicy.enabled=true` restricts inbound traffic to the MCP service port. Use `networkPolicy.extraEgress` when
+tools, S3/Git sources, JWT JWKS discovery, or package installation need outbound access to specific destinations.
+
+```yaml
+networkPolicy:
+  enabled: true
+  extraEgress:
+    - to:
+        - ipBlock:
+            cidr: 10.0.0.0/8
+      ports:
+        - protocol: TCP
+          port: 443
+```
 
 ## Gateway API
 
@@ -271,6 +295,7 @@ curl http://localhost:8000/mcp
 | `gatewayAPI.enabled`                          | `false`                              | Render an HTTPRoute.                             |
 | `ingress.enabled`                             | `false`                              | Render an Ingress.                               |
 | `networkPolicy.enabled`                       | `false`                              | Render a NetworkPolicy for the MCP port.         |
+| `networkPolicy.extraEgress`                   | `[]`                                 | Additional NetworkPolicy egress rules.           |
 | `autoscaling.enabled`                         | `false`                              | Render an HPA.                                   |
 | `pdb.enabled`                                 | `false`                              | Render a PodDisruptionBudget.                    |
 

--- a/src/pages/playground.astro
+++ b/src/pages/playground.astro
@@ -44,6 +44,7 @@ const siteSyncPlaygroundConfigs: Record<string, string> = {
   druid: 'src/data/playground-configs.ts',
   drupal: 'src/data/playground-configs.ts',
   'envoy-gateway': 'src/data/playground-configs.ts',
+  'fastmcp-server': 'src/data/playground-configs.ts',
   medikeep: 'src/data/playground-configs.ts',
   memcached: 'src/data/playground-configs.ts',
   notediscovery: 'src/data/playground-configs.ts',


### PR DESCRIPTION
## Summary
- document `networkPolicy.extraEgress` for `fastmcp-server`
- add `fastmcp-server` to the playground coverage allowlist

## Validation
- make site-sync-check CHART=fastmcp-server
- npm run lint
- npm run format:check
- npm run build
- make release-check REPO=site
- make attribution-check REPO=site

Chart PR: helmforgedev/charts#665
Issue: helmforgedev/charts#633

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added documentation for configuring extra outbound network access in the FastMCP Server chart.
  * The FastMCP Server chart is now available in the playground.

* **Documentation**
  * Expanded the production example with an egress rule example.
  * Added a new section explaining how network policy affects inbound and outbound traffic.
  * Documented the new extra egress setting in the values reference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->