### PR TITLE
docs(ghost): sync 6.50.0 default

### DIFF
--- a/src/data/playground-configs.ts
+++ b/src/data/playground-configs.ts
@@ -607,7 +607,7 @@ export const chartConfigs: Record<string, ChartConfig> = {
           label: 'Image Tag',
           key: 'image.tag',
           type: 'text',
-          default: '6.44.1',
+          default: '6.50.0',
           description: 'Ghost image tag',
         },
         {

--- a/src/pages/docs/charts/ghost.mdx
+++ b/src/pages/docs/charts/ghost.mdx
@@ -203,7 +203,7 @@ backup:
 | Parameter          | Type   | Default                   | Description                          |
 | ------------------ | ------ | ------------------------- | ------------------------------------ |
 | `image.repository` | string | `docker.io/library/ghost` | Ghost container image.               |
-| `image.tag`        | string | `"6.44.1"`                | Image tag.                           |
+| `image.tag`        | string | `"6.50.0"`                | Image tag.                           |
 | `image.pullPolicy` | string | `IfNotPresent`            | Image pull policy.                   |
 | `imagePullSecrets` | array  | `[]`                      | Pull secrets for private registries. |
 

--- a/src/pages/playground.astro
+++ b/src/pages/playground.astro
@@ -47,6 +47,7 @@ const siteSyncPlaygroundConfigs: Record<string, string> = {
   'fastmcp-server': 'src/data/playground-configs.ts',
   flowise: 'src/data/playground-configs.ts',
   generic: 'src/data/playground-configs.ts',
+  ghost: 'src/data/playground-configs.ts',
   'github-mcp-server': 'src/data/playground-configs.ts',
   hoppscotch: 'src/data/playground-configs.ts',
   immich: 'src/data/playground-configs.ts',


### PR DESCRIPTION
## Summary
- Sync Ghost docs and playground defaults with Ghost 6.50.0.
- Update the documented Ghost image tag default.
- Register the existing Ghost playground config in the site sync map.

## Validation
- make site-sync-check CHART=ghost
- npm run format:check
- npm run lint
- npm run build
- make release-check REPO=site
- make attribution-check REPO=site

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the Ghost chart to the playground, making it available for browsing and testing alongside other supported charts.

* **Documentation**
  * Updated the Ghost chart reference to show the latest default container image tag.
  * Aligned the playground configuration example with the newer Ghost image version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->