### PR TITLE
docs(hoppscotch): sync template standards updates

### DIFF
--- a/src/data/playground-configs.ts
+++ b/src/data/playground-configs.ts
@@ -10940,6 +10940,27 @@ export const chartConfigs: Record<string, ChartConfig> = {
         },
       ],
     },
+    {
+      name: 'Network Policy',
+      collapsible: true,
+      gateField: 'networkPolicy.enabled',
+      fields: [
+        {
+          label: 'Extra Egress CIDR',
+          key: 'networkPolicy.extraEgress[0].to[0].ipBlock.cidr',
+          type: 'text',
+          default: '10.0.0.0/8',
+          description: 'Additional destination allowed after DNS and database baseline rules',
+        },
+        {
+          label: 'Extra Egress Port',
+          key: 'networkPolicy.extraEgress[0].ports[0].port',
+          type: 'number',
+          default: '443',
+          description: 'Additional TCP egress port',
+        },
+      ],
+    },
   ],
 };
 

--- a/src/pages/docs/charts/hoppscotch.mdx
+++ b/src/pages/docs/charts/hoppscotch.mdx
@@ -388,30 +388,30 @@ helm test hoppscotch -n hoppscotch
 
 ## Parameters
 
-| Parameter                        | Description                                               | Default    |
-| -------------------------------- | --------------------------------------------------------- | ---------- |
-| `mode`                           | Chart mode: `dev` or `production`                         | `dev`      |
-| `namespaceOverride`              | Override namespace for chart-managed resources            | `""`       |
-| `image.tag`                      | Hoppscotch image tag                                      | `2026.5.0` |
-| `replicaCount`                   | Number of replicas                                        | `1`        |
-| `ingress.enabled`                | Enable Ingress                                            | `false`    |
-| `ingress.host`                   | Hostname (auto-derives all VITE\_\* URLs)                 | `""`       |
-| `postgresql.enabled`             | Enable PostgreSQL subchart                                | `true`     |
-| `database.external.enabled`      | Use external PostgreSQL                                   | `false`    |
-| `encryption.key`                 | 32-char encryption key (auto-generated)                   | `""`       |
-| `encryption.existingSecret`      | Existing secret with encryption key                       | `""`       |
-| `auth.providers`                 | Comma-separated enabled auth providers                    | `EMAIL`    |
-| `auth.github.enabled`            | Enable GitHub OAuth                                       | `false`    |
-| `auth.google.enabled`            | Enable Google OAuth                                       | `false`    |
-| `auth.microsoft.enabled`         | Enable Microsoft OAuth                                    | `false`    |
-| `mailer.enabled`                 | Enable SMTP                                               | `false`    |
-| `gatewayAPI.enabled`             | Enable HTTPRoute                                          | `false`    |
-| `externalSecrets.enabled`        | Enable ExternalSecret                                     | `false`    |
-| `networkPolicy.enabled`          | Enable NetworkPolicy                                      | `false`    |
-| `networkPolicy.extraEgress`      | Additional egress rules after DNS and database            | `[]`       |
-| `podDisruptionBudget.enabled`    | Enable PDB                                                | `false`    |
-| `extraManifests`                 | Additional Kubernetes manifests rendered with the release | `[]`       |
-| `metrics.serviceMonitor.enabled` | Enable ServiceMonitor                                     | `false`    |
+| Parameter                        | Description                                              | Default    |
+| -------------------------------- | -------------------------------------------------------- | ---------- |
+| `mode`                           | Chart mode: `dev` or `production`                        | `dev`      |
+| `namespaceOverride`              | Override namespace for chart-managed resources           | `""`       |
+| `image.tag`                      | Hoppscotch image tag                                     | `2026.5.0` |
+| `replicaCount`                   | Number of replicas                                       | `1`        |
+| `ingress.enabled`                | Enable Ingress                                           | `false`    |
+| `ingress.host`                   | Hostname (auto-derives all VITE\_\* URLs)                | `""`       |
+| `postgresql.enabled`             | Enable PostgreSQL subchart                               | `true`     |
+| `database.external.enabled`      | Use external PostgreSQL                                  | `false`    |
+| `encryption.key`                 | 32-char encryption key (auto-generated)                  | `""`       |
+| `encryption.existingSecret`      | Existing secret with encryption key                      | `""`       |
+| `auth.providers`                 | Comma-separated enabled auth providers                   | `EMAIL`    |
+| `auth.github.enabled`            | Enable GitHub OAuth                                      | `false`    |
+| `auth.google.enabled`            | Enable Google OAuth                                      | `false`    |
+| `auth.microsoft.enabled`         | Enable Microsoft OAuth                                   | `false`    |
+| `mailer.enabled`                 | Enable SMTP                                              | `false`    |
+| `gatewayAPI.enabled`             | Enable HTTPRoute                                         | `false`    |
+| `externalSecrets.enabled`        | Enable ExternalSecret                                    | `false`    |
+| `networkPolicy.enabled`          | Enable NetworkPolicy                                     | `false`    |
+| `networkPolicy.extraEgress`      | Additional egress rules after DNS and database           | `[]`       |
+| `podDisruptionBudget.enabled`    | Enable PDB                                               | `false`    |
+| `extraManifests`                 | Additional Kubernetes manifests rendered with Helm `tpl` | `[]`       |
+| `metrics.serviceMonitor.enabled` | Enable ServiceMonitor                                    | `false`    |
 
 ## Links
 

