### PR TITLE
docs(jenkins): sync template standards updates

### DIFF
--- a/src/data/playground-configs.ts
+++ b/src/data/playground-configs.ts
@@ -810,14 +810,14 @@ export const chartConfigs: Record<string, ChartConfig> = {
         },
         {
           label: 'Extra Egress CIDR',
-          key: 'networkPolicy.extraEgress[0].to[0].ipBlock.cidr',
+          key: 'networkPolicy.egress.extraEgress[0].to[0].ipBlock.cidr',
           type: 'text',
           default: '10.0.0.0/8',
           description: 'Additional destination allowed by NetworkPolicy',
         },
         {
           label: 'Extra Egress Port',
-          key: 'networkPolicy.extraEgress[0].ports[0].port',
+          key: 'networkPolicy.egress.extraEgress[0].ports[0].port',
           type: 'number',
           default: '443',
           description: 'Additional TCP egress port',

--- a/src/data/playground-configs.ts
+++ b/src/data/playground-configs.ts
@@ -809,6 +809,20 @@ export const chartConfigs: Record<string, ChartConfig> = {
           description: 'Allow outbound plugin and SCM access',
         },
         {
+          label: 'Extra Egress CIDR',
+          key: 'networkPolicy.extraEgress[0].to[0].ipBlock.cidr',
+          type: 'text',
+          default: '10.0.0.0/8',
+          description: 'Additional destination allowed by NetworkPolicy',
+        },
+        {
+          label: 'Extra Egress Port',
+          key: 'networkPolicy.extraEgress[0].ports[0].port',
+          type: 'number',
+          default: '443',
+          description: 'Additional TCP egress port',
+        },
+        {
           label: 'ServiceMonitor',
           key: 'metrics.serviceMonitor.enabled',
           type: 'toggle',

--- a/src/pages/docs/charts/jenkins.mdx
+++ b/src/pages/docs/charts/jenkins.mdx
@@ -252,6 +252,7 @@ Also validate a real pipeline run if Kubernetes agents, credentials, or network 
 | `service.ipFamilyPolicy`         | `null`                      | Optional Service IP family policy.                                               |
 | `gateway.enabled`                | `false`                     | Render Gateway API HTTPRoute.                                                    |
 | `networkPolicy.enabled`          | `false`                     | Render NetworkPolicy resources.                                                  |
+| `networkPolicy.extraEgress`      | `[]`                        | Additional NetworkPolicy egress rules appended after generated egress rules.     |
 | `metrics.serviceMonitor.enabled` | `false`                     | Render ServiceMonitor.                                                           |
 | `externalSecrets.enabled`        | `false`                     | Render ExternalSecret resources.                                                 |
 

--- a/src/pages/docs/charts/jenkins.mdx
+++ b/src/pages/docs/charts/jenkins.mdx
@@ -236,25 +236,25 @@ Also validate a real pipeline run if Kubernetes agents, credentials, or network 
 
 ## Values
 
-| Parameter                        | Default                     | Description                                                                      |
-| -------------------------------- | --------------------------- | -------------------------------------------------------------------------------- |
-| `replicaCount`                   | `1`                         | Controller replicas. Keep one unless shared storage and HA behavior are planned. |
-| `image.repository`               | `docker.io/jenkins/jenkins` | Jenkins controller image.                                                        |
-| `admin.create`                   | `true`                      | Create initial admin credentials.                                                |
-| `admin.existingSecret`           | `""`                        | Existing Secret for initial admin credentials.                                   |
-| `controller.jenkinsUrl`          | `""`                        | Optional Jenkins root URL for JCasC/plugin use.                                  |
-| `plugins.install.enabled`        | `false`                     | Install pinned plugins before startup.                                           |
-| `plugins.install.initializeOnce` | `true`                      | Skip plugin installation after the first initialized Jenkins home.               |
-| `jcasC.enabled`                  | `false`                     | Enable Jenkins Configuration as Code.                                            |
-| `agent.enabled`                  | `true`                      | Enable Kubernetes agent integration.                                             |
-| `rbac.create`                    | `false`                     | Create namespaced RBAC for Kubernetes agents.                                    |
-| `persistence.enabled`            | `true`                      | Persist Jenkins home.                                                            |
-| `service.ipFamilyPolicy`         | `null`                      | Optional Service IP family policy.                                               |
-| `gateway.enabled`                | `false`                     | Render Gateway API HTTPRoute.                                                    |
-| `networkPolicy.enabled`          | `false`                     | Render NetworkPolicy resources.                                                  |
-| `networkPolicy.extraEgress`      | `[]`                        | Additional NetworkPolicy egress rules appended after generated egress rules.     |
-| `metrics.serviceMonitor.enabled` | `false`                     | Render ServiceMonitor.                                                           |
-| `externalSecrets.enabled`        | `false`                     | Render ExternalSecret resources.                                                 |
+| Parameter                          | Default                     | Description                                                                      |
+| ---------------------------------- | --------------------------- | -------------------------------------------------------------------------------- |
+| `replicaCount`                     | `1`                         | Controller replicas. Keep one unless shared storage and HA behavior are planned. |
+| `image.repository`                 | `docker.io/jenkins/jenkins` | Jenkins controller image.                                                        |
+| `admin.create`                     | `true`                      | Create initial admin credentials.                                                |
+| `admin.existingSecret`             | `""`                        | Existing Secret for initial admin credentials.                                   |
+| `controller.jenkinsUrl`            | `""`                        | Optional Jenkins root URL for JCasC/plugin use.                                  |
+| `plugins.install.enabled`          | `false`                     | Install pinned plugins before startup.                                           |
+| `plugins.install.initializeOnce`   | `true`                      | Skip plugin installation after the first initialized Jenkins home.               |
+| `jcasC.enabled`                    | `false`                     | Enable Jenkins Configuration as Code.                                            |
+| `agent.enabled`                    | `true`                      | Enable Kubernetes agent integration.                                             |
+| `rbac.create`                      | `false`                     | Create namespaced RBAC for Kubernetes agents.                                    |
+| `persistence.enabled`              | `true`                      | Persist Jenkins home.                                                            |
+| `service.ipFamilyPolicy`           | `null`                      | Optional Service IP family policy.                                               |
+| `gateway.enabled`                  | `false`                     | Render Gateway API HTTPRoute.                                                    |
+| `networkPolicy.enabled`            | `false`                     | Render NetworkPolicy resources.                                                  |
+| `networkPolicy.egress.extraEgress` | `[]`                        | Additional NetworkPolicy egress rules appended after generated egress rules.     |
+| `metrics.serviceMonitor.enabled`   | `false`                     | Render ServiceMonitor.                                                           |
+| `externalSecrets.enabled`          | `false`                     | Render ExternalSecret resources.                                                 |
 
 ## Links
 

--- a/src/pages/playground.astro
+++ b/src/pages/playground.astro
@@ -50,6 +50,7 @@ const siteSyncPlaygroundConfigs: Record<string, string> = {
   'github-mcp-server': 'src/data/playground-configs.ts',
   hoppscotch: 'src/data/playground-configs.ts',
   immich: 'src/data/playground-configs.ts',
+  jenkins: 'src/data/playground-configs.ts',
   'kubernetes-mcp-server': 'src/data/playground-configs.ts',
   langflow: 'src/data/playground-configs.ts',
   medikeep: 'src/data/playground-configs.ts',


### PR DESCRIPTION
## Summary
- sync Jenkins chart docs with the template-standards chart update
- expose `networkPolicy.extraEgress` in the Jenkins playground controls
- mark Jenkins as a curated playground config for site-sync tracking

## Validation
- `npm run lint`
- `npm run format:check`
- `npm run build`
- `make site-sync-check CHART=jenkins`

Related charts PR: https://github.com/helmforgedev/charts/pull/677

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the Jenkins chart to the playground chart selector so it’s now available alongside other supported charts.
  * Enhanced Jenkins network policy egress settings with two new optional options to allow an extra destination CIDR and an extra TCP egress port.

* **Documentation**
  * Updated the Jenkins chart “Values” table to document the new egress append/override value (defaulting to an empty list) and refined table formatting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->