### PR TITLE
docs(qdrant): sync template standards updates

### DIFF
--- a/src/data/playground-configs.ts
+++ b/src/data/playground-configs.ts
@@ -8363,6 +8363,34 @@ export const chartConfigs: Record<string, ChartConfig> = {
         },
       ],
     },
+    {
+      name: 'Network Policy',
+      collapsible: true,
+      gateField: 'networkPolicy.enabled',
+      fields: [
+        {
+          label: 'Ingress Namespace',
+          key: 'networkPolicy.ingressFrom[0].namespaceSelector.matchLabels.kubernetes\\.io/metadata\\.name',
+          type: 'text',
+          default: 'rag',
+          description: 'Namespace allowed to reach Qdrant HTTP and gRPC',
+        },
+        {
+          label: 'Extra Egress CIDR',
+          key: 'networkPolicy.extraEgress[0].to[0].ipBlock.cidr',
+          type: 'text',
+          default: '10.0.0.0/8',
+          description: 'Additional destination allowed after baseline DNS, HTTPS, and p2p rules',
+        },
+        {
+          label: 'Extra Egress Port',
+          key: 'networkPolicy.extraEgress[0].ports[0].port',
+          type: 'number',
+          default: '6333',
+          description: 'Additional TCP egress port',
+        },
+      ],
+    },
   ],
   memos: [
     {

--- a/src/pages/docs/charts/qdrant.mdx
+++ b/src/pages/docs/charts/qdrant.mdx
@@ -126,9 +126,9 @@ Plan snapshots, restore procedures, and collection replication before enabling t
 `networkPolicy.enabled=true` restricts inbound HTTP and gRPC traffic to the configured `networkPolicy.ingressFrom` peers, or to all
 namespaces when no peers are set. Cluster p2p ingress is allowed from Qdrant pods when `cluster.enabled=true`.
 
-Setting `networkPolicy.extraEgress` also enables egress isolation. The chart keeps DNS and HTTPS egress available before appending custom
-egress rules. In distributed mode, it also keeps Qdrant p2p egress between pods so cluster bootstrap and peer communication remain
-available.
+Setting `networkPolicy.extraEgress` also enables egress isolation. The chart keeps DNS and broad HTTPS egress to any IPv4/IPv6
+destination available before appending custom egress rules. In distributed mode, it also keeps Qdrant p2p egress between pods so cluster
+bootstrap and peer communication remain available.
 
 ## Monitoring
 

--- a/src/pages/docs/charts/qdrant.mdx
+++ b/src/pages/docs/charts/qdrant.mdx
@@ -54,6 +54,13 @@ resources:
 
 networkPolicy:
   enabled: true
+  extraEgress:
+    - to:
+        - ipBlock:
+            cidr: 10.0.0.0/8
+      ports:
+        - protocol: TCP
+          port: 6333
 ```
 
 ## Runtime Values
@@ -85,7 +92,8 @@ Security and exposure:
 - `service.type`, `service.port`, `service.grpcPort`, `service.annotations`, `service.ipFamilyPolicy`, `service.ipFamilies`.
 - `ingress.enabled`, `ingress.ingressClassName`, `ingress.annotations`, `ingress.hosts`, `ingress.tls`.
 - `gateway.enabled`, `gateway.parentRefs`, `gateway.hostnames`, `gateway.path`, `gateway.pathType`.
-- `networkPolicy.enabled`, `networkPolicy.ingressFrom`: client ingress peers. Cluster p2p traffic gets a separate self-peer rule.
+- `networkPolicy.enabled`, `networkPolicy.ingressFrom`, `networkPolicy.extraEgress`: client ingress peers and optional egress isolation.
+  Cluster p2p traffic gets separate self-peer ingress and egress rules when needed.
 
 Operations:
 
@@ -112,6 +120,15 @@ Distributed mode requires at least two replicas, persistence, and chart-managed 
 The chart also owns the startup command in distributed mode so it can pass Qdrant the required peer bootstrap arguments; use `app.args`
 for additional Qdrant flags.
 Plan snapshots, restore procedures, and collection replication before enabling this in production.
+
+## Network Policy
+
+`networkPolicy.enabled=true` restricts inbound HTTP and gRPC traffic to the configured `networkPolicy.ingressFrom` peers, or to all
+namespaces when no peers are set. Cluster p2p ingress is allowed from Qdrant pods when `cluster.enabled=true`.
+
+Setting `networkPolicy.extraEgress` also enables egress isolation. The chart keeps DNS and HTTPS egress available before appending custom
+egress rules. In distributed mode, it also keeps Qdrant p2p egress between pods so cluster bootstrap and peer communication remain
+available.
 
 ## Monitoring
 

--- a/src/pages/playground.astro
+++ b/src/pages/playground.astro
@@ -55,6 +55,7 @@ const siteSyncPlaygroundConfigs: Record<string, string> = {
   memcached: 'src/data/playground-configs.ts',
   notediscovery: 'src/data/playground-configs.ts',
   poznote: 'src/data/playground-configs.ts',
+  qdrant: 'src/data/playground-configs.ts',
 };
 const configuredChartSlugs = new Set([...Object.keys(mergedConfigs), ...Object.keys(siteSyncPlaygroundConfigs)]);
 const playgroundCharts = charts.filter(


### PR DESCRIPTION
## Summary

- Document `networkPolicy.extraEgress` for the Qdrant chart.
- Add the Qdrant NetworkPolicy controls to the playground config.
- Register Qdrant as a required playground config for site sync.

## Related

Chart PR: helmforgedev/charts#673

## Validation

- `make site-sync-check CHART=qdrant`: passed
- `npm run lint`: passed
- `npm run format:check`: passed
- `npm run build`: passed
- `make release-check REPO=site`: passed
- `make attribution-check REPO=site`: passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a “Network Policy” section to the Qdrant playground configuration, enabling ingress namespace filtering and optional extra egress (destination CIDR and TCP port).
  * Included Qdrant in the site-synced playground charts list so it’s properly included in playground filtering and syncing.

* **Documentation**
  * Updated Qdrant chart docs with a production egress example and clearer guidance on `networkPolicy.extraEgress`, including how network restrictions interact with cluster and peer communication.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->