### PR TITLE
docs(olivetin): sync 3000.16.2 default

### DIFF
--- a/src/data/playground-configs.ts
+++ b/src/data/playground-configs.ts
@@ -1600,6 +1600,13 @@ export const chartConfigs: Record<string, ChartConfig> = {
       name: 'Actions',
       fields: [
         {
+          label: 'Image Tag',
+          key: 'image.tag',
+          type: 'text',
+          default: '3000.16.2',
+          description: 'Pinned OliveTin image tag',
+        },
+        {
           label: 'HTTP Port',
           key: 'olivetin.port',
           type: 'number',
@@ -1630,7 +1637,7 @@ export const chartConfigs: Record<string, ChartConfig> = {
           label: 'Init Image Tag',
           key: 'configInit.image.tag',
           type: 'text',
-          default: '1.37.0',
+          default: '1.37',
           description: 'BusyBox image tag for config bootstrap',
         },
       ],

--- a/src/pages/docs/charts/olivetin.mdx
+++ b/src/pages/docs/charts/olivetin.mdx
@@ -289,7 +289,7 @@ externalSecrets:
 | Parameter          | Type   | Default                        | Description                          |
 | ------------------ | ------ | ------------------------------ | ------------------------------------ |
 | `image.repository` | string | `docker.io/jamesread/olivetin` | OliveTin container image.            |
-| `image.tag`        | string | `"3000.14.0"`                  | Image tag.                           |
+| `image.tag`        | string | `"3000.16.2"`                  | Image tag.                           |
 | `image.pullPolicy` | string | `IfNotPresent`                 | Image pull policy.                   |
 | `imagePullSecrets` | array  | `[]`                           | Pull secrets for private registries. |
 
@@ -327,6 +327,13 @@ The `config` block supports the full OliveTin configuration schema. Key action o
 | `arguments`          | List of user-provided arguments interpolated into `shell` via `{{ }}`. |
 
 See the [full OliveTin configuration reference](https://docs.olivetin.app/config.html) for all available options.
+
+## Upgrade Notes
+
+OliveTin `3000.16.2` is a bugfix release focused on Windows packaging and
+upstream unit test stability. Upstream reports no upgrade warnings or breaking
+changes between `3000.16.1` and `3000.16.2`; keep chart-managed config and any
+persistent data paths unchanged when rolling production deployments.
 
 ### Metrics
 

--- a/src/pages/playground.astro
+++ b/src/pages/playground.astro
@@ -63,6 +63,7 @@ const siteSyncPlaygroundConfigs: Record<string, string> = {
   'metrics-server': 'src/data/playground-configs.ts',
   notediscovery: 'src/data/playground-configs.ts',
   'oauth2-proxy': 'src/data/playground-configs.ts',
+  olivetin: 'src/data/playground-configs.ts',
   opencut: 'src/data/playground-configs.ts',
   openhab: 'src/data/playground-configs.ts',
   'openreel-video': 'src/data/playground-configs.ts',


### PR DESCRIPTION
## Summary
- Sync OliveTin docs with the chart default image tag `3000.16.2`.
- Register OliveTin in the playground and expose the pinned image tag control.
- Correct the playground BusyBox init image default from `1.37.0` to the chart default `1.37`.

## Validation
- `make site-sync-check CHART=olivetin`
- `npm run format:check`
- `npm run lint`
- `npm run build`
- `make release-check REPO=site`
- `make attribution-check REPO=site`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added OliveTin to the playground chart list, making it available in the playground experience.
  * Added a new default image tag setting for OliveTin in the playground configuration.

* **Documentation**
  * Updated the OliveTin chart docs to reflect the latest image version.
  * Added upgrade notes with guidance for safe production rollouts and no expected breaking changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->