### PR TITLE
docs(homarr): sync 1.69.2 default

### DIFF
--- a/src/data/playground-configs.ts
+++ b/src/data/playground-configs.ts
@@ -5350,7 +5350,7 @@ export const chartConfigs: Record<string, ChartConfig> = {
           label: 'Image Tag',
           key: 'image.tag',
           type: 'text',
-          default: 'v1.67.0',
+          default: 'v1.69.2',
           description: 'Homarr image tag',
         },
         {

--- a/src/pages/docs/charts/homarr.mdx
+++ b/src/pages/docs/charts/homarr.mdx
@@ -50,9 +50,8 @@ helm install homarr oci://ghcr.io/helmforgedev/helm/homarr -f values.yaml
 
 ## Upgrade Notes
 
-The chart defaults to Homarr `v1.67.0`. This skips the `v1.65.0` MySQL migration regression; upstream fixed that issue in
-`v1.66.1`, and `v1.67.0` keeps the fix while adding the latest Homarr improvements. Review the upstream Homarr release
-notes before upgrading production environments.
+The chart defaults to Homarr `v1.69.2`. This patch release fixes layout stacking so the AppShell header renders above
+indicator dots. Review the upstream Homarr release notes before upgrading production environments.
 
 ## Deployment Examples
 
@@ -227,7 +226,7 @@ ingress:
 | Parameter          | Type   | Default                      | Description        |
 | ------------------ | ------ | ---------------------------- | ------------------ |
 | `image.repository` | string | `ghcr.io/homarr-labs/homarr` | Homarr image.      |
-| `image.tag`        | string | `"v1.67.0"`                  | Image tag.         |
+| `image.tag`        | string | `"v1.69.2"`                  | Image tag.         |
 | `image.pullPolicy` | string | `IfNotPresent`               | Image pull policy. |
 
 ### Homarr Configuration

--- a/src/pages/playground.astro
+++ b/src/pages/playground.astro
@@ -50,6 +50,7 @@ const siteSyncPlaygroundConfigs: Record<string, string> = {
   generic: 'src/data/playground-configs.ts',
   ghost: 'src/data/playground-configs.ts',
   'github-mcp-server': 'src/data/playground-configs.ts',
+  homarr: 'src/data/playground-configs.ts',
   hoppscotch: 'src/data/playground-configs.ts',
   immich: 'src/data/playground-configs.ts',
   jenkins: 'src/data/playground-configs.ts',


### PR DESCRIPTION
## Summary
- Sync Homarr docs and playground defaults with Homarr v1.69.2.
- Update the documented Homarr image tag default.
- Register Homarr in the playground site sync map.

## Validation
- make site-sync-check CHART=homarr
- npm run format:check
- npm run lint
- npm run build
- make release-check REPO=site
- make attribution-check REPO=site

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the Homarr chart to the playground, making it available in the UI alongside other configured charts.

* **Documentation**
  * Updated chart docs to reflect the latest default image versions.
  * Clarified upgrade notes for the newer Homarr release, including a layout stacking behavior change.

* **Bug Fixes**
  * Updated default chart version values to newer releases for a more accurate out-of-the-box experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->