--- a/src/pages/docs/charts/hoppscotch.mdx
+++ b/src/pages/docs/charts/hoppscotch.mdx
@@ -9,7 +9,7 @@ import Callout from '../../../components/Callout.astro';
 
 # Hoppscotch
 
-Hoppscotch is an open-source API development platform supporting REST, GraphQL, and WebSocket APIs. The HelmForge chart deploys the Community Edition All-in-One image (`2026.4.1`) with subpath-based routing, automatic Prisma migrations, optional OAuth providers, SMTP, ExternalSecrets Operator support, and a bundled HelmForge PostgreSQL subchart.
+Hoppscotch is an open-source API development platform supporting REST, GraphQL, and WebSocket APIs. The HelmForge chart deploys the Community Edition All-in-One image (`2026.5.0`) with subpath-based routing, automatic Prisma migrations, optional OAuth providers, SMTP, ExternalSecrets Operator support, and a bundled HelmForge PostgreSQL subchart.
 
 ## Key Features
 
@@ -388,28 +388,30 @@ helm test hoppscotch -n hoppscotch
 
 ## Parameters
 
-| Parameter                        | Description                                    | Default    |
-| -------------------------------- | ---------------------------------------------- | ---------- |
-| `mode`                           | Chart mode: `dev` or `production`              | `dev`      |
-| `namespaceOverride`              | Override namespace for chart-managed resources | `""`       |
-| `image.tag`                      | Hoppscotch image tag                           | `2026.4.1` |
-| `replicaCount`                   | Number of replicas                             | `1`        |
-| `ingress.enabled`                | Enable Ingress                                 | `false`    |
-| `ingress.host`                   | Hostname (auto-derives all VITE\_\* URLs)      | `""`       |
-| `postgresql.enabled`             | Enable PostgreSQL subchart                     | `true`     |
-| `database.external.enabled`      | Use external PostgreSQL                        | `false`    |
-| `encryption.key`                 | 32-char encryption key (auto-generated)        | `""`       |
-| `encryption.existingSecret`      | Existing secret with encryption key            | `""`       |
-| `auth.providers`                 | Comma-separated enabled auth providers         | `EMAIL`    |
-| `auth.github.enabled`            | Enable GitHub OAuth                            | `false`    |
-| `auth.google.enabled`            | Enable Google OAuth                            | `false`    |
-| `auth.microsoft.enabled`         | Enable Microsoft OAuth                         | `false`    |
-| `mailer.enabled`                 | Enable SMTP                                    | `false`    |
-| `gatewayAPI.enabled`             | Enable HTTPRoute                               | `false`    |
-| `externalSecrets.enabled`        | Enable ExternalSecret                          | `false`    |
-| `networkPolicy.enabled`          | Enable NetworkPolicy                           | `false`    |
-| `podDisruptionBudget.enabled`    | Enable PDB                                     | `false`    |
-| `metrics.serviceMonitor.enabled` | Enable ServiceMonitor                          | `false`    |
+| Parameter                        | Description                                               | Default    |
+| -------------------------------- | --------------------------------------------------------- | ---------- |
+| `mode`                           | Chart mode: `dev` or `production`                         | `dev`      |
+| `namespaceOverride`              | Override namespace for chart-managed resources            | `""`       |
+| `image.tag`                      | Hoppscotch image tag                                      | `2026.5.0` |
+| `replicaCount`                   | Number of replicas                                        | `1`        |
+| `ingress.enabled`                | Enable Ingress                                            | `false`    |
+| `ingress.host`                   | Hostname (auto-derives all VITE\_\* URLs)                 | `""`       |
+| `postgresql.enabled`             | Enable PostgreSQL subchart                                | `true`     |
+| `database.external.enabled`      | Use external PostgreSQL                                   | `false`    |
+| `encryption.key`                 | 32-char encryption key (auto-generated)                   | `""`       |
+| `encryption.existingSecret`      | Existing secret with encryption key                       | `""`       |
+| `auth.providers`                 | Comma-separated enabled auth providers                    | `EMAIL`    |
+| `auth.github.enabled`            | Enable GitHub OAuth                                       | `false`    |
+| `auth.google.enabled`            | Enable Google OAuth                                       | `false`    |
+| `auth.microsoft.enabled`         | Enable Microsoft OAuth                                    | `false`    |
+| `mailer.enabled`                 | Enable SMTP                                               | `false`    |
+| `gatewayAPI.enabled`             | Enable HTTPRoute                                          | `false`    |
+| `externalSecrets.enabled`        | Enable ExternalSecret                                     | `false`    |
+| `networkPolicy.enabled`          | Enable NetworkPolicy                                      | `false`    |
+| `networkPolicy.extraEgress`      | Additional egress rules after DNS and database            | `[]`       |
+| `podDisruptionBudget.enabled`    | Enable PDB                                                | `false`    |
+| `extraManifests`                 | Additional Kubernetes manifests rendered with the release | `[]`       |
+| `metrics.serviceMonitor.enabled` | Enable ServiceMonitor                                     | `false`    |
 
 ## Links
 

