### PR TITLE
docs(tomcat): sync template standards updates

### DIFF
--- a/src/data/playground-configs.ts
+++ b/src/data/playground-configs.ts
@@ -1993,6 +1993,34 @@ export const chartConfigs: Record<string, ChartConfig> = {
         },
       ],
     },
+    {
+      name: 'Network Policy',
+      collapsible: true,
+      gateField: 'networkPolicy.enabled',
+      fields: [
+        {
+          label: 'Egress Policy',
+          key: 'networkPolicy.egress.enabled',
+          type: 'toggle',
+          default: 'false',
+          description: 'Render explicit egress rules',
+        },
+        {
+          label: 'Extra Egress CIDR',
+          key: 'networkPolicy.egress.extraEgress[0].to[0].ipBlock.cidr',
+          type: 'text',
+          default: '10.80.0.0/16',
+          description: 'Additional egress destination',
+        },
+        {
+          label: 'Extra Egress Port',
+          key: 'networkPolicy.egress.extraEgress[0].ports[0].port',
+          type: 'number',
+          default: '443',
+          description: 'Additional TCP egress port',
+        },
+      ],
+    },
   ],
   valkey: [
     {

--- a/src/pages/docs/charts/tomcat.mdx
+++ b/src/pages/docs/charts/tomcat.mdx
@@ -119,13 +119,9 @@ networkPolicy:
             kubernetes.io/metadata.name: gateway-system
   egress:
     enabled: true
-    extraEgress:
-      - to:
-          - ipBlock:
-              cidr: 10.80.0.0/16
-        ports:
-          - protocol: TCP
-            port: 443
+    extraTo:
+      - ipBlock:
+          cidr: 10.80.0.0/16
 ```
 
 ## Deploying Applications
@@ -250,6 +246,7 @@ webapp.
 | `jmx.enabled`                      | `false`                       | Enable JMX remote settings and Service ports.   |
 | `gatewayAPI.enabled`               | `false`                       | Render Gateway API HTTPRoute.                   |
 | `networkPolicy.enabled`            | `false`                       | Render NetworkPolicy.                           |
+| `networkPolicy.egress.extraTo`     | `[]`                          | Additional peers for built-in egress rules.     |
 | `networkPolicy.egress.extraEgress` | `[]`                          | Additional complete NetworkPolicy egress rules. |
 
 ## Links

--- a/src/pages/docs/charts/tomcat.mdx
+++ b/src/pages/docs/charts/tomcat.mdx
@@ -19,7 +19,7 @@ egress boundaries.
 
 ## Key Features
 
-- Official Tomcat image pinned to `11.0.22-jdk17-temurin-noble`
+- Official Tomcat image pinned to `11.0.23-jdk17-temurin-noble`
 - Optional ROOT health webapp for deterministic probes and Helm tests
 - Copies image-baked webapps into writable runtime volume when needed
 - Writable `webapps`, `logs`, `temp`, and `work` volumes for non-root runtime
@@ -117,6 +117,15 @@ networkPolicy:
       - namespaceSelector:
           matchLabels:
             kubernetes.io/metadata.name: gateway-system
+  egress:
+    enabled: true
+    extraEgress:
+      - to:
+          - ipBlock:
+              cidr: 10.80.0.0/16
+        ports:
+          - protocol: TCP
+            port: 443
 ```
 
 ## Deploying Applications
@@ -229,18 +238,19 @@ webapp.
 
 ## Values
 
-| Parameter                          | Default                       | Description                                    |
-| ---------------------------------- | ----------------------------- | ---------------------------------------------- |
-| `replicaCount`                     | `1`                           | Number of Tomcat pods when HPA is disabled.    |
-| `image.repository`                 | `docker.io/library/tomcat`    | Official Tomcat image repository.              |
-| `image.tag`                        | `11.0.22-jdk17-temurin-noble` | Tomcat image tag.                              |
-| `webapps.defaultRoot.enabled`      | `true`                        | Render minimal ROOT app for health checks.     |
-| `webapps.copyImageContent.enabled` | `true`                        | Copy image-baked webapps into writable volume. |
-| `webapps.persistence.enabled`      | `false`                       | Persist `/usr/local/tomcat/webapps`.           |
-| `logs.persistence.enabled`         | `false`                       | Persist Tomcat logs.                           |
-| `jmx.enabled`                      | `false`                       | Enable JMX remote settings and Service ports.  |
-| `gatewayAPI.enabled`               | `false`                       | Render Gateway API HTTPRoute.                  |
-| `networkPolicy.enabled`            | `false`                       | Render NetworkPolicy.                          |
+| Parameter                          | Default                       | Description                                     |
+| ---------------------------------- | ----------------------------- | ----------------------------------------------- |
+| `replicaCount`                     | `1`                           | Number of Tomcat pods when HPA is disabled.     |
+| `image.repository`                 | `docker.io/library/tomcat`    | Official Tomcat image repository.               |
+| `image.tag`                        | `11.0.23-jdk17-temurin-noble` | Tomcat image tag.                               |
+| `webapps.defaultRoot.enabled`      | `true`                        | Render minimal ROOT app for health checks.      |
+| `webapps.copyImageContent.enabled` | `true`                        | Copy image-baked webapps into writable volume.  |
+| `webapps.persistence.enabled`      | `false`                       | Persist `/usr/local/tomcat/webapps`.            |
+| `logs.persistence.enabled`         | `false`                       | Persist Tomcat logs.                            |
+| `jmx.enabled`                      | `false`                       | Enable JMX remote settings and Service ports.   |
+| `gatewayAPI.enabled`               | `false`                       | Render Gateway API HTTPRoute.                   |
+| `networkPolicy.enabled`            | `false`                       | Render NetworkPolicy.                           |
+| `networkPolicy.egress.extraEgress` | `[]`                          | Additional complete NetworkPolicy egress rules. |
 
 ## Links
 

--- a/src/pages/playground.astro
+++ b/src/pages/playground.astro
@@ -67,6 +67,7 @@ const siteSyncPlaygroundConfigs: Record<string, string> = {
   poznote: 'src/data/playground-configs.ts',
   qdrant: 'src/data/playground-configs.ts',
   sonarqube: 'src/data/playground-configs.ts',
+  tomcat: 'src/data/playground-configs.ts',
 };
 const configuredChartSlugs = new Set([...Object.keys(mergedConfigs), ...Object.keys(siteSyncPlaygroundConfigs)]);
 const playgroundCharts = charts.filter(


### PR DESCRIPTION
## Summary

- Document `networkPolicy.egress.extraEgress` for Tomcat.
- Correct the documented Tomcat image tag to `11.0.23-jdk17-temurin-noble`.
- Add Tomcat playground allowlist coverage and NetworkPolicy extra egress controls.
- Keep site docs aligned with helmforgedev/charts#686.

## Related

- Syncs with helmforgedev/charts#686.
- Issue: helmforgedev/charts#633.

## Validation

- `npm run lint`
- `npm run format:check`
- `npm run build`
- `make site-sync-check CHART=tomcat`
- `make release-check REPO=site`
- `make attribution-check REPO=site`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new “Network Policy” section for the Tomcat chart, with a gated egress toggle and configurable extra egress rules (including default CIDR and port).
  * Enabled Tomcat to appear in the playground.
* **Documentation**
  * Updated the Tomcat chart documentation to use the newer official image tag.
  * Expanded the production values and reference table with the new network policy egress options and defaults.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->