### PR TITLE
docs(openhab): sync 5.2.0 default

### DIFF
--- a/src/data/playground-configs.ts
+++ b/src/data/playground-configs.ts
@@ -3474,6 +3474,13 @@ export const chartConfigs: Record<string, ChartConfig> = {
       name: 'Runtime',
       fields: [
         {
+          label: 'Image Tag',
+          key: 'image.tag',
+          type: 'text',
+          default: '5.2.0',
+          description: 'Pinned openHAB image tag',
+        },
+        {
           label: 'Timezone',
           key: 'env.TZ',
           type: 'text',

--- a/src/pages/docs/charts/openhab.mdx
+++ b/src/pages/docs/charts/openhab.mdx
@@ -660,7 +660,7 @@ kubectl scale statefulset my-openhab -n openhab --replicas=1
 | Parameter          | Description      | Default                     |
 | ------------------ | ---------------- | --------------------------- |
 | `image.repository` | Image repository | `docker.io/openhab/openhab` |
-| `image.tag`        | Image tag        | `5.1.4`                     |
+| `image.tag`        | Image tag        | `5.2.0`                     |
 | `image.pullPolicy` | Pull policy      | `IfNotPresent`              |
 
 ### Workload
@@ -801,6 +801,16 @@ gateway:
 | `backup.s3.accessKey`               | S3 access key                                           | `""`                       |
 | `backup.s3.secretKey`               | S3 secret key                                           | `""`                       |
 | `backup.s3.existingSecret`          | Existing Secret name (keys: `access-key`, `secret-key`) | `""`                       |
+
+## Upgrade Notes
+
+openHAB `5.2.0` is a stable feature release for the 5.x line. The upstream
+release notes list new add-ons, runtime/UI enhancements, and several breaking
+changes that may require manual action after upgrade. Back up the `userdata`,
+`conf`, and `addons` PVCs before upgrading. Review any affected rules, UI
+layouts, persistence queries, voice IDs, and add-ons before rolling production
+deployments. openHAB 5.x still requires Java 21, which is provided by the
+official container image used by this chart.
 
 ## Troubleshooting
 


### PR DESCRIPTION
## Summary
- Sync openHAB documentation defaults to 5.2.0.
- Add the openHAB image tag control to the playground with the new pinned default.
- Document the upstream 5.2.0 upgrade notes and Java 21 context.

## Validation
- make site-sync-check CHART=openhab
- npm run format:check
- npm run lint
- npm run build
- make release-check REPO=site
- make attribution-check REPO=site

Charts PR: helmforgedev/charts#721

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a configurable image tag option for the openHAB runtime, with a new default of `5.2.0`.

* **Documentation**
  * Updated the openHAB chart reference to reflect the new default image version.
  * Added upgrade notes for openHAB `5.2.0`, including backup guidance and key compatibility reminders.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->