### PR TITLE
docs(hoppscotch): sync 2026.6.0 default

### DIFF
--- a/src/data/playground-configs.ts
+++ b/src/data/playground-configs.ts
@@ -11325,6 +11325,13 @@ export const chartConfigs: Record<string, ChartConfig> = {
           description: 'dev uses defaults; production requires a hostname',
         },
         {
+          label: 'Image Tag',
+          key: 'image.tag',
+          type: 'text',
+          default: '2026.6.0',
+          description: 'Hoppscotch image tag',
+        },
+        {
           label: 'Replica Count',
           key: 'replicaCount',
           type: 'number',

--- a/src/pages/docs/charts/hoppscotch.mdx
+++ b/src/pages/docs/charts/hoppscotch.mdx
@@ -9,7 +9,7 @@ import Callout from '../../../components/Callout.astro';
 
 # Hoppscotch
 
-Hoppscotch is an open-source API development platform supporting REST, GraphQL, and WebSocket APIs. The HelmForge chart deploys the Community Edition All-in-One image (`2026.5.0`) with subpath-based routing, automatic Prisma migrations, optional OAuth providers, SMTP, ExternalSecrets Operator support, and a bundled HelmForge PostgreSQL subchart.
+Hoppscotch is an open-source API development platform supporting REST, GraphQL, and WebSocket APIs. The HelmForge chart deploys the Community Edition All-in-One image (`2026.6.0`) with subpath-based routing, automatic Prisma migrations, optional OAuth providers, SMTP, ExternalSecrets Operator support, and a bundled HelmForge PostgreSQL subchart.
 
 ## Key Features
 
@@ -392,7 +392,7 @@ helm test hoppscotch -n hoppscotch
 | -------------------------------- | -------------------------------------------------------- | ---------- |
 | `mode`                           | Chart mode: `dev` or `production`                        | `dev`      |
 | `namespaceOverride`              | Override namespace for chart-managed resources           | `""`       |
-| `image.tag`                      | Hoppscotch image tag                                     | `2026.5.0` |
+| `image.tag`                      | Hoppscotch image tag                                     | `2026.6.0` |
 | `replicaCount`                   | Number of replicas                                       | `1`        |
 | `ingress.enabled`                | Enable Ingress                                           | `false`    |
 | `ingress.host`                   | Hostname (auto-derives all VITE\_\* URLs)                | `""`       |


### PR DESCRIPTION
## Summary
- Sync Hoppscotch docs and playground defaults with Hoppscotch 2026.6.0.
- Update the documented Hoppscotch image tag default.
- Add the image tag control to the Hoppscotch playground config.

## Validation
- `make site-sync-check CHART=hoppscotch`
- `npm run format:check`
- `npm run lint`
- `npm run build`
- `make release-check REPO=site`
- `make attribution-check REPO=site`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an editable **Image Tag** option in the Hoppscotch chart’s general settings, with a default of `2026.6.0`.
* **Documentation**
  * Updated Hoppscotch Helm chart docs to reflect the new deployed image tag `2026.6.0`.
  * Kept the parameters reference in sync with the latest default image tag.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->