### PR TITLE
docs(memcached): sync template standards updates

### DIFF
--- a/src/data/playground-configs.ts
+++ b/src/data/playground-configs.ts
@@ -7438,6 +7438,20 @@ export const chartConfigs: Record<string, ChartConfig> = {
           default: 'true',
           description: 'Allow DNS egress',
         },
+        {
+          label: 'Extra Egress CIDR',
+          key: 'networkPolicy.extraEgress[0].to[0].ipBlock.cidr',
+          type: 'text',
+          default: '10.80.0.0/16',
+          description: 'Additional egress destination',
+        },
+        {
+          label: 'Extra Egress Port',
+          key: 'networkPolicy.extraEgress[0].ports[0].port',
+          type: 'number',
+          default: '443',
+          description: 'Additional TCP egress port',
+        },
       ],
     },
     {

--- a/src/data/playground-configs.ts
+++ b/src/data/playground-configs.ts
@@ -7440,14 +7440,14 @@ export const chartConfigs: Record<string, ChartConfig> = {
         },
         {
           label: 'Extra Egress CIDR',
-          key: 'networkPolicy.extraEgress[0].to[0].ipBlock.cidr',
+          key: 'networkPolicy.egress.extraEgress[0].to[0].ipBlock.cidr',
           type: 'text',
           default: '10.80.0.0/16',
           description: 'Additional egress destination',
         },
         {
           label: 'Extra Egress Port',
-          key: 'networkPolicy.extraEgress[0].ports[0].port',
+          key: 'networkPolicy.egress.extraEgress[0].ports[0].port',
           type: 'number',
           default: '443',
           description: 'Additional TCP egress port',

--- a/src/pages/docs/charts/memcached.mdx
+++ b/src/pages/docs/charts/memcached.mdx
@@ -240,7 +240,7 @@ networkPolicy:
   egress:
     enabled: true
     allowDNS: true
-  extraEgress: []
+    extraEgress: []
 
 pdb:
   enabled: true
@@ -302,7 +302,7 @@ Memcached authentication is disabled.
 | `metrics.memcachedTLS.enabled`                | `false`                       | Uses TLS between the exporter and local Memcached process.                    |
 | `networkPolicy.enabled`                       | `false`                       | Renders NetworkPolicy rules for cache and metrics access.                     |
 | `networkPolicy.egress.enabled`                | `false`                       | Adds optional egress policy rules.                                            |
-| `networkPolicy.extraEgress`                   | `[]`                          | Appends full custom NetworkPolicy egress rules to generated egress.           |
+| `networkPolicy.egress.extraEgress`            | `[]`                          | Appends full custom NetworkPolicy egress rules to generated egress.           |
 | `autoscaling.enabled`                         | `false`                       | Enables HPA for distributed mode only.                                        |
 | `pdb.enabled`                                 | `false`                       | Renders a PodDisruptionBudget.                                                |
 | `service.type`                                | `ClusterIP`                   | Client Service type; use `LoadBalancer` if external TCP exposure is required. |

--- a/src/pages/docs/charts/memcached.mdx
+++ b/src/pages/docs/charts/memcached.mdx
@@ -240,7 +240,13 @@ networkPolicy:
   egress:
     enabled: true
     allowDNS: true
-    extraEgress: []
+    extraEgress:
+      - to:
+          - ipBlock:
+              cidr: 10.80.0.0/16
+        ports:
+          - port: 443
+            protocol: TCP
 
 pdb:
   enabled: true

--- a/src/pages/docs/charts/memcached.mdx
+++ b/src/pages/docs/charts/memcached.mdx
@@ -240,6 +240,7 @@ networkPolicy:
   egress:
     enabled: true
     allowDNS: true
+  extraEgress: []
 
 pdb:
   enabled: true
@@ -301,6 +302,7 @@ Memcached authentication is disabled.
 | `metrics.memcachedTLS.enabled`                | `false`                       | Uses TLS between the exporter and local Memcached process.                    |
 | `networkPolicy.enabled`                       | `false`                       | Renders NetworkPolicy rules for cache and metrics access.                     |
 | `networkPolicy.egress.enabled`                | `false`                       | Adds optional egress policy rules.                                            |
+| `networkPolicy.extraEgress`                   | `[]`                          | Appends full custom NetworkPolicy egress rules to generated egress.           |
 | `autoscaling.enabled`                         | `false`                       | Enables HPA for distributed mode only.                                        |
 | `pdb.enabled`                                 | `false`                       | Renders a PodDisruptionBudget.                                                |
 | `service.type`                                | `ClusterIP`                   | Client Service type; use `LoadBalancer` if external TCP exposure is required. |


### PR DESCRIPTION
## Summary
- Document `networkPolicy.extraEgress` for Memcached.
- Add Memcached playground controls for custom egress CIDR and port.

## Related
- Syncs with helmforgedev/charts#680.

## Validation
- `npm run lint`
- `npm run format:check`
- `npm run build`
- `make site-sync-check CHART=memcached`
- `make release-check REPO=site`
- `make attribution-check REPO=site`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced the Memcached chart’s Network Policy configuration to support adding extra outbound access via an additional egress CIDR and port.
  * Updated the Memcached documentation with a Production example showing how to append custom egress entries, and added a configuration reference for the new `extraEgress` option.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->