### PR TITLE
docs(memos): sync template standards updates

### DIFF
--- a/src/data/playground-configs.ts
+++ b/src/data/playground-configs.ts
@@ -8401,7 +8401,7 @@ export const chartConfigs: Record<string, ChartConfig> = {
           key: 'ingress.ingressClassName',
           type: 'select',
           default: 'traefik',
-          options: ['traefik', 'nginx'],
+          options: ['', 'traefik', 'nginx'],
           description: 'Ingress controller class',
         },
         {

--- a/src/data/playground-configs.ts
+++ b/src/data/playground-configs.ts
@@ -8421,6 +8421,34 @@ export const chartConfigs: Record<string, ChartConfig> = {
         },
       ],
     },
+    {
+      name: 'Network Policy',
+      collapsible: true,
+      gateField: 'networkPolicy.enabled',
+      fields: [
+        {
+          label: 'Egress Isolation',
+          key: 'networkPolicy.egressIsolation',
+          type: 'toggle',
+          default: 'false',
+          description: 'Render baseline DNS and HTTPS egress rules',
+        },
+        {
+          label: 'HTTPS IPv4 CIDR',
+          key: 'networkPolicy.httpsEgress[0].ipBlock.cidr',
+          type: 'text',
+          default: '0.0.0.0/0',
+          description: 'IPv4 HTTPS egress destination',
+        },
+        {
+          label: 'HTTPS IPv6 CIDR',
+          key: 'networkPolicy.httpsEgress[1].ipBlock.cidr',
+          type: 'text',
+          default: '::/0',
+          description: 'IPv6 HTTPS egress destination',
+        },
+      ],
+    },
   ],
   notediscovery: [
     {

--- a/src/pages/docs/charts/memos.mdx
+++ b/src/pages/docs/charts/memos.mdx
@@ -49,10 +49,13 @@ Exposure and operations:
 
 - `serviceAccount.create`, `serviceAccount.name`, `serviceAccount.annotations`, `serviceAccount.automountServiceAccountToken`.
 - `service.type`, `service.port`, `service.annotations`, `service.ipFamilyPolicy`, `service.ipFamilies`.
-- `ingress.enabled`, `ingress.ingressClassName`, `ingress.annotations`, `ingress.hosts`, `ingress.tls`.
+- `ingress.enabled`, `ingress.ingressClassName`, `ingress.annotations`, `ingress.hosts`, `ingress.tls`. Set
+  `ingress.ingressClassName: ""` to omit `spec.ingressClassName`.
 - `gateway.enabled`, `gateway.parentRefs`, `gateway.hostnames`, `gateway.path`, `gateway.pathType`.
 - `pdb.enabled`, `pdb.minAvailable`.
-- `networkPolicy.enabled`, `networkPolicy.ingressFrom`.
+- `networkPolicy.enabled`, `networkPolicy.ingressFrom`, `networkPolicy.extraEgress`.
+  Enabling only `networkPolicy.enabled` creates an ingress-only policy.
+  Setting `networkPolicy.extraEgress` adds egress isolation with built-in DNS and HTTPS allowances before appending the supplied rules.
 - `probes.startup`, `probes.liveness`, `probes.readiness`: enable flags and timing values.
 - `resources`, `podSecurityContext`, `securityContext`, `nodeSelector`, `tolerations`, `affinity`.
 - `topologySpreadConstraints`, `priorityClassName`, `terminationGracePeriodSeconds`.

--- a/src/pages/docs/charts/memos.mdx
+++ b/src/pages/docs/charts/memos.mdx
@@ -54,10 +54,12 @@ Exposure and operations:
 - `gateway.enabled`, `gateway.parentRefs`, `gateway.hostnames`, `gateway.path`, `gateway.pathType`.
 - `pdb.enabled`, `pdb.minAvailable`.
 - `networkPolicy.enabled`, `networkPolicy.ingressFrom`, `networkPolicy.egressIsolation`, `networkPolicy.dnsEgress`,
-  `networkPolicy.extraEgress`.
+  `networkPolicy.httpsEgress`, `networkPolicy.extraEgress`.
   Enabling only `networkPolicy.enabled` creates an ingress-only policy.
   Set `networkPolicy.egressIsolation=true` for baseline DNS and HTTPS egress rules without custom rules.
   `networkPolicy.dnsEgress` defaults to `kube-system` pods labeled `k8s-app: kube-dns` and can be overridden for different DNS labels.
+  `networkPolicy.httpsEgress` defaults to IPv4 and IPv6 internet destinations on port 443 and can be overridden for restricted webhook or
+  integration destinations.
   Setting `networkPolicy.extraEgress` also enables egress isolation and appends the supplied rules.
 - `probes.startup`, `probes.liveness`, `probes.readiness`: enable flags and timing values.
 - `resources`, `podSecurityContext`, `securityContext`, `nodeSelector`, `tolerations`, `affinity`.
@@ -106,6 +108,7 @@ networkPolicy:
 ```
 
 Set `memos.instanceUrl` when Memos is behind Ingress, Gateway API, or another reverse proxy.
+Set `networkPolicy.egressIsolation=true` when outbound DNS and HTTPS should be explicitly allowed by the chart-managed NetworkPolicy.
 
 ## External Database
 

--- a/src/pages/docs/charts/memos.mdx
+++ b/src/pages/docs/charts/memos.mdx
@@ -53,9 +53,12 @@ Exposure and operations:
   `ingress.ingressClassName: ""` to omit `spec.ingressClassName`.
 - `gateway.enabled`, `gateway.parentRefs`, `gateway.hostnames`, `gateway.path`, `gateway.pathType`.
 - `pdb.enabled`, `pdb.minAvailable`.
-- `networkPolicy.enabled`, `networkPolicy.ingressFrom`, `networkPolicy.extraEgress`.
+- `networkPolicy.enabled`, `networkPolicy.ingressFrom`, `networkPolicy.egressIsolation`, `networkPolicy.dnsEgress`,
+  `networkPolicy.extraEgress`.
   Enabling only `networkPolicy.enabled` creates an ingress-only policy.
-  Setting `networkPolicy.extraEgress` adds egress isolation with built-in DNS and HTTPS allowances before appending the supplied rules.
+  Set `networkPolicy.egressIsolation=true` for baseline DNS and HTTPS egress rules without custom rules.
+  `networkPolicy.dnsEgress` defaults to `kube-system` pods labeled `k8s-app: kube-dns` and can be overridden for different DNS labels.
+  Setting `networkPolicy.extraEgress` also enables egress isolation and appends the supplied rules.
 - `probes.startup`, `probes.liveness`, `probes.readiness`: enable flags and timing values.
 - `resources`, `podSecurityContext`, `securityContext`, `nodeSelector`, `tolerations`, `affinity`.
 - `topologySpreadConstraints`, `priorityClassName`, `terminationGracePeriodSeconds`.

--- a/src/pages/playground.astro
+++ b/src/pages/playground.astro
@@ -51,6 +51,7 @@ const siteSyncPlaygroundConfigs: Record<string, string> = {
   'kubernetes-mcp-server': 'src/data/playground-configs.ts',
   langflow: 'src/data/playground-configs.ts',
   medikeep: 'src/data/playground-configs.ts',
+  memos: 'src/data/playground-configs.ts',
   memcached: 'src/data/playground-configs.ts',
   notediscovery: 'src/data/playground-configs.ts',
   poznote: 'src/data/playground-configs.ts',


### PR DESCRIPTION
## Summary
- document optional ingressClassName rendering and networkPolicy.extraEgress behavior for Memos
- expose Memos NetworkPolicy controls and empty ingress class option in the playground registry
- register Memos in the playground site-sync map

## Validation
- make site-sync-check CHART=memos
- npm run lint
- npm run format:check
- npm run build

Chart PR: helmforgedev/charts#671
Issue: helmforgedev/charts#633

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Updated the `memos` chart playground with an expanded “Ingress Class” selector that includes an empty option.
  * Added NetworkPolicy controls to the `memos` playground (shown when enabled), including “Egress Isolation” and HTTPS IPv4/IPv6 CIDR fields (defaults: disabled, `0.0.0.0/0`, `::/0`).
  * Included `memos` in site-synced playground chart filtering.
* **Documentation**
  * Expanded the `memos` configuration reference for Ingress and NetworkPolicy, including behavior when Ingress Class is empty and how egress isolation affects outbound DNS/HTTPS.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->