### PR TITLE
docs(openhab): sync template standards updates

### DIFF
--- a/src/pages/docs/charts/openhab.mdx
+++ b/src/pages/docs/charts/openhab.mdx
@@ -673,6 +673,7 @@ kubectl scale statefulset my-openhab -n openhab --replicas=1
 | `securityContext.allowPrivilegeEscalation`    | Prevent privilege escalation                   | `false`          |
 | `securityContext.readOnlyRootFilesystem`      | Keep writable for OSGi/Karaf runtime state     | `false`          |
 | `namespaceOverride`                           | Override chart-managed object namespace        | `""`             |
+| `podLabels`                                   | Extra pod labels; selector labels are reserved | `{}`             |
 | `serviceAccount.create`                       | Create a dedicated ServiceAccount              | `true`           |
 | `serviceAccount.automountServiceAccountToken` | Mount Kubernetes API token into pods           | `false`          |
 

--- a/src/pages/playground.astro
+++ b/src/pages/playground.astro
@@ -54,6 +54,7 @@ const siteSyncPlaygroundConfigs: Record<string, string> = {
   memos: 'src/data/playground-configs.ts',
   memcached: 'src/data/playground-configs.ts',
   notediscovery: 'src/data/playground-configs.ts',
+  openhab: 'src/data/playground-configs.ts',
   poznote: 'src/data/playground-configs.ts',
   qdrant: 'src/data/playground-configs.ts',
 };


### PR DESCRIPTION
## Summary

- Document the openHAB `podLabels` selector-label reservation.
- Register openHAB as a required playground config for site sync.

## Related

Chart PR: helmforgedev/charts#674

## Validation

- `make site-sync-check CHART=openhab`: passed
- `npm run lint`: passed
- `npm run format:check`: passed
- `npm run build`: passed
- `make release-check REPO=site`: passed
- `make attribution-check REPO=site`: passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for the OpenHAB chart in the playground’s site-sync chart selection.
* **Documentation**
  * Updated the Configuration Reference → Workload section to include a new `podLabels` option for adding extra pod labels, while reserving selector labels (default `{}`).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->