### PR TITLE
docs(generic): sync template standards updates

### DIFF
--- a/src/data/playground-configs.ts
+++ b/src/data/playground-configs.ts
@@ -8,6 +8,134 @@
 // field definitions from values.schema.json.
 
 export const chartConfigs: Record<string, ChartConfig> = {
+  generic: [
+    {
+      name: 'Workload',
+      fields: [
+        {
+          label: 'Replicas',
+          key: 'replicaCount',
+          type: 'number',
+          default: '1',
+          description: 'Workload replicas when HPA is disabled',
+        },
+        {
+          label: 'Workload Type',
+          key: 'workload.type',
+          type: 'select',
+          default: 'Deployment',
+          options: ['Deployment', 'StatefulSet', 'DaemonSet'],
+          description: 'Primary workload controller',
+        },
+        {
+          label: 'Image Repository',
+          key: 'image.repository',
+          type: 'text',
+          default: 'docker.io/library/nginx',
+          description: 'Container image repository',
+        },
+        {
+          label: 'Image Tag',
+          key: 'image.tag',
+          type: 'text',
+          default: '1.31.1',
+          description: 'Container image tag',
+        },
+      ],
+    },
+    {
+      name: 'Ingress',
+      collapsible: true,
+      gateField: 'ingress.enabled',
+      fields: [
+        {
+          label: 'Hostname',
+          key: 'ingress.hosts[0].host',
+          type: 'text',
+          default: 'app.example.com',
+          description: 'Ingress host',
+        },
+        {
+          label: 'Path',
+          key: 'ingress.hosts[0].paths[0].path',
+          type: 'text',
+          default: '/',
+          description: 'Ingress path',
+        },
+        {
+          label: 'Path Type',
+          key: 'ingress.hosts[0].paths[0].pathType',
+          type: 'select',
+          default: 'Prefix',
+          options: ['Prefix', 'Exact', 'ImplementationSpecific'],
+          description: 'Ingress path matching mode',
+        },
+        {
+          label: 'Ingress Class',
+          key: 'ingress.ingressClassName',
+          type: 'select',
+          default: 'traefik',
+          options: ['', 'traefik', 'nginx'],
+          description: 'Ingress controller class',
+        },
+      ],
+    },
+    {
+      name: 'Resources',
+      collapsible: true,
+      fields: [
+        {
+          label: 'CPU Request',
+          key: 'resources.requests.cpu',
+          type: 'text',
+          default: '',
+          description: 'Default container CPU request',
+        },
+        {
+          label: 'Memory Request',
+          key: 'resources.requests.memory',
+          type: 'text',
+          default: '',
+          description: 'Default container memory request',
+        },
+        {
+          label: 'CPU Limit',
+          key: 'resources.limits.cpu',
+          type: 'text',
+          default: '',
+          description: 'Default container CPU limit',
+        },
+        {
+          label: 'Memory Limit',
+          key: 'resources.limits.memory',
+          type: 'text',
+          default: '',
+          description: 'Default container memory limit',
+        },
+      ],
+    },
+    {
+      name: 'NetworkPolicy',
+      collapsible: true,
+      gateField: 'networkPolicy.enabled',
+      fields: [
+        {
+          label: 'Default Deny',
+          key: 'networkPolicy.defaultDeny',
+          type: 'toggle',
+          default: 'false',
+          description: 'Include both Ingress and Egress policy types',
+        },
+        {
+          label: 'DNS Egress',
+          key: 'networkPolicy.extraEgress[0].ports[0].port',
+          type: 'number',
+          default: '53',
+          description: 'Example extra egress DNS port',
+        },
+      ],
+    },
+  ],
   apache: [
     {
       name: 'General',

--- a/src/pages/docs/charts/generic.mdx
+++ b/src/pages/docs/charts/generic.mdx
@@ -278,7 +278,7 @@ Kubernetes or operator API fields inside the corresponding value.
 | `service.extraPorts`       | `[]`      | Extra ports on the primary Service.                                                |
 | `services[]`               | `[]`      | Additional Service resources.                                                      |
 | `ingress.enabled`          | `false`   | Render Ingress.                                                                    |
-| `ingress.ingressClassName` | `traefik` | Ingress class name.                                                                |
+| `ingress.ingressClassName` | `traefik` | Ingress class name. Set `""` to omit `spec.ingressClassName`.                      |
 | `ingress.annotations`      | `{}`      | Annotations for Ingress.                                                           |
 | `ingress.defaultBackend`   | `{}`      | Optional default backend for Ingress.                                              |
 | `ingress.hosts[]`          | `[]`      | Ingress host rules; paths require explicit `backend` when `service.enabled=false`. |
@@ -288,29 +288,30 @@ Kubernetes or operator API fields inside the corresponding value.
 
 ### Security and Storage
 
-| Parameter                                     | Default | Description                                                  |
-| --------------------------------------------- | ------- | ------------------------------------------------------------ |
-| `serviceAccount.create`                       | `false` | Render a ServiceAccount.                                     |
-| `serviceAccount.automountServiceAccountToken` | `false` | Mount API token into pods.                                   |
-| `resources`                                   | `{}`    | Default container resources.                                 |
-| `livenessProbe`                               | `{}`    | Global liveness probe for the first container.               |
-| `readinessProbe`                              | `{}`    | Global readiness probe for the first container.              |
-| `startupProbe`                                | `{}`    | Global startup probe for the first container.                |
-| `podSecurityContext`                          | `{}`    | Pod-level security context.                                  |
-| `securityContext`                             | `{}`    | Container-level security context.                            |
-| `securityPreset`                              | `""`    | Optional `baseline` or `restricted` security context preset. |
-| `configMaps[]`                                | `[]`    | Chart-managed ConfigMaps.                                    |
-| `secrets[]`                                   | `[]`    | Chart-managed Secrets.                                       |
-| `externalSecrets.enabled`                     | `false` | Render ExternalSecret resources.                             |
-| `sealedSecrets.enabled`                       | `false` | Render SealedSecret resources.                               |
-| `rbac.create`                                 | `false` | Render Role and RoleBinding.                                 |
-| `rbac.clusterRole.create`                     | `false` | Render a ClusterRole and binding.                            |
-| `networkPolicy.enabled`                       | `false` | Render NetworkPolicy.                                        |
-| `persistence.volumes[]`                       | `[]`    | Pod volume definitions.                                      |
-| `persistence.mounts[]`                        | `[]`    | Container volume mounts.                                     |
-| `persistence.storage[]`                       | `[]`    | Legacy PV/PVC helper definitions.                            |
-| `persistence.persistentVolumeClaims[]`        | `[]`    | Declarative PVCs.                                            |
-| `persistence.persistentVolumes[]`             | `[]`    | Explicit opt-in PVs.                                         |
+| Parameter                                     | Default | Description                                                    |
+| --------------------------------------------- | ------- | -------------------------------------------------------------- |
+| `serviceAccount.create`                       | `false` | Render a ServiceAccount.                                       |
+| `serviceAccount.automountServiceAccountToken` | `false` | Mount API token into pods.                                     |
+| `resources`                                   | `{}`    | Default container resources.                                   |
+| `livenessProbe`                               | `{}`    | Global liveness probe for the first container.                 |
+| `readinessProbe`                              | `{}`    | Global readiness probe for the first container.                |
+| `startupProbe`                                | `{}`    | Global startup probe for the first container.                  |
+| `podSecurityContext`                          | `{}`    | Pod-level security context.                                    |
+| `securityContext`                             | `{}`    | Container-level security context.                              |
+| `securityPreset`                              | `""`    | Optional `baseline` or `restricted` security context preset.   |
+| `configMaps[]`                                | `[]`    | Chart-managed ConfigMaps.                                      |
+| `secrets[]`                                   | `[]`    | Chart-managed Secrets.                                         |
+| `externalSecrets.enabled`                     | `false` | Render ExternalSecret resources.                               |
+| `sealedSecrets.enabled`                       | `false` | Render SealedSecret resources.                                 |
+| `rbac.create`                                 | `false` | Render Role and RoleBinding.                                   |
+| `rbac.clusterRole.create`                     | `false` | Render a ClusterRole and binding.                              |
+| `networkPolicy.enabled`                       | `false` | Render NetworkPolicy.                                          |
+| `networkPolicy.extraEgress`                   | `[]`    | Additional egress rules appended after `networkPolicy.egress`. |
+| `persistence.volumes[]`                       | `[]`    | Pod volume definitions.                                        |
+| `persistence.mounts[]`                        | `[]`    | Container volume mounts.                                       |
+| `persistence.storage[]`                       | `[]`    | Legacy PV/PVC helper definitions.                              |
+| `persistence.persistentVolumeClaims[]`        | `[]`    | Declarative PVCs.                                              |
+| `persistence.persistentVolumes[]`             | `[]`    | Explicit opt-in PVs.                                           |
 
 ### Scheduling and Rollout
 

--- a/src/pages/playground.astro
+++ b/src/pages/playground.astro
@@ -46,6 +46,7 @@ const siteSyncPlaygroundConfigs: Record<string, string> = {
   'envoy-gateway': 'src/data/playground-configs.ts',
   'fastmcp-server': 'src/data/playground-configs.ts',
   flowise: 'src/data/playground-configs.ts',
+  generic: 'src/data/playground-configs.ts',
   medikeep: 'src/data/playground-configs.ts',
   memcached: 'src/data/playground-configs.ts',
   notediscovery: 'src/data/playground-configs.ts',


### PR DESCRIPTION
## Summary
- document Generic ingress class behavior and `networkPolicy.extraEgress`
- add Generic to the playground registry with curated defaults
- sync the configuration reference for the new NetworkPolicy value

## Validation
- make site-sync-check CHART=generic
- npm run lint
- npm run format:check
- npm run build
- make release-check REPO=site
- make attribution-check REPO=site

Charts PR: helmforgedev/charts#667
Issue: helmforgedev/charts#633

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new generic chart configuration to the playground, making it available alongside existing charts.
  * Included curated setup options for workloads, ingress, resources, and network policy in the generic chart.

* **Documentation**
  * Clarified ingress behavior for the generic chart when no ingress class is set.
  * Reformatted the security and storage reference table for easier reading.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->