### PR TITLE
docs(n8n): sync 2.29.7 default

### DIFF
--- a/src/data/playground-configs.ts
+++ b/src/data/playground-configs.ts
@@ -4326,6 +4326,13 @@ export const chartConfigs: Record<string, ChartConfig> = {
       name: 'General',
       fields: [
         {
+          label: 'Image Tag',
+          key: 'image.tag',
+          type: 'text',
+          default: '2.29.7',
+          description: 'Pinned n8n image tag',
+        },
+        {
           label: 'Webhook URL',
           key: 'n8n.webhookUrl',
           type: 'text',

--- a/src/pages/docs/charts/n8n.mdx
+++ b/src/pages/docs/charts/n8n.mdx
@@ -225,7 +225,7 @@ backup:
 | Parameter          | Type   | Default               | Description          |
 | ------------------ | ------ | --------------------- | -------------------- |
 | `image.repository` | string | `docker.io/n8nio/n8n` | n8n container image. |
-| `image.tag`        | string | `"2.22.3"`            | Image tag.           |
+| `image.tag`        | string | `"2.29.7"`            | Image tag.           |
 | `image.pullPolicy` | string | `IfNotPresent`        | Image pull policy.   |
 
 ### n8n Configuration

--- a/src/pages/playground.astro
+++ b/src/pages/playground.astro
@@ -66,6 +66,7 @@ const siteSyncPlaygroundConfigs: Record<string, string> = {
   memos: 'src/data/playground-configs.ts',
   'metrics-server': 'src/data/playground-configs.ts',
   minecraft: 'src/data/playground-configs.ts',
+  n8n: 'src/data/playground-configs.ts',
   notediscovery: 'src/data/playground-configs.ts',
   'oauth2-proxy': 'src/data/playground-configs.ts',
   opencut: 'src/data/playground-configs.ts',


### PR DESCRIPTION
## Summary
- Sync n8n documentation with the chart default image tag `2.29.7`.
- Add n8n to the curated playground registration and expose `image.tag` in the playground controls.

## Validation
- `make site-sync-check CHART=n8n`
- `npm run format:check`
- `npm run lint`
- `npm run build`
- `make release-check REPO=site`
- `make attribution-check REPO=site`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an **“Image Tag”** field to the n8n playground configuration (default set to **2.29.7**).
  * Included the **n8n** chart in the playground’s site-sync configuration so it’s available for more synced workflows.
* **Documentation**
  * Updated the n8n chart reference to reflect the current default container **image tag** (**2.29.7**).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->