--- a/src/pages/playground.astro
+++ b/src/pages/playground.astro
@@ -48,6 +48,7 @@ const siteSyncPlaygroundConfigs: Record<string, string> = {
   flowise: 'src/data/playground-configs.ts',
   generic: 'src/data/playground-configs.ts',
   'github-mcp-server': 'src/data/playground-configs.ts',
+  hoppscotch: 'src/data/playground-configs.ts',
   'kubernetes-mcp-server': 'src/data/playground-configs.ts',
   langflow: 'src/data/playground-configs.ts',
   medikeep: 'src/data/playground-configs.ts',


### PR DESCRIPTION
## Summary
- sync Hoppscotch docs for the template-standards chart update
- document networkPolicy.extraEgress and extraManifests
- correct the documented image tag to 2026.5.0
- add Hoppscotch to the playground site-sync registry and expose network policy controls

## Validation
- npm run lint
- npm run format:check
- npm run build
- make site-sync-check CHART=hoppscotch
- make release-check REPO=site
- make attribution-check REPO=site

Chart PR: helmforgedev/charts#675

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added the Hoppscotch chart to the playground list when eligible.
  - Introduced an optional Network Policy “Network Policy” section (shown when enabled) with extra egress controls for destination CIDRs and ports.

- **Documentation**
  - Updated Hoppscotch Helm chart docs to use image tag `2026.5.0`.
  - Documented the new Helm parameters, including `networkPolicy.extraEgress` and `extraManifests`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->