### PR TITLE
docs(langflow): sync template standards updates

### DIFF
--- a/src/data/playground-configs.ts
+++ b/src/data/playground-configs.ts
@@ -4772,6 +4772,34 @@ export const chartConfigs: Record<string, ChartConfig> = {
         },
       ],
     },
+    {
+      name: 'DNS Egress',
+      collapsible: true,
+      gateField: 'networkPolicy.enabled',
+      fields: [
+        {
+          label: 'DNS Namespace',
+          key: 'networkPolicy.dnsEgressPeers[0].namespaceSelector.matchLabels.kubernetes\\.io/metadata\\.name',
+          type: 'text',
+          default: 'kube-system',
+          description: 'Namespace label for cluster DNS pods',
+        },
+        {
+          label: 'DNS Pod Label',
+          key: 'networkPolicy.dnsEgressPeers[0].podSelector.matchLabels.k8s-app',
+          type: 'text',
+          default: 'kube-dns',
+          description: 'Pod label for cluster DNS',
+        },
+        {
+          label: 'Extra Egress Port',
+          key: 'networkPolicy.extraEgress[0].ports[0].port',
+          type: 'number',
+          default: '5432',
+          description: 'Additional egress port',
+        },
+      ],
+    },
   ],
   vaultwarden: [
     {

--- a/src/data/playground-configs.ts
+++ b/src/data/playground-configs.ts
@@ -4773,10 +4773,17 @@ export const chartConfigs: Record<string, ChartConfig> = {
       ],
     },
     {
-      name: 'DNS Egress',
+      name: 'Network Policy',
       collapsible: true,
       gateField: 'networkPolicy.enabled',
       fields: [
+        {
+          label: 'Network Policy',
+          key: 'networkPolicy.enabled',
+          type: 'toggle',
+          default: 'false',
+          description: 'Restrict ingress and enable egress isolation',
+        },
         {
           label: 'DNS Namespace',
           key: 'networkPolicy.dnsEgressPeers[0].namespaceSelector.matchLabels.kubernetes\\.io/metadata\\.name',
@@ -4790,6 +4797,13 @@ export const chartConfigs: Record<string, ChartConfig> = {
           type: 'text',
           default: 'kube-dns',
           description: 'Pod label for cluster DNS',
+        },
+        {
+          label: 'Extra Egress CIDR',
+          key: 'networkPolicy.extraEgress[0].to[0].ipBlock.cidr',
+          type: 'text',
+          default: '10.0.0.0/8',
+          description: 'Additional database, provider, or proxy egress destination',
         },
         {
           label: 'Extra Egress Port',

--- a/src/data/playground-configs.ts
+++ b/src/data/playground-configs.ts
@@ -4778,13 +4778,6 @@ export const chartConfigs: Record<string, ChartConfig> = {
       gateField: 'networkPolicy.enabled',
       fields: [
         {
-          label: 'Network Policy',
-          key: 'networkPolicy.enabled',
-          type: 'toggle',
-          default: 'false',
-          description: 'Restrict ingress and enable egress isolation',
-        },
-        {
           label: 'DNS Namespace',
           key: 'networkPolicy.dnsEgressPeers[0].namespaceSelector.matchLabels.kubernetes\\.io/metadata\\.name',
           type: 'text',

--- a/src/pages/docs/charts/langflow.mdx
+++ b/src/pages/docs/charts/langflow.mdx
@@ -11,7 +11,7 @@ integrations.
 
 ## Overview
 
-The HelmForge Langflow chart uses the official `docker.io/langflowai/langflow:1.10.0` image and exposes the web/API server on port `7860`.
+The HelmForge Langflow chart uses the official `docker.io/langflowai/langflow:1.10.1` image and exposes the web/API server on port `7860`.
 The default deployment persists `/app/langflow` because flows, local SQLite state, provider settings, and local configuration are not stateless.
 
 The chart generates the core Langflow runtime environment:
@@ -19,8 +19,8 @@ The chart generates the core Langflow runtime environment:
 - `LANGFLOW_HOST=0.0.0.0`
 - `LANGFLOW_PORT`
 - `LANGFLOW_CONFIG_DIR`
-- `LANGFLOW_SAVE_DB_IN_CONFIG_DIR=true`
-- `LANGFLOW_OPEN_BROWSER=false`
+- `LANGFLOW_SAVE_DB_IN_CONFIG_DIR`
+- `LANGFLOW_OPEN_BROWSER`
 
 ## Configuration Reference
 
@@ -46,7 +46,7 @@ Storage and scaling:
 
 - `persistence.enabled`, `persistence.size`, `persistence.storageClass`: local config and SQLite storage.
 - `persistence.accessModes`: generated PVC access modes. Multi-replica persistent deployments require `ReadWriteMany`.
-- `persistence.existingClaim`: mount an existing claim instead of creating one.
+- `persistence.existingClaim`: mount an existing claim instead of creating one. With `replicaCount > 1`, the external claim controls access modes.
 - `persistence.mountPath`: Langflow config directory, default `/app/langflow`.
 - `pdb.enabled`, `pdb.minAvailable`: disruption budget for scaled deployments.
 
@@ -54,9 +54,13 @@ Exposure and operations:
 
 - `serviceAccount.create`, `serviceAccount.name`, `serviceAccount.annotations`, `serviceAccount.automountServiceAccountToken`.
 - `service.type`, `service.port`, `service.annotations`, `service.ipFamilyPolicy`, `service.ipFamilies`.
-- `ingress.enabled`, `ingress.ingressClassName`, `ingress.annotations`, `ingress.hosts`, `ingress.tls`.
+- `ingress.enabled`, `ingress.ingressClassName`, `ingress.annotations`, `ingress.hosts`, `ingress.tls`. Set
+  `ingress.ingressClassName: ""` to omit `spec.ingressClassName`.
 - `gateway.enabled`, `gateway.parentRefs`, `gateway.hostnames`, `gateway.path`, `gateway.pathType`.
-- `networkPolicy.enabled`, `networkPolicy.ingressFrom`.
+- `networkPolicy.enabled`, `networkPolicy.ingressFrom`, `networkPolicy.dnsEgressPeers`, `networkPolicy.extraEgress`.
+  Enabling `networkPolicy.enabled` creates ingress restrictions plus egress isolation with built-in DNS and HTTPS allowances.
+  `networkPolicy.dnsEgressPeers` defaults to kube-system/kube-dns and can be changed for clusters with different DNS labels.
+  `networkPolicy.extraEgress` appends database, provider, or proxy rules after the built-in allowances.
 - `probes.startup`, `probes.liveness`, `probes.readiness`: enable flags and timing values.
 - `resources`, `podSecurityContext`, `securityContext`, `nodeSelector`, `tolerations`, `affinity`.
 - `topologySpreadConstraints`, `priorityClassName`, `terminationGracePeriodSeconds`.
@@ -95,6 +99,13 @@ persistence:
 
 networkPolicy:
   enabled: true
+  dnsEgressPeers:
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: kube-system
+      podSelector:
+        matchLabels:
+          k8s-app: kube-dns
 ```
 
 ## Secrets
@@ -124,7 +135,7 @@ pdb:
 ```
 
 The chart blocks `replicaCount > 1` unless `database.url` or `database.existingSecret` is configured.
-When persistence stays enabled for multiple replicas, the shared config directory must use `ReadWriteMany`; the default generated
+When chart-created persistence stays enabled for multiple replicas, the shared config directory must use `ReadWriteMany`; the default generated
 `ReadWriteOnce` PVC is rejected to avoid multi-attach failures on multi-node clusters.
 
 ## Backup

--- a/src/pages/playground.astro
+++ b/src/pages/playground.astro
@@ -49,6 +49,7 @@ const siteSyncPlaygroundConfigs: Record<string, string> = {
   generic: 'src/data/playground-configs.ts',
   'github-mcp-server': 'src/data/playground-configs.ts',
   'kubernetes-mcp-server': 'src/data/playground-configs.ts',
+  langflow: 'src/data/playground-configs.ts',
   medikeep: 'src/data/playground-configs.ts',
   memcached: 'src/data/playground-configs.ts',
   notediscovery: 'src/data/playground-configs.ts',


### PR DESCRIPTION
## Summary
- Sync Langflow chart docs with the NetworkPolicy egress behavior from helmforgedev/charts#670.
- Document `networkPolicy.dnsEgressPeers` and the default kube-system/kube-dns DNS peer selection.
- Add Langflow Network Policy controls to the playground config.

## Related
- Chart PR: helmforgedev/charts#670.

## Validation
- `make site-sync-check CHART=langflow`
- `npm run lint`
- `npm run format:check`
- `npm run build`
- `make release-check REPO=site`
- `make attribution-check REPO=site`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Langflow to the playground chart selection.
  * Introduced new network policy settings, including DNS egress controls and extra egress CIDR/port options.
* **Bug Fixes**
  * Improved the Olivetin ingress class dropdown with an empty option and reordered choices.
* **Documentation**
  * Updated Langflow chart documentation with the pinned image version and expanded guidance on core environment variables, persistence behavior, ingress class handling, and network policy examples (including DNS egress peers).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->