### PR TITLE
docs(minecraft): sync 2026.7.0 default

### DIFF
--- a/src/data/playground-configs.ts
+++ b/src/data/playground-configs.ts
@@ -7988,6 +7988,13 @@ export const chartConfigs: Record<string, ChartConfig> = {
           default: '10Gi',
           description: 'World data storage size',
         },
+        {
+          label: 'Image Tag',
+          key: 'image.tag',
+          type: 'text',
+          default: '2026.7.0',
+          description: 'Minecraft server image tag',
+        },
       ],
     },
     {

--- a/src/pages/docs/charts/minecraft.mdx
+++ b/src/pages/docs/charts/minecraft.mdx
@@ -29,7 +29,7 @@ cross-play, mod and plugin management, Aikar-optimized JVM flags, and RCON-backe
 - **Mod/plugin management** — Modrinth, CurseForge, Spiget, and direct URL downloads
 - **Resource packs** — configure server-side resource packs with SHA-1 verification
 - **Prometheus metrics** — mc-monitor sidecar with optional ServiceMonitor
-- **Pinned upstream image** — defaults to `2026.5.4`, with Java-specific tags available when needed
+- **Pinned upstream image** — defaults to `2026.7.0`, with Java-specific tags available when needed
 
 ## Installation
 
@@ -49,12 +49,12 @@ helm install minecraft oci://ghcr.io/helmforgedev/helm/minecraft --set server.eu
 
 | Minecraft Version | Required Java | Example `image.tag` |
 | ----------------- | ------------- | ------------------- |
-| 1.21.5+           | Java 25       | `2026.5.4`          |
-| 1.20.x - 1.21.4   | Java 21       | `2026.5.4-java21`   |
-| 1.17.x - 1.19.x   | Java 17       | `2026.5.4-java17`   |
+| 1.21.5+           | Java 25       | `2026.7.0`          |
+| 1.20.x - 1.21.4   | Java 21       | `2026.7.0-java21`   |
+| 1.17.x - 1.19.x   | Java 17       | `2026.7.0-java17`   |
 
-The chart defaults to the dated upstream image tag `2026.5.4`. Pin `image.tag`
-to a Java-specific variant, such as `2026.5.4-java21`, when running older
+The chart defaults to the dated upstream image tag `2026.7.0`. Pin `image.tag`
+to a Java-specific variant, such as `2026.7.0-java21`, when running older
 Minecraft versions or modpacks that require a specific Java runtime.
 
 ## Server Type Reference
@@ -300,7 +300,7 @@ service:
 | Parameter          | Type   | Default                           | Description                                                         |
 | ------------------ | ------ | --------------------------------- | ------------------------------------------------------------------- |
 | `image.repository` | string | `docker.io/itzg/minecraft-server` | Minecraft server container image.                                   |
-| `image.tag`        | string | `"2026.5.4"`                      | Image tag. Use Java-specific variants for older Minecraft versions. |
+| `image.tag`        | string | `"2026.7.0"`                      | Image tag. Use Java-specific variants for older Minecraft versions. |
 | `image.pullPolicy` | string | `IfNotPresent`                    | Image pull policy.                                                  |
 | `imagePullSecrets` | array  | `[]`                              | Pull secrets for private registries.                                |
 
@@ -442,7 +442,7 @@ upload — ensuring the world is in a consistent state before the backup is take
 | `backup.backoffLimit`                  | integer | `1`                                        | Job retry limit.                                             |
 | `backup.archivePrefix`                 | string  | `minecraft`                                | Prefix for backup archive filenames.                         |
 | `backup.excludes`                      | string  | `"*.jar cache logs"`                       | Space-separated patterns excluded from the archive.          |
-| `backup.images.worker`                 | string  | `docker.io/itzg/minecraft-server:2026.5.4` | Image for RCON and tar operations.                           |
+| `backup.images.worker`                 | string  | `docker.io/itzg/minecraft-server:2026.7.0` | Image for RCON and tar operations.                           |
 | `backup.images.uploader`               | string  | `docker.io/helmforge/mc:1.0.0`             | Image for S3 upload.                                         |
 | `backup.resources`                     | object  | `{}`                                       | Resources for backup containers.                             |
 | `backup.s3.endpoint`                   | string  | `""`                                       | S3-compatible endpoint URL.                                  |
@@ -511,13 +511,14 @@ upload — ensuring the world is in a consistent state before the backup is take
 
 ## Upgrade Notes
 
-`docker.io/itzg/minecraft-server:2026.5.4` updates the upstream server image from
-`2026.5.2`. The upstream releases include env-file loading at startup, server
-library cleanup on Paper installs, helper/monitor/RCON dependency updates, and a
-fix for deriving `MC_IMAGE_HELPER_OPTS` from `PROXY_*` variables. Review the
-upstream release notes before upgrading production servers, take a world backup,
-and verify plugins, mods, datapacks, proxy settings, and pinned `server.version`
-values in a staging environment before reusing existing PVCs.
+`docker.io/itzg/minecraft-server:2026.7.0` updates the upstream server image from
+`2026.6.1`. The upstream release adds Purpur support for ServerLibraryCleaner,
+fixes start-utils extraction for non-specific file types, fixes Paper boolean
+flag handling, improves GTNH pack version handling, and reloads
+`LOAD_ENV_FROM_FILE` after the packwiz installer runs.
+Review the upstream release notes before upgrading production servers, take a
+world backup, and verify plugins, mods, datapacks, proxy settings, and pinned
+`server.version` values in a staging environment before reusing existing PVCs.
 
 ## More Information
 

--- a/src/pages/playground.astro
+++ b/src/pages/playground.astro
@@ -61,6 +61,7 @@ const siteSyncPlaygroundConfigs: Record<string, string> = {
   memcached: 'src/data/playground-configs.ts',
   memos: 'src/data/playground-configs.ts',
   'metrics-server': 'src/data/playground-configs.ts',
+  minecraft: 'src/data/playground-configs.ts',
   notediscovery: 'src/data/playground-configs.ts',
   'oauth2-proxy': 'src/data/playground-configs.ts',
   opencut: 'src/data/playground-configs.ts',


### PR DESCRIPTION
## Summary
- Sync Minecraft docs with the 2026.7.0 upstream image default.
- Update Java-specific image tag examples, backup worker image documentation, and upgrade notes.
- Add the Minecraft image tag control to the playground config and register Minecraft in the playground source map.

## Validation
- `make site-sync-check CHART=minecraft`
- `npm run format:check`
- `npm run lint`
- `npm run build`
- `make release-check REPO=site`
- `make attribution-check REPO=site`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a configurable image tag field for the Minecraft chart in the playground.
  * Included Minecraft chart settings in playground sync so they appear in the configuration experience.

* **Documentation**
  * Updated Minecraft chart docs to reflect the latest upstream image tag and revised related examples and upgrade notes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->