### PR TITLE
docs(jupyterhub): sync template standards updates

### DIFF
--- a/src/data/playground-configs.ts
+++ b/src/data/playground-configs.ts
@@ -1099,6 +1099,20 @@ export const chartConfigs: Record<string, ChartConfig> = {
           description: 'Render NetworkPolicy resources',
         },
         {
+          label: 'Extra Egress CIDR',
+          key: 'networkPolicy.extraEgress[0].to[0].ipBlock.cidr',
+          type: 'text',
+          default: '10.60.0.0/16',
+          description: 'Additional Hub egress destination',
+        },
+        {
+          label: 'Extra Egress Port',
+          key: 'networkPolicy.extraEgress[0].ports[0].port',
+          type: 'number',
+          default: '443',
+          description: 'Additional Hub egress port',
+        },
+        {
           label: 'PodDisruptionBudget',
           key: 'pdb.enabled',
           type: 'toggle',

--- a/src/pages/docs/charts/jupyterhub.mdx
+++ b/src/pages/docs/charts/jupyterhub.mdx
@@ -258,18 +258,19 @@ when `hub.cleanupServers=false`.
 
 ## Values
 
-| Parameter                        | Default                         | Description                               |
-| -------------------------------- | ------------------------------- | ----------------------------------------- |
-| `hub.replicaCount`               | `1`                             | Number of Hub replicas.                   |
-| `hub.persistence.enabled`        | `true`                          | Persist Hub state.                        |
-| `proxy.secretToken`              | `""`                            | Inline proxy token, generated when empty. |
-| `proxy.existingSecret`           | `""`                            | Existing Secret for proxy token.          |
-| `singleuser.image.name`          | `quay.io/jupyter/base-notebook` | Default notebook image.                   |
-| `singleuser.storage.enabled`     | `false`                         | Create user notebook PVCs.                |
-| `service.ipFamilyPolicy`         | `null`                          | Optional Service dual-stack policy.       |
-| `gateway.enabled`                | `false`                         | Render Gateway API HTTPRoute.             |
-| `metrics.serviceMonitor.enabled` | `false`                         | Render ServiceMonitor.                    |
-| `externalSecrets.enabled`        | `false`                         | Render ExternalSecret resources.          |
+| Parameter                        | Default                         | Description                                |
+| -------------------------------- | ------------------------------- | ------------------------------------------ |
+| `hub.replicaCount`               | `1`                             | Number of Hub replicas.                    |
+| `hub.persistence.enabled`        | `true`                          | Persist Hub state.                         |
+| `proxy.secretToken`              | `""`                            | Inline proxy token, generated when empty.  |
+| `proxy.existingSecret`           | `""`                            | Existing Secret for proxy token.           |
+| `singleuser.image.name`          | `quay.io/jupyter/base-notebook` | Default notebook image.                    |
+| `singleuser.storage.enabled`     | `false`                         | Create user notebook PVCs.                 |
+| `service.ipFamilyPolicy`         | `null`                          | Optional Service dual-stack policy.        |
+| `gateway.enabled`                | `false`                         | Render Gateway API HTTPRoute.              |
+| `networkPolicy.extraEgress`      | `[]`                            | Additional Hub NetworkPolicy egress rules. |
+| `metrics.serviceMonitor.enabled` | `false`                         | Render ServiceMonitor.                     |
+| `externalSecrets.enabled`        | `false`                         | Render ExternalSecret resources.           |
 
 ## Links
 

--- a/src/pages/playground.astro
+++ b/src/pages/playground.astro
@@ -51,6 +51,7 @@ const siteSyncPlaygroundConfigs: Record<string, string> = {
   hoppscotch: 'src/data/playground-configs.ts',
   immich: 'src/data/playground-configs.ts',
   jenkins: 'src/data/playground-configs.ts',
+  jupyterhub: 'src/data/playground-configs.ts',
   'kubernetes-mcp-server': 'src/data/playground-configs.ts',
   langflow: 'src/data/playground-configs.ts',
   medikeep: 'src/data/playground-configs.ts',


### PR DESCRIPTION
## Summary
- sync JupyterHub docs with the template-standards chart update
- expose `networkPolicy.extraEgress` in the JupyterHub playground controls
- mark JupyterHub as a curated playground config for site-sync tracking

## Validation
- `npm run lint`
- `npm run format:check`
- `npm run build`
- `make site-sync-check CHART=jupyterhub`

Related charts PR: https://github.com/helmforgedev/charts/pull/678

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added additional JupyterHub chart egress NetworkPolicy options, including an extra destination CIDR and egress port.
  * Included the JupyterHub chart in the playground chart list.

* **Documentation**
  * Reformatted the JupyterHub chart “Values” table for improved alignment, and documented the new `networkPolicy.extraEgress` parameter.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->