### PR TITLE
docs(notediscovery): sync 0.28.1 default

### DIFF
--- a/src/data/playground-configs.ts
+++ b/src/data/playground-configs.ts
@@ -5154,6 +5154,13 @@ export const chartConfigs: Record<string, ChartConfig> = {
       name: 'General',
       fields: [
         {
+          label: 'Image Tag',
+          key: 'image.tag',
+          type: 'text',
+          default: '0.28.1',
+          description: 'Pinned NoteDiscovery image tag',
+        },
+        {
           label: 'HTTP Port',
           key: 'app.port',
           type: 'number',

--- a/src/data/playground-configs.ts
+++ b/src/data/playground-configs.ts
@@ -5154,13 +5154,6 @@ export const chartConfigs: Record<string, ChartConfig> = {
       name: 'General',
       fields: [
         {
-          label: 'Image Tag',
-          key: 'image.tag',
-          type: 'text',
-          default: '0.28.1',
-          description: 'Pinned NoteDiscovery image tag',
-        },
-        {
           label: 'HTTP Port',
           key: 'app.port',
           type: 'number',
@@ -8751,6 +8744,13 @@ export const chartConfigs: Record<string, ChartConfig> = {
     {
       name: 'General',
       fields: [
+        {
+          label: 'Image Tag',
+          key: 'image.tag',
+          type: 'text',
+          default: '0.28.1',
+          description: 'Pinned NoteDiscovery image tag',
+        },
         {
           label: 'HTTP Port',
           key: 'app.port',

--- a/src/pages/docs/charts/notediscovery.mdx
+++ b/src/pages/docs/charts/notediscovery.mdx
@@ -10,7 +10,7 @@ Deploy [NoteDiscovery](https://github.com/gamosoft/NoteDiscovery) on Kubernetes 
 
 ## Overview
 
-The HelmForge NoteDiscovery chart uses the official `ghcr.io/gamosoft/notediscovery:0.27.3` image and deploys a single-writer web application.
+The HelmForge NoteDiscovery chart uses the official `ghcr.io/gamosoft/notediscovery:0.28.1` image and deploys a single-writer web application.
 NoteDiscovery listens on port `8000`, stores durable notes under `/app/data`, and reads its runtime configuration from `/app/config.yaml`.
 
 The default topology is one persistent Deployment replica with a chart-managed PVC and generated unauthenticated config. When authentication is enabled, the generated config file is stored in a Secret. Production installs should normally use `auth.existingSecret` with a complete `config.yaml`.
@@ -215,6 +215,14 @@ rules.
 ## Backup
 
 Back up the PVC in every production deployment. The default `/app/data` directory contains notes and local application data.
+
+## Upgrade Notes
+
+NoteDiscovery `0.28.1` includes large-vault indexing and startup improvements
+from `0.28.0`, plus a task rendering fix. The upstream app can now override
+storage paths with `NOTES_DIR` and `PLUGINS_DIR`; this chart still writes the
+data directory into `config.yaml` from `persistence.mountPath`, so keep that
+path stable and back up the PVC before upgrading production vaults.
 
 ## Additional Resources
 


### PR DESCRIPTION
## Summary
- Sync NoteDiscovery docs with the chart default image tag `0.28.1`.
- Add the pinned image tag control to the playground defaults.
- Document the 0.28.x large-vault indexing/storage path notes for operators.

## Validation
- `make site-sync-check CHART=notediscovery`
- `npm run format:check`
- `npm run lint`
- `npm run build`
- `make release-check REPO=site`
- `make attribution-check REPO=site`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an **Image Tag** setting to the Qdrant playground configuration to simplify selecting the container version.

* **Documentation**
  * Updated NoteDiscovery chart documentation to reference the latest pinned container image tag.
  * Added an **Upgrade Notes** section highlighting changes in the new version and guidance to keep storage mount paths stable during upgrades.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->