### PR TITLE
docs(sonarqube): sync template standards updates

### DIFF
--- a/src/data/playground-configs.ts
+++ b/src/data/playground-configs.ts
@@ -1929,6 +1929,34 @@ export const chartConfigs: Record<string, ChartConfig> = {
         },
       ],
     },
+    {
+      name: 'Network Policy',
+      collapsible: true,
+      gateField: 'networkPolicy.enabled',
+      fields: [
+        {
+          label: 'Egress Policy',
+          key: 'networkPolicy.egress.enabled',
+          type: 'toggle',
+          default: 'false',
+          description: 'Render explicit egress rules',
+        },
+        {
+          label: 'Extra Egress CIDR',
+          key: 'networkPolicy.egress.extraEgress[0].to[0].ipBlock.cidr',
+          type: 'text',
+          default: '10.80.0.0/16',
+          description: 'Additional egress destination',
+        },
+        {
+          label: 'Extra Egress Port',
+          key: 'networkPolicy.egress.extraEgress[0].ports[0].port',
+          type: 'number',
+          default: '443',
+          description: 'Additional TCP egress port',
+        },
+      ],
+    },
   ],
   tomcat: [
     {

--- a/src/pages/docs/charts/sonarqube.mdx
+++ b/src/pages/docs/charts/sonarqube.mdx
@@ -16,6 +16,7 @@ SonarQube Community Build provides code quality and security analysis. The HelmF
 - First-class community branch plugin wiring, Java agents, and webapp replacement support
 - Gateway API, Ingress, dual-stack Service fields, NetworkPolicy, PDB, persistence, and Helm tests
 - External Secrets Operator support for database credentials
+- `extraManifests` extension point for small companion resources and self-contained validation fixtures
 
 <a id="install"></a>
 
@@ -97,6 +98,13 @@ networkPolicy:
   enabled: true
   egress:
     enabled: true
+    extraEgress:
+      - to:
+          - ipBlock:
+              cidr: 10.80.0.0/16
+        ports:
+          - protocol: TCP
+            port: 443
 
 pdb:
   enabled: true
@@ -145,6 +153,21 @@ plugins:
 ```
 
 Use an internal artifact repository for production. Startup should not depend on public internet availability.
+
+## Extension Manifests
+
+Use `extraManifests` for small companion resources that must ship with the release, such as a Service alias or a
+short-lived validation dependency:
+
+```yaml
+extraManifests:
+  - apiVersion: v1
+    kind: ConfigMap
+    metadata:
+      name: sonarqube-extra
+    data:
+      enabled: 'true'
+```
 
 ## Community Branch Plugin
 
@@ -225,18 +248,21 @@ is enabled.
 
 ## Values
 
-| Parameter                       | Default                       | Description                                                     |
-| ------------------------------- | ----------------------------- | --------------------------------------------------------------- |
-| `image.repository`              | `docker.io/library/sonarqube` | Official SonarQube image.                                       |
-| `image.tag`                     | `26.4.0.121862-community`     | SonarQube Community Build tag.                                  |
-| `sonarqube.databaseMode`        | `auto`                        | Database mode: `auto`, `embedded`, `postgresql`, or `external`. |
-| `postgresql.enabled`            | `false`                       | Deploy HelmForge PostgreSQL dependency.                         |
-| `waitForDatabase.enabled`       | `true`                        | Wait for PostgreSQL before startup.                             |
-| `plugins.enabled`               | `false`                       | Enable plugin download init container.                          |
-| `communityBranchPlugin.enabled` | `false`                       | Install and wire the community branch plugin.                   |
-| `persistence.data.enabled`      | `true`                        | Persist SonarQube data.                                         |
-| `gatewayAPI.enabled`            | `false`                       | Render Gateway API HTTPRoute.                                   |
-| `externalSecrets.enabled`       | `false`                       | Render ExternalSecret resources.                                |
+| Parameter                          | Default                       | Description                                                     |
+| ---------------------------------- | ----------------------------- | --------------------------------------------------------------- |
+| `image.repository`                 | `docker.io/library/sonarqube` | Official SonarQube image.                                       |
+| `image.tag`                        | `26.4.0.121862-community`     | SonarQube Community Build tag.                                  |
+| `sonarqube.databaseMode`           | `auto`                        | Database mode: `auto`, `embedded`, `postgresql`, or `external`. |
+| `postgresql.enabled`               | `false`                       | Deploy HelmForge PostgreSQL dependency.                         |
+| `waitForDatabase.enabled`          | `true`                        | Wait for PostgreSQL before startup.                             |
+| `plugins.enabled`                  | `false`                       | Enable plugin download init container.                          |
+| `communityBranchPlugin.enabled`    | `false`                       | Install and wire the community branch plugin.                   |
+| `persistence.data.enabled`         | `true`                        | Persist SonarQube data.                                         |
+| `gatewayAPI.enabled`               | `false`                       | Render Gateway API HTTPRoute.                                   |
+| `networkPolicy.enabled`            | `false`                       | Render NetworkPolicy.                                           |
+| `networkPolicy.egress.extraEgress` | `[]`                          | Additional complete NetworkPolicy egress rules.                 |
+| `externalSecrets.enabled`          | `false`                       | Render ExternalSecret resources.                                |
+| `extraManifests`                   | `[]`                          | Additional Kubernetes manifests rendered with the release.      |
 
 ## Links
 

--- a/src/pages/playground.astro
+++ b/src/pages/playground.astro
@@ -66,6 +66,7 @@ const siteSyncPlaygroundConfigs: Record<string, string> = {
   'openreel-video': 'src/data/playground-configs.ts',
   poznote: 'src/data/playground-configs.ts',
   qdrant: 'src/data/playground-configs.ts',
+  sonarqube: 'src/data/playground-configs.ts',
 };
 const configuredChartSlugs = new Set([...Object.keys(mergedConfigs), ...Object.keys(siteSyncPlaygroundConfigs)]);
 const playgroundCharts = charts.filter(


### PR DESCRIPTION
## Summary

- Document `networkPolicy.egress.extraEgress` and `extraManifests` for SonarQube.
- Add SonarQube playground allowlist coverage and NetworkPolicy extra egress controls.
- Keep the chart docs aligned with the template standards update in helmforgedev/charts#685.

## Related

- Syncs with helmforgedev/charts#685.
- Issue: helmforgedev/charts#633.

## Validation

- `npm run lint`
- `npm run format:check`
- `npm run build`
- `make site-sync-check CHART=sonarqube`
- `make release-check REPO=site`
- `make attribution-check REPO=site`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new collapsible Network Policy section for the SonarQube chart in the playground, including options for enabling egress rules, setting an extra destination CIDR, and specifying an extra TCP port.
  * Introduced support for rendering additional extension manifests, with documentation and examples.

* **Documentation**
  * Expanded the SonarQube chart docs with the new Network Policy options and `extraManifests` usage.
  * Added examples showing how to include extra Kubernetes resources and egress rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->