### PR TITLE
docs(metrics-server): sync template standards updates

### DIFF
--- a/src/data/playground-configs.ts
+++ b/src/data/playground-configs.ts
@@ -1330,6 +1330,48 @@ export const chartConfigs: Record<string, ChartConfig> = {
         },
       ],
     },
+    {
+      name: 'Network Policy',
+      collapsible: true,
+      gateField: 'networkPolicy.enabled',
+      fields: [
+        {
+          label: 'Egress Rules',
+          key: 'networkPolicy.egress.enabled',
+          type: 'toggle',
+          default: 'true',
+          description: 'Add explicit egress rules',
+        },
+        {
+          label: 'DNS Egress',
+          key: 'networkPolicy.egress.allowDNS',
+          type: 'toggle',
+          default: 'true',
+          description: 'Allow DNS egress',
+        },
+        {
+          label: 'Kubelet Egress',
+          key: 'networkPolicy.egress.allowKubelet',
+          type: 'toggle',
+          default: 'true',
+          description: 'Allow kubelet scrapes',
+        },
+        {
+          label: 'Extra Egress CIDR',
+          key: 'networkPolicy.extraEgress[0].to[0].ipBlock.cidr',
+          type: 'text',
+          default: '10.80.0.0/16',
+          description: 'Additional egress destination',
+        },
+        {
+          label: 'Extra Egress Port',
+          key: 'networkPolicy.extraEgress[0].ports[0].port',
+          type: 'number',
+          default: '443',
+          description: 'Additional TCP egress port',
+        },
+      ],
+    },
   ],
   'oauth2-proxy': [
     {

--- a/src/data/playground-configs.ts
+++ b/src/data/playground-configs.ts
@@ -1358,14 +1358,14 @@ export const chartConfigs: Record<string, ChartConfig> = {
         },
         {
           label: 'Extra Egress CIDR',
-          key: 'networkPolicy.extraEgress[0].to[0].ipBlock.cidr',
+          key: 'networkPolicy.egress.extraEgress[0].to[0].ipBlock.cidr',
           type: 'text',
           default: '10.80.0.0/16',
           description: 'Additional egress destination',
         },
         {
           label: 'Extra Egress Port',
-          key: 'networkPolicy.extraEgress[0].ports[0].port',
+          key: 'networkPolicy.egress.extraEgress[0].ports[0].port',
           type: 'number',
           default: '443',
           description: 'Additional TCP egress port',

--- a/src/pages/docs/charts/metrics-server.mdx
+++ b/src/pages/docs/charts/metrics-server.mdx
@@ -117,7 +117,8 @@ networkPolicy:
   enabled: true
   egress:
     enabled: true
-    allowDns: true
+    allowDNS: true
+  extraEgress: []
 ```
 
 Host networking is opt-in for platforms where pod-to-kubelet routing requires it:
@@ -181,6 +182,7 @@ the APIService condition.
 | `metricsServer.kubelet.insecureTLS` | `false`                                         | Disable kubelet TLS verification for local clusters. |
 | `hostNetwork.enabled`               | `false`                                         | Use host networking.                                 |
 | `service.ipFamilyPolicy`            | `null`                                          | Optional Service dual-stack policy.                  |
+| `networkPolicy.extraEgress`         | `[]`                                            | Append full custom NetworkPolicy egress rules.       |
 | `serviceMonitor.enabled`            | `false`                                         | Render ServiceMonitor.                               |
 
 ## Links

--- a/src/pages/docs/charts/metrics-server.mdx
+++ b/src/pages/docs/charts/metrics-server.mdx
@@ -118,7 +118,7 @@ networkPolicy:
   egress:
     enabled: true
     allowDNS: true
-  extraEgress: []
+    extraEgress: []
 ```
 
 Host networking is opt-in for platforms where pod-to-kubelet routing requires it:
@@ -182,7 +182,7 @@ the APIService condition.
 | `metricsServer.kubelet.insecureTLS` | `false`                                         | Disable kubelet TLS verification for local clusters. |
 | `hostNetwork.enabled`               | `false`                                         | Use host networking.                                 |
 | `service.ipFamilyPolicy`            | `null`                                          | Optional Service dual-stack policy.                  |
-| `networkPolicy.extraEgress`         | `[]`                                            | Append full custom NetworkPolicy egress rules.       |
+| `networkPolicy.egress.extraEgress`  | `[]`                                            | Append full custom NetworkPolicy egress rules.       |
 | `serviceMonitor.enabled`            | `false`                                         | Render ServiceMonitor.                               |
 
 ## Links

--- a/src/pages/playground.astro
+++ b/src/pages/playground.astro
@@ -58,6 +58,7 @@ const siteSyncPlaygroundConfigs: Record<string, string> = {
   medikeep: 'src/data/playground-configs.ts',
   memcached: 'src/data/playground-configs.ts',
   memos: 'src/data/playground-configs.ts',
+  'metrics-server': 'src/data/playground-configs.ts',
   notediscovery: 'src/data/playground-configs.ts',
   openhab: 'src/data/playground-configs.ts',
   poznote: 'src/data/playground-configs.ts',


### PR DESCRIPTION
## Summary

- Document `networkPolicy.extraEgress` for Metrics Server.
- Add Metrics Server playground NetworkPolicy controls, including custom egress CIDR and port.
- Register Metrics Server in the playground sync allowlist.

## Related

- Syncs with helmforgedev/charts#681.
- Issue: helmforgedev/charts#633.

## Validation

- `npm run lint`
- `npm run format:check`
- `npm run build`
- `make site-sync-check CHART=metrics-server`
- `make release-check REPO=site`
- `make attribution-check REPO=site`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a collapsible **Network Policy** section for the metrics-server playground configuration, with controls for enabling egress rules, DNS and kubelet egress, optional extra egress destinations (CIDR + TCP port), and related settings.
  * Enabled the **metrics-server** chart in the site-sync playground chart selection.

* **Documentation**
  * Updated the metrics-server Network Policy YAML example and configuration reference to use `allowDNS` and added the new `networkPolicy.egress.extraEgress` parameter.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->