### PR TITLE
docs(docmost): sync 0.95.0 default

### DIFF
--- a/src/pages/docs/charts/docmost.mdx
+++ b/src/pages/docs/charts/docmost.mdx
@@ -271,7 +271,7 @@ ingress:
 | Parameter          | Type   | Default                     | Description        |
 | ------------------ | ------ | --------------------------- | ------------------ |
 | `image.repository` | string | `docker.io/docmost/docmost` | Docmost image.     |
-| `image.tag`        | string | `"0.90.1"`                  | Image tag.         |
+| `image.tag`        | string | `"0.95.0"`                  | Image tag.         |
 | `image.pullPolicy` | string | `IfNotPresent`              | Image pull policy. |
 
 ### Docmost Configuration


### PR DESCRIPTION
## Summary

- Sync Docmost docs with the chart bump to Docmost 0.95.0.
- Update the documented image tag default in the values reference.

## Validation

- npm run format:check
- npm run lint
- npm run build
- make release-check REPO=site
- make attribution-check REPO=site

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the Helm chart documentation to reflect the latest default Docker image tag.
  * The “Image” configuration reference now shows version `0.95.0` instead of `0.90.1`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->