### PR TITLE
docs(elasticsearch): sync 9.4.3 default

### DIFF
--- a/src/pages/docs/charts/elasticsearch.mdx
+++ b/src/pages/docs/charts/elasticsearch.mdx
@@ -301,7 +301,7 @@ monitoring:
 | `namespaceOverride`                           | `""`                        | Override namespace for chart-managed resources           |
 | `clusterProfile`                              | `dev`                       | Cluster preset: `dev`, `staging`, `production-ha`        |
 | `clusterName`                                 | `helmforge-cluster`         | Elasticsearch cluster name                               |
-| `image.tag`                                   | `9.4.2`                     | Elasticsearch version                                    |
+| `image.tag`                                   | `9.4.3`                     | Elasticsearch version                                    |
 | `master.replicaCount`                         | profile-driven              | Number of master-eligible nodes (must be odd)            |
 | `master.heapSize`                             | auto (50% mem)              | JVM heap for master nodes                                |
 | `data.replicaCount`                           | profile-driven              | Number of data nodes                                     |
@@ -317,7 +317,7 @@ monitoring:
 | `dataTiers.warm.enabled`                      | `false`                     | Enable dedicated warm tier nodes                         |
 | `monitoring.enabled`                          | `false`                     | Enable Prometheus exporter sidecar                       |
 | `kibana.enabled`                              | `false`                     | Deploy optional Kibana                                   |
-| `kibana.image.tag`                            | `9.4.2`                     | Kibana version aligned with Elasticsearch                |
+| `kibana.image.tag`                            | `9.4.3`                     | Kibana version aligned with Elasticsearch                |
 | `service.ipFamilyPolicy`                      | `null`                      | Service dual-stack policy for HTTP and headless Services |
 | `service.ipFamilies`                          | `[]`                        | Service IP families for HTTP and headless Services       |
 | `serviceAccount.create`                       | `false`                     | Create a dedicated ServiceAccount                        |
@@ -334,8 +334,8 @@ namespaceOverride: search-runtime
 
 ## Upgrade Notes
 
-`docker.io/library/elasticsearch:9.4.2` is an upstream image update from
-`9.4.1`. Review the upstream Elasticsearch release notes before upgrading
+`docker.io/library/elasticsearch:9.4.3` is an upstream image update from
+`9.4.2`. Review the upstream Elasticsearch release notes before upgrading
 production clusters, take a snapshot backup, and verify Kibana compatibility,
 plugins, ILM policies, and index templates in a staging environment before
 reusing existing PVCs.

--- a/src/pages/playground.astro
+++ b/src/pages/playground.astro
@@ -43,6 +43,7 @@ const siteSyncPlaygroundConfigs: Record<string, string> = {
   dolibarr: 'src/data/playground-configs.ts',
   druid: 'src/data/playground-configs.ts',
   drupal: 'src/data/playground-configs.ts',
+  elasticsearch: 'src/data/playground-configs.ts',
   'envoy-gateway': 'src/data/playground-configs.ts',
   'fastmcp-server': 'src/data/playground-configs.ts',
   flowise: 'src/data/playground-configs.ts',


### PR DESCRIPTION
## Summary
- Sync Elasticsearch docs with the chart bump to Elasticsearch 9.4.3.
- Update the documented Elasticsearch and Kibana default image tags.
- Register the existing Elasticsearch playground config in the site sync map.

## Validation
- make site-sync-check CHART=elasticsearch
- npm run format:check
- npm run lint
- npm run build
- make release-check REPO=site
- make attribution-check REPO=site

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Elasticsearch to the set of charts available in the playground, expanding the charts users can explore there.
* **Documentation**
  * Updated Elasticsearch documentation to reflect the latest image tag version.
  * Kept Kibana version details aligned with Elasticsearch and refreshed the upgrade notes accordingly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->