### PR TITLE
docs(komga): sync 1.25.0 default

### DIFF
--- a/src/data/playground-configs.ts
+++ b/src/data/playground-configs.ts
@@ -7423,6 +7423,13 @@ export const chartConfigs: Record<string, ChartConfig> = {
           description: 'Comic and manga library PVC size',
         },
         {
+          label: 'Image Tag',
+          key: 'image.tag',
+          type: 'text',
+          default: '1.25.0',
+          description: 'Komga image tag',
+        },
+        {
           label: 'Timezone',
           key: 'komga.timezone',
           type: 'text',

--- a/src/pages/docs/charts/komga.mdx
+++ b/src/pages/docs/charts/komga.mdx
@@ -20,6 +20,10 @@ and native apps for iOS and Android.
   source collection. Always back up `/config`.
 </Callout>
 
+Komga `1.25.0` adds solid RAR4 archive support, Kobo content restriction fixes,
+OpenAPI schema flattening, and dependency updates including Spring Boot. Back
+up `/config` before upgrading because it contains the SQLite databases.
+
 ## Chart References
 
 - [Chart source](https://github.com/helmforgedev/charts/tree/main/charts/komga)
@@ -257,7 +261,7 @@ ingress:
 | Parameter          | Type   | Default                  | Description                          |
 | ------------------ | ------ | ------------------------ | ------------------------------------ |
 | `image.repository` | string | `docker.io/gotson/komga` | Komga container image.               |
-| `image.tag`        | string | `"1.24.4"`               | Image tag.                           |
+| `image.tag`        | string | `"1.25.0"`               | Image tag.                           |
 | `image.pullPolicy` | string | `IfNotPresent`           | Image pull policy.                   |
 | `imagePullSecrets` | array  | `[]`                     | Pull secrets for private registries. |
 

--- a/src/pages/playground.astro
+++ b/src/pages/playground.astro
@@ -53,6 +53,7 @@ const siteSyncPlaygroundConfigs: Record<string, string> = {
   jenkins: 'src/data/playground-configs.ts',
   jupyterhub: 'src/data/playground-configs.ts',
   kibana: 'src/data/playground-configs.ts',
+  komga: 'src/data/playground-configs.ts',
   'kubernetes-mcp-server': 'src/data/playground-configs.ts',
   langflow: 'src/data/playground-configs.ts',
   clickhouse: 'src/data/playground-configs.ts',


### PR DESCRIPTION
## Summary
- Sync Komga docs and playground defaults with Komga 1.25.0.
- Add the Komga image tag control to the playground config.
- Register Komga in the playground config source map required by site sync.

## Validation
- `make site-sync-check CHART=komga`
- `npm run format:check`
- `npm run lint`
- `npm run build`
- `make release-check REPO=site`
- `make attribution-check REPO=site`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Komga to the playground configuration selector, including the container image tag field with a default value.
* **Documentation**
  * Updated Komga docs to reflect version 1.25.0.
  * Added upgrade notes highlighting new release improvements and reminding users to back up `/config` before upgrading.
  * Updated the documented default container image tag to 1.25.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->