### PR TITLE
docs(opencut): sync template standards updates

### DIFF
--- a/src/data/playground-configs.ts
+++ b/src/data/playground-configs.ts
@@ -432,27 +432,6 @@ export const chartConfigs: Record<string, ChartConfig> = {
         },
       ],
     },
-    {
-      name: 'Extra Egress',
-      collapsible: true,
-      gateField: 'networkPolicy.enabled',
-      fields: [
-        {
-          label: 'Extra Egress CIDR',
-          key: 'networkPolicy.extraEgress[0].to[0].ipBlock.cidr',
-          type: 'text',
-          default: '10.80.0.0/16',
-          description: 'Additional egress destination',
-        },
-        {
-          label: 'Extra Egress Port',
-          key: 'networkPolicy.extraEgress[0].ports[0].port',
-          type: 'number',
-          default: '443',
-          description: 'Additional TCP egress port',
-        },
-      ],
-    },
   ],
   ghost: [
     {
@@ -1825,6 +1804,27 @@ export const chartConfigs: Record<string, ChartConfig> = {
           default: 'nginx',
           options: ['nginx', 'traefik'],
           description: 'Ingress controller class',
+        },
+      ],
+    },
+    {
+      name: 'Network Policy',
+      collapsible: true,
+      gateField: 'networkPolicy.enabled',
+      fields: [
+        {
+          label: 'Extra Egress CIDR',
+          key: 'networkPolicy.extraEgress[0].to[0].ipBlock.cidr',
+          type: 'text',
+          default: '10.80.0.0/16',
+          description: 'Additional web egress destination',
+        },
+        {
+          label: 'Extra Egress Port',
+          key: 'networkPolicy.extraEgress[0].ports[0].port',
+          type: 'number',
+          default: '443',
+          description: 'Additional TCP egress port',
         },
       ],
     },

--- a/src/data/playground-configs.ts
+++ b/src/data/playground-configs.ts
@@ -432,6 +432,27 @@ export const chartConfigs: Record<string, ChartConfig> = {
         },
       ],
     },
+    {
+      name: 'Extra Egress',
+      collapsible: true,
+      gateField: 'networkPolicy.enabled',
+      fields: [
+        {
+          label: 'Extra Egress CIDR',
+          key: 'networkPolicy.extraEgress[0].to[0].ipBlock.cidr',
+          type: 'text',
+          default: '10.80.0.0/16',
+          description: 'Additional egress destination',
+        },
+        {
+          label: 'Extra Egress Port',
+          key: 'networkPolicy.extraEgress[0].ports[0].port',
+          type: 'number',
+          default: '443',
+          description: 'Additional TCP egress port',
+        },
+      ],
+    },
   ],
   ghost: [
     {

--- a/src/pages/docs/charts/opencut.mdx
+++ b/src/pages/docs/charts/opencut.mdx
@@ -119,6 +119,7 @@ redisHttp:
 
 networkPolicy:
   enabled: true
+  extraEgress: []
 ```
 
 `opencut.siteUrl` should match the externally visible URL exactly. Authentication callback and generated links depend on
@@ -235,18 +236,19 @@ reachable from the OpenCut pod.
 
 ## Values
 
-| Parameter                 | Default                       | Description                                          |
-| ------------------------- | ----------------------------- | ---------------------------------------------------- |
-| `replicaCount`            | `1`                           | Number of OpenCut pods when autoscaling is disabled. |
-| `image.repository`        | `docker.io/helmforge/opencut` | HelmForge OpenCut image.                             |
-| `postgresql.enabled`      | `true`                        | Deploy HelmForge PostgreSQL dependency.              |
-| `redis.enabled`           | `true`                        | Deploy HelmForge Redis dependency.                   |
-| `database.external.host`  | `""`                          | External PostgreSQL host.                            |
-| `redisHttp.enabled`       | `true`                        | Deploy Redis-over-HTTP bridge.                       |
-| `service.ipFamilyPolicy`  | `null`                        | Optional Service dual-stack policy.                  |
-| `ingress.enabled`         | `false`                       | Render Ingress.                                      |
-| `gateway.enabled`         | `false`                       | Render Gateway API HTTPRoute.                        |
-| `externalSecrets.enabled` | `false`                       | Render ExternalSecret resources.                     |
+| Parameter                   | Default                       | Description                                          |
+| --------------------------- | ----------------------------- | ---------------------------------------------------- |
+| `replicaCount`              | `1`                           | Number of OpenCut pods when autoscaling is disabled. |
+| `image.repository`          | `docker.io/helmforge/opencut` | HelmForge OpenCut image.                             |
+| `postgresql.enabled`        | `true`                        | Deploy HelmForge PostgreSQL dependency.              |
+| `redis.enabled`             | `true`                        | Deploy HelmForge Redis dependency.                   |
+| `database.external.host`    | `""`                          | External PostgreSQL host.                            |
+| `redisHttp.enabled`         | `true`                        | Deploy Redis-over-HTTP bridge.                       |
+| `service.ipFamilyPolicy`    | `null`                        | Optional Service dual-stack policy.                  |
+| `ingress.enabled`           | `false`                       | Render Ingress.                                      |
+| `gateway.enabled`           | `false`                       | Render Gateway API HTTPRoute.                        |
+| `networkPolicy.extraEgress` | `[]`                          | Append full custom web egress rules.                 |
+| `externalSecrets.enabled`   | `false`                       | Render ExternalSecret resources.                     |
 
 ## Links
 

--- a/src/pages/playground.astro
+++ b/src/pages/playground.astro
@@ -61,6 +61,7 @@ const siteSyncPlaygroundConfigs: Record<string, string> = {
   'metrics-server': 'src/data/playground-configs.ts',
   notediscovery: 'src/data/playground-configs.ts',
   'oauth2-proxy': 'src/data/playground-configs.ts',
+  opencut: 'src/data/playground-configs.ts',
   openhab: 'src/data/playground-configs.ts',
   poznote: 'src/data/playground-configs.ts',
   qdrant: 'src/data/playground-configs.ts',


### PR DESCRIPTION
## Summary

- Document `networkPolicy.extraEgress` for OpenCut.
- Add OpenCut playground controls for custom egress CIDR and port.
- Register OpenCut in the playground sync allowlist.

## Related

- Syncs with helmforgedev/charts#683.
- Issue: helmforgedev/charts#633.

## Validation

- `npm run lint`
- `npm run format:check`
- `npm run build`
- `make site-sync-check CHART=opencut`
- `make release-check REPO=site`
- `make attribution-check REPO=site`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added extra egress options to the Network Policy section for the Opencut chart playground.
  * Opencut is now included in the playground’s available chart list.

* **Documentation**
  * Updated Opencut chart docs with `networkPolicy.extraEgress` (including defaults) and adjusted the “Production Values” example accordingly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->