### PR TITLE
docs(kubernetes-mcp-server): sync template standards updates

### DIFF
--- a/src/data/playground-configs.ts
+++ b/src/data/playground-configs.ts
@@ -8678,6 +8678,34 @@ export const chartConfigs: Record<string, ChartConfig> = {
         },
       ],
     },
+    {
+      name: 'DNS Egress',
+      collapsible: true,
+      gateField: 'networkPolicy.enabled',
+      fields: [
+        {
+          label: 'DNS Namespace',
+          key: 'networkPolicy.dnsEgressPeers[0].namespaceSelector.matchLabels.kubernetes\\.io/metadata\\.name',
+          type: 'text',
+          default: 'kube-system',
+          description: 'Namespace label for cluster DNS pods',
+        },
+        {
+          label: 'DNS Pod Label',
+          key: 'networkPolicy.dnsEgressPeers[0].podSelector.matchLabels.k8s-app',
+          type: 'text',
+          default: 'kube-dns',
+          description: 'Pod label for cluster DNS',
+        },
+        {
+          label: 'API Egress Port',
+          key: 'networkPolicy.extraEgress[0].ports[0].port',
+          type: 'number',
+          default: '6443',
+          description: 'Additional Kubernetes API egress port',
+        },
+      ],
+    },
   ],
   'fastmcp-server': [
     {

--- a/src/pages/docs/charts/kubernetes-mcp-server.mdx
+++ b/src/pages/docs/charts/kubernetes-mcp-server.mdx
@@ -10,7 +10,7 @@ Deploy [Kubernetes MCP Server](https://github.com/containers/kubernetes-mcp-serv
 
 ## Overview
 
-The HelmForge chart uses the official `ghcr.io/containers/kubernetes-mcp-server:v0.0.62` image and serves HTTP on port `8080`.
+The HelmForge chart uses the official `ghcr.io/containers/kubernetes-mcp-server:v0.0.63` image and serves HTTP on port `8080`.
 This workload is a control-plane bridge: its effective permissions are the Kubernetes RBAC permissions granted to its ServiceAccount.
 
 Defaults are inspection-oriented:
@@ -47,16 +47,21 @@ Storage and scaling:
 - `persistence.enabled`: optional data volume. The server is stateless by default.
 - `persistence.size`, `persistence.storageClass`, `persistence.accessModes`: generated PVC settings.
 - `persistence.existingClaim`, `persistence.mountPath`: existing claim and mount path.
-- `replicaCount > 1` with persistence requires `ReadWriteMany` or `persistence.enabled=false`.
+- `replicaCount > 1` with chart-created persistence requires `ReadWriteMany` or `persistence.enabled=false`.
+  When `persistence.existingClaim` is set, the external claim controls access modes.
 
 Exposure and operations:
 
 - `serviceAccount.create`, `serviceAccount.name`, `serviceAccount.annotations`, `serviceAccount.automountServiceAccountToken`.
 - `service.type`, `service.port`, `service.annotations`, `service.ipFamilyPolicy`, `service.ipFamilies`.
-- `ingress.enabled`, `ingress.ingressClassName`, `ingress.annotations`, `ingress.hosts`, `ingress.tls`.
+- `ingress.enabled`, `ingress.ingressClassName`, `ingress.annotations`, `ingress.hosts`, `ingress.tls`. Set
+  `ingress.ingressClassName: ""` to omit `spec.ingressClassName`.
 - `gateway.enabled`, `gateway.parentRefs`, `gateway.hostnames`, `gateway.path`, `gateway.pathType`.
 - `pdb.enabled`, `pdb.minAvailable`.
-- `networkPolicy.enabled`, `networkPolicy.ingressFrom`.
+- `networkPolicy.enabled`, `networkPolicy.ingressFrom`, `networkPolicy.dnsEgressPeers`, `networkPolicy.extraEgress`.
+  Enabling only `networkPolicy.enabled` creates an ingress-only policy.
+  Setting `networkPolicy.enabled=true` enables egress isolation with built-in DNS and HTTPS allowances; `networkPolicy.extraEgress` appends the supplied rules.
+  `networkPolicy.dnsEgressPeers` defaults to kube-system/kube-dns and can be changed for clusters with different DNS labels.
 - `probes.startup`, `probes.liveness`, `probes.readiness`: enable flags and timing values.
 - `resources`, `podSecurityContext`, `securityContext`, `nodeSelector`, `tolerations`, `affinity`.
 - `topologySpreadConstraints`, `priorityClassName`, `terminationGracePeriodSeconds`.

--- a/src/pages/playground.astro
+++ b/src/pages/playground.astro
@@ -48,6 +48,7 @@ const siteSyncPlaygroundConfigs: Record<string, string> = {
   flowise: 'src/data/playground-configs.ts',
   generic: 'src/data/playground-configs.ts',
   'github-mcp-server': 'src/data/playground-configs.ts',
+  'kubernetes-mcp-server': 'src/data/playground-configs.ts',
   medikeep: 'src/data/playground-configs.ts',
   memcached: 'src/data/playground-configs.ts',
   notediscovery: 'src/data/playground-configs.ts',


### PR DESCRIPTION
## Summary
- sync Kubernetes MCP Server docs to chart defaults, including v0.0.63
- document optional ingressClassName rendering, `networkPolicy.enabled` baseline DNS/HTTPS egress, configurable `networkPolicy.dnsEgressPeers`, and additive `networkPolicy.extraEgress` behavior
- expose Kubernetes MCP Server in the playground registry with curated ingress, NetworkPolicy, DNS egress, and API egress controls

## Validation
- make site-sync-check CHART=kubernetes-mcp-server
- npm run lint
- npm run format:check
- npm run build
- make release-check REPO=site
- make attribution-check REPO=site

Chart PR: helmforgedev/charts#669
Issue: helmforgedev/charts#633

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added playground support for the Kubernetes MCP Server chart.
  * Expanded chart settings with a new DNS egress section for network policy configuration.

* **Documentation**
  * Updated Kubernetes MCP Server docs to reflect the latest image version.
  * Clarified persistence, scaling, and network policy behavior, including egress allowances and access mode requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->