### PR TITLE
docs(medikeep): sync 0.68.0 default

### DIFF
--- a/src/pages/docs/charts/medikeep.mdx
+++ b/src/pages/docs/charts/medikeep.mdx
@@ -10,9 +10,15 @@ Deploy [MediKeep](https://github.com/afairgiant/MediKeep) on Kubernetes as a sel
 
 ## Overview
 
-The HelmForge MediKeep chart uses the official `ghcr.io/afairgiant/medikeep:v0.67.0` image. The container serves the React frontend and FastAPI backend on port `8000`, stores structured records in PostgreSQL, and writes files under `/app/uploads`, `/app/backups`, and `/app/logs`.
+The HelmForge MediKeep chart uses the official `ghcr.io/afairgiant/medikeep:v0.68.0` image. The container serves the React frontend and FastAPI backend on port `8000`, stores structured records in PostgreSQL, and writes files under `/app/uploads`, `/app/backups`, and `/app/logs`.
 
 MediKeep handles personal health data. Treat the PostgreSQL database, uploads PVC, backups PVC, logs, and runtime Secrets as sensitive.
+
+MediKeep `v0.68.0` adds medication reminder configuration and test reminders,
+Chikungunya vaccine support, stacked lab result views, and practitioner entry
+improvements. It also fixes reference range validation, immunization history
+linking, condition lab result visibility, and a migration file ID overlap. Back
+up PostgreSQL and uploaded records before upgrading.
 
 ## Configuration Reference
 


### PR DESCRIPTION
## Summary
- Sync MediKeep docs with the v0.68.0 upstream image default.
- Add upgrade notes for medication reminders, lab result improvements, vaccine data, and migration fixes.

## Validation
- `make site-sync-check CHART=medikeep`
- `npm run format:check`
- `npm run lint`
- `npm run build`
- `make release-check REPO=site`
- `make attribution-check REPO=site`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the MediKeep chart overview to reflect the latest `v0.68.0` release.
  * Added a brief summary of new capabilities, including medication reminders, Chikungunya vaccine support, stacked lab result views, and practitioner entry improvements.
  * Listed notable fixes around reference range validation, immunization history linking, lab result visibility, and migration ID overlap.
  * Reiterated upgrade guidance to back up PostgreSQL data and uploaded records before upgrading.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->