### PR TITLE
docs(openreel-video): sync template standards updates

### DIFF
--- a/src/data/playground-configs.ts
+++ b/src/data/playground-configs.ts
@@ -1865,6 +1865,27 @@ export const chartConfigs: Record<string, ChartConfig> = {
         },
       ],
     },
+    {
+      name: 'Network Policy',
+      collapsible: true,
+      gateField: 'networkPolicy.enabled',
+      fields: [
+        {
+          label: 'Extra Egress CIDR',
+          key: 'networkPolicy.extraEgress[0].to[0].ipBlock.cidr',
+          type: 'text',
+          default: '10.80.0.0/16',
+          description: 'Additional egress destination',
+        },
+        {
+          label: 'Extra Egress Port',
+          key: 'networkPolicy.extraEgress[0].ports[0].port',
+          type: 'number',
+          default: '443',
+          description: 'Additional TCP egress port',
+        },
+      ],
+    },
   ],
   sonarqube: [
     {

--- a/src/pages/docs/charts/openreel-video.mdx
+++ b/src/pages/docs/charts/openreel-video.mdx
@@ -10,7 +10,7 @@ OpenReel Video is a browser-based video editor. The HelmForge chart serves the s
 
 ## Key Features
 
-- HelmForge-maintained `docker.io/helmforge/openreel-video:v0.4.0` image
+- HelmForge-maintained `docker.io/helmforge/openreel-video:v0.5.0` image
 - Static hosting for the upstream browser-based editor
 - WebCodecs-ready deployment with writable temporary volume support
 - Ingress, Gateway API through the single `gateway` values block, dual-stack Service fields, HPA, PDB, NetworkPolicy, and Helm tests
@@ -104,6 +104,7 @@ ingress:
 
 networkPolicy:
   enabled: true
+  extraEgress: []
 
 resources:
   requests:
@@ -194,18 +195,19 @@ For public routes, validate that static assets load with the same host, scheme, 
 
 ## Values
 
-| Parameter                | Default                              | Description                                  |
-| ------------------------ | ------------------------------------ | -------------------------------------------- |
-| `replicaCount`           | `1`                                  | Number of pods when autoscaling is disabled. |
-| `image.repository`       | `docker.io/helmforge/openreel-video` | HelmForge OpenReel Video image.              |
-| `service.type`           | `ClusterIP`                          | Kubernetes Service type.                     |
-| `service.ipFamilyPolicy` | `null`                               | Optional Service dual-stack policy.          |
-| `ingress.enabled`        | `false`                              | Render Ingress.                              |
-| `gateway.enabled`        | `false`                              | Render Gateway API HTTPRoute.                |
-| `autoscaling.enabled`    | `false`                              | Render HPA.                                  |
-| `pdb.enabled`            | `false`                              | Render PodDisruptionBudget.                  |
-| `networkPolicy.enabled`  | `false`                              | Render NetworkPolicy.                        |
-| `tmpVolume.enabled`      | `true`                               | Mount writable temporary storage.            |
+| Parameter                   | Default                              | Description                                  |
+| --------------------------- | ------------------------------------ | -------------------------------------------- |
+| `replicaCount`              | `1`                                  | Number of pods when autoscaling is disabled. |
+| `image.repository`          | `docker.io/helmforge/openreel-video` | HelmForge OpenReel Video image.              |
+| `service.type`              | `ClusterIP`                          | Kubernetes Service type.                     |
+| `service.ipFamilyPolicy`    | `null`                               | Optional Service dual-stack policy.          |
+| `ingress.enabled`           | `false`                              | Render Ingress.                              |
+| `gateway.enabled`           | `false`                              | Render Gateway API HTTPRoute.                |
+| `autoscaling.enabled`       | `false`                              | Render HPA.                                  |
+| `pdb.enabled`               | `false`                              | Render PodDisruptionBudget.                  |
+| `networkPolicy.enabled`     | `false`                              | Render NetworkPolicy.                        |
+| `networkPolicy.extraEgress` | `[]`                                 | Append full custom egress rules.             |
+| `tmpVolume.enabled`         | `true`                               | Mount writable temporary storage.            |
 
 ## Links
 

--- a/src/pages/playground.astro
+++ b/src/pages/playground.astro
@@ -63,6 +63,7 @@ const siteSyncPlaygroundConfigs: Record<string, string> = {
   'oauth2-proxy': 'src/data/playground-configs.ts',
   opencut: 'src/data/playground-configs.ts',
   openhab: 'src/data/playground-configs.ts',
+  'openreel-video': 'src/data/playground-configs.ts',
   poznote: 'src/data/playground-configs.ts',
   qdrant: 'src/data/playground-configs.ts',
 };


### PR DESCRIPTION
## Summary

- Document `networkPolicy.extraEgress` for OpenReel Video.
- Add OpenReel Video playground controls for custom egress CIDR and port.
- Correct the documented pinned image tag to `v0.5.0`.
- Register OpenReel Video in the playground sync allowlist.

## Related

- Syncs with helmforgedev/charts#684.
- Issue: helmforgedev/charts#633.

## Validation

- `npm run lint`
- `npm run format:check`
- `npm run build`
- `make site-sync-check CHART=openreel-video`
- `make release-check REPO=site`
- `make attribution-check REPO=site`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the OpenReel Video chart to the playground, making it available for users to explore.
  * Expanded network policy options with additional egress settings for a custom destination and TCP port.

* **Documentation**
  * Updated the OpenReel Video chart docs to reflect the latest image version.
  * Added the new egress configuration to the production example and values reference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->