### PR TITLE
docs(appwrite): sync 1.9.5 defaults

### DIFF
--- a/src/pages/docs/charts/appwrite.mdx
+++ b/src/pages/docs/charts/appwrite.mdx
@@ -22,7 +22,7 @@ multi-workload chart (~20 Kubernetes Deployments) with bundled MariaDB and Redis
 
 ## Key Features
 
-- **Full Appwrite stack** — API, Console v7.5.7, Realtime WebSocket, 12 workers, schedulers, maintenance
+- **Full Appwrite stack** — API, Console v8.7.5, Realtime WebSocket, 12 workers, schedulers, maintenance
 - **~20 Kubernetes workloads** — each component runs independently and scales separately
 - **MariaDB + Redis** — bundled subcharts or external connections
 - **Shared PVCs** — uploads, cache, certificates, functions, builds, and sites shared across pods
@@ -249,9 +249,9 @@ ingress:
 | Parameter                  | Type   | Default                       | Description            |
 | -------------------------- | ------ | ----------------------------- | ---------------------- |
 | `image.repository`         | string | `docker.io/appwrite/appwrite` | Appwrite server image. |
-| `image.tag`                | string | `"1.8.1"`                     | Appwrite image tag.    |
+| `image.tag`                | string | `"1.9.5"`                     | Appwrite image tag.    |
 | `console.image.repository` | string | `docker.io/appwrite/console`  | Console image.         |
-| `console.image.tag`        | string | `"7.5.7"`                     | Console image tag.     |
+| `console.image.tag`        | string | `"8.7.5"`                     | Console image tag.     |
 
 ### Appwrite Configuration
 

--- a/src/pages/docs/charts/appwrite.mdx
+++ b/src/pages/docs/charts/appwrite.mdx
@@ -234,6 +234,15 @@ ingress:
 
 </DocsTabs>
 
+## Upgrade Notes
+
+<Callout type="warning" title="Appwrite 1.9.5 requires database migrations">
+  Appwrite 1.9.5 requires the upstream migration step even when upgrading from Appwrite 1.9.0. After `helm
+  upgrade`, run the Appwrite migrate command against an Appwrite API pod before returning production traffic to the
+  release, for example `kubectl exec deploy/<release>-appwrite-api -- appwrite migrate` adjusted to your release name
+  and namespace.
+</Callout>
+
 ## Configuration Reference
 
 ### Core


### PR DESCRIPTION
## Summary

- Sync Appwrite docs with the chart bump to Appwrite 1.9.5.
- Update the documented Console image default to 8.7.5.
- Correct the stale Appwrite image default in the values reference.

## Validation

- npm run format:check
- npm run lint
- npm run build
- make release-check REPO=site
- make attribution-check REPO=site

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated the Appwrite charts documentation to reflect newer Appwrite and Console component versions.
  * Revised default `image.tag` values to match current documented server and console releases.
  * Added upgrade notes explaining that Appwrite 1.9.5 upgrades require running the upstream database migration step, with an example command.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->