### PR TITLE
docs(poznote): sync 6.30.2 default

### DIFF
--- a/src/pages/docs/charts/poznote.mdx
+++ b/src/pages/docs/charts/poznote.mdx
@@ -156,9 +156,8 @@ Poznote `6.30.2` is a stable UI, backup, API, and security hardening release.
 Upstream highlights include brute-force login throttling, improved backup import
 validation, trashed notes included in exports, new REST API endpoints, MCP server
 fixes, dark mode fixes, and mobile/task editing fixes. No Kubernetes-facing
-configuration changes are required by this chart, but back up the data PVC before
-upgrading because it stores the SQLite database, notes, attachments, and
-application configuration.
+configuration changes are required by this chart. Follow the Backup section
+above before upgrading production workloads.
 
 ## Additional Resources
 

--- a/src/pages/docs/charts/poznote.mdx
+++ b/src/pages/docs/charts/poznote.mdx
@@ -10,7 +10,7 @@ Deploy [Poznote](https://github.com/timothepoznanski/poznote) on Kubernetes as a
 
 ## Overview
 
-The HelmForge Poznote chart uses the official `ghcr.io/timothepoznanski/poznote:6.29.0` image. The container serves the web frontend and API on port `80`, stores all data (notes, attachments, configuration) in a SQLite database under `/var/www/html/data`.
+The HelmForge Poznote chart uses the official `ghcr.io/timothepoznanski/poznote:6.30.2` image. The container serves the web frontend and API on port `80`, stores all data (notes, attachments, configuration) in a SQLite database under `/var/www/html/data`.
 
 Poznote is designed for personal and small-team use. Data persistence relies on a single PVC. Scaling beyond one replica is not supported because SQLite does not handle concurrent writes from multiple instances.
 
@@ -149,6 +149,16 @@ externalSecrets:
 ## Backup
 
 Back up the data PVC regularly. It contains the SQLite database, all notes, attachments, and application configuration. Use your storage provider's snapshot mechanism or a tool like Velero. Poznote also supports data export from the web interface (Settings > Export).
+
+## Upgrade Notes
+
+Poznote `6.30.2` is a stable UI, backup, API, and security hardening release.
+Upstream highlights include brute-force login throttling, improved backup import
+validation, trashed notes included in exports, new REST API endpoints, MCP server
+fixes, dark mode fixes, and mobile/task editing fixes. No Kubernetes-facing
+configuration changes are required by this chart, but back up the data PVC before
+upgrading because it stores the SQLite database, notes, attachments, and
+application configuration.
 
 ## Additional Resources
 


### PR DESCRIPTION
## Summary
- Sync Poznote docs from 6.29.0 to 6.30.2.
- Add upgrade notes covering the latest stable upstream fixes and backup guidance.

## Validation
- make site-sync-check CHART=poznote
- npm run format:check
- npm run lint
- npm run build
- make release-check REPO=site
- make attribution-check REPO=site

Charts PR: helmforgedev/charts#722

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated the Poznote chart docs to reference the latest stable image tag, `6.30.2`.
  * Added an “Upgrade Notes” section covering key improvements in this release (including login throttling, backup import validation, export changes, REST API updates, MCP server fixes, and UI/mobile/task editing enhancements).
  * Included a reminder to back up the data PVC before upgrading.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->