### PR TITLE
docs(oauth2-proxy): sync template standards updates

### DIFF
--- a/src/data/playground-configs.ts
+++ b/src/data/playground-configs.ts
@@ -1414,6 +1414,27 @@ export const chartConfigs: Record<string, ChartConfig> = {
         },
       ],
     },
+    {
+      name: 'Network Policy',
+      collapsible: true,
+      gateField: 'networkPolicy.enabled',
+      fields: [
+        {
+          label: 'Extra Egress CIDR',
+          key: 'networkPolicy.extraEgress[0].to[0].ipBlock.cidr',
+          type: 'text',
+          default: '10.80.0.0/16',
+          description: 'Additional egress destination',
+        },
+        {
+          label: 'Extra Egress Port',
+          key: 'networkPolicy.extraEgress[0].ports[0].port',
+          type: 'number',
+          default: '443',
+          description: 'Additional TCP egress port',
+        },
+      ],
+    },
   ],
   olivetin: [
     {

--- a/src/pages/docs/charts/oauth2-proxy.mdx
+++ b/src/pages/docs/charts/oauth2-proxy.mdx
@@ -10,7 +10,7 @@ OAuth2 Proxy is a reverse proxy and authentication gateway for OAuth2 and OIDC p
 
 ## Key Features
 
-- Official `quay.io/oauth2-proxy/oauth2-proxy` image pinned to `v7.15.2`
+- Official `quay.io/oauth2-proxy/oauth2-proxy` image pinned to `v7.15.3`
 - Chart-managed Secret, existing Secret, or ExternalSecret credential modes
 - Reverse proxy header trust disabled by default
 - Config validation init container using `--config-test`
@@ -121,6 +121,7 @@ metrics:
 
 networkPolicy:
   enabled: true
+  extraEgress: []
 ```
 
 The Secret referenced by `auth.existingSecret` should contain the client secret and cookie secret keys expected by the
@@ -229,6 +230,7 @@ callback URL, cookie domain, and upstream proxy integration are correct.
 | `metrics.enabled`             | `true`                              | Enable metrics endpoint.         |
 | `ingress.enabled`             | `false`                             | Render Ingress.                  |
 | `gateway.enabled`             | `false`                             | Render Gateway API HTTPRoute.    |
+| `networkPolicy.extraEgress`   | `[]`                                | Append full custom egress rules. |
 | `externalSecrets.enabled`     | `false`                             | Render ExternalSecret resources. |
 
 ## Links

--- a/src/pages/playground.astro
+++ b/src/pages/playground.astro
@@ -60,6 +60,7 @@ const siteSyncPlaygroundConfigs: Record<string, string> = {
   memos: 'src/data/playground-configs.ts',
   'metrics-server': 'src/data/playground-configs.ts',
   notediscovery: 'src/data/playground-configs.ts',
+  'oauth2-proxy': 'src/data/playground-configs.ts',
   openhab: 'src/data/playground-configs.ts',
   poznote: 'src/data/playground-configs.ts',
   qdrant: 'src/data/playground-configs.ts',


### PR DESCRIPTION
## Summary

- Document `networkPolicy.extraEgress` for OAuth2 Proxy.
- Add OAuth2 Proxy playground controls for custom egress CIDR and port.
- Correct the documented pinned image tag to `v7.15.3`.
- Register OAuth2 Proxy in the playground sync allowlist.

## Related

- Syncs with helmforgedev/charts#682.
- Issue: helmforgedev/charts#633.

## Validation

- `npm run lint`
- `npm run format:check`
- `npm run build`
- `make site-sync-check CHART=oauth2-proxy`
- `make release-check REPO=site`
- `make attribution-check REPO=site`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new collapsible **Network Policy** section for the OAuth2 Proxy chart in the playground, with options to configure extra egress CIDR and port values.
  * Allowed the OAuth2 Proxy chart to appear in the playground chart selector.

* **Documentation**
  * Updated the OAuth2 Proxy chart docs with the latest upstream image version.
  * Expanded the values examples to include custom network policy egress settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->