### PR TITLE
docs(notediscovery): sync template standards updates

### DIFF
--- a/src/data/playground-configs.ts
+++ b/src/data/playground-configs.ts
@@ -8563,6 +8563,34 @@ export const chartConfigs: Record<string, ChartConfig> = {
         },
       ],
     },
+    {
+      name: 'Network Policy',
+      collapsible: true,
+      gateField: 'networkPolicy.enabled',
+      fields: [
+        {
+          label: 'Ingress Namespace',
+          key: 'networkPolicy.ingressFrom[0].namespaceSelector.matchLabels.kubernetes\\.io/metadata\\.name',
+          type: 'text',
+          default: 'ingress-system',
+          description: 'Namespace allowed to reach NoteDiscovery HTTP',
+        },
+        {
+          label: 'Extra Egress CIDR',
+          key: 'networkPolicy.extraEgress[0].to[0].ipBlock.cidr',
+          type: 'text',
+          default: '10.0.0.0/8',
+          description: 'Additional destination allowed after DNS and HTTPS baseline rules',
+        },
+        {
+          label: 'Extra Egress Port',
+          key: 'networkPolicy.extraEgress[0].ports[0].port',
+          type: 'number',
+          default: '8443',
+          description: 'Additional TCP egress port',
+        },
+      ],
+    },
   ],
   'github-mcp-server': [
     {

--- a/src/pages/docs/charts/notediscovery.mdx
+++ b/src/pages/docs/charts/notediscovery.mdx
@@ -53,7 +53,7 @@ Exposure and operations:
 - `gatewayAPI.enabled`, `gatewayAPI.httpRoutes`.
 - `externalSecrets.enabled`, `externalSecrets.items`: materialize complete config Secrets through External Secrets Operator.
 - `pdb.enabled`, `pdb.minAvailable`.
-- `networkPolicy.enabled`, `networkPolicy.ingressFrom`.
+- `networkPolicy.enabled`, `networkPolicy.ingressFrom`, `networkPolicy.extraEgress`.
 - `probes.startup`, `probes.liveness`, `probes.readiness`: enable flags and timing values.
 - `resources`, `podSecurityContext`, `securityContext`, `nodeSelector`, `tolerations`, `affinity`.
 - `topologySpreadConstraints`, `priorityClassName`, `terminationGracePeriodSeconds`.
@@ -99,6 +99,13 @@ ingress:
 
 networkPolicy:
   enabled: true
+  extraEgress:
+    - to:
+        - ipBlock:
+            cidr: 10.0.0.0/8
+      ports:
+        - protocol: TCP
+          port: 8443
 ```
 
 Because this example uses `auth.existingSecret`, put every runtime setting in the
@@ -192,6 +199,14 @@ externalSecrets:
 ```
 
 `config.yaml` should include all runtime settings, not only secret fields.
+
+## Network Policy
+
+`networkPolicy.enabled=true` restricts inbound HTTP traffic to the configured
+`networkPolicy.ingressFrom` peers, or to all namespaces when no ingress peers
+are set. Setting `networkPolicy.extraEgress` also enables egress isolation. The
+chart keeps DNS and HTTPS egress available before appending the custom egress
+rules.
 
 ## Backup
 

--- a/src/pages/docs/charts/notediscovery.mdx
+++ b/src/pages/docs/charts/notediscovery.mdx
@@ -99,6 +99,10 @@ ingress:
 
 networkPolicy:
   enabled: true
+  ingressFrom:
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: ingress-system
   extraEgress:
     - to:
         - ipBlock:


### PR DESCRIPTION
## Summary

- Document `networkPolicy.extraEgress` for the NoteDiscovery chart.
- Update the production example with an extra egress rule.
- Add NoteDiscovery NetworkPolicy controls to the playground config.

## Related

Chart PR: helmforgedev/charts#672

## Validation

- `make site-sync-check CHART=notediscovery`: passed
- `npm run lint`: passed
- `npm run format:check`: passed
- `npm run build`: passed
- `make release-check REPO=site`: passed
- `make attribution-check REPO=site`: passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new “Network Policy” section to the NoteDiscovery chart configuration, including editable options for allowed ingress namespace, extra egress CIDR, and extra egress port.
  * Expanded the NoteDiscovery chart documentation with the new network policy settings, updating the production example and clarifying how network policy affects inbound HTTP access and egress isolation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->