### PR TITLE
docs(community): refresh contributors list

### DIFF
--- a/src/data/contributors.ts
+++ b/src/data/contributors.ts
@@ -1,0 +1,52 @@
+export type Contributor = {
+  name: string;
+  login: string;
+  profileUrl: string;
+  avatarUrl: string;
+  contributions: number;
+};
+
+export const chartContributors: Contributor[] = [
+  {
+    name: 'Maicon Berlofa',
+    login: 'mberlofa',
+    profileUrl: 'https://github.com/mberlofa',
+    avatarUrl: 'https://github.com/mberlofa.png?size=96',
+    contributions: 612,
+  },
+  {
+    name: 'Mathieu REHO',
+    login: 'mreho',
+    profileUrl: 'https://github.com/mreho',
+    avatarUrl: 'https://github.com/mreho.png?size=96',
+    contributions: 12,
+  },
+  {
+    name: 'ummon-v',
+    login: 'ummon-v',
+    profileUrl: 'https://github.com/ummon-v',
+    avatarUrl: 'https://github.com/ummon-v.png?size=96',
+    contributions: 3,
+  },
+  {
+    name: 'Volodymyr',
+    login: 'volodymyr-devops',
+    profileUrl: 'https://github.com/volodymyr-devops',
+    avatarUrl: 'https://github.com/volodymyr-devops.png?size=96',
+    contributions: 2,
+  },
+  {
+    name: 'Dennis Rieks',
+    login: 'drieks',
+    profileUrl: 'https://github.com/drieks',
+    avatarUrl: 'https://github.com/drieks.png?size=96',
+    contributions: 1,
+  },
+  {
+    name: 'Radek Crlik',
+    login: 'rcrlik',
+    profileUrl: 'https://github.com/rcrlik',
+    avatarUrl: 'https://github.com/rcrlik.png?size=96',
+    contributions: 1,
+  },
+];

--- a/src/data/contributors.ts
+++ b/src/data/contributors.ts
@@ -6,6 +6,9 @@ export type Contributor = {
   contributions: number;
 };
 
+// Generated on 2026-07-09 from helmforgedev/charts origin/main with:
+// git shortlog -sne origin/main --no-merges
+// Exclude bot and automation accounts, then map GitHub-linked authors to profiles.
 export const chartContributors: Contributor[] = [
   {
     name: 'Maicon Berlofa',

--- a/src/pages/community.astro
+++ b/src/pages/community.astro
@@ -4,6 +4,7 @@ import Header from '../components/Header.astro';
 import Footer from '../components/Footer.astro';
 import Container from '../components/Container.astro';
 import SectionHeader from '../components/SectionHeader.astro';
+import { chartContributors } from '../data/contributors';
 
 const ways = [
   {
@@ -132,66 +133,46 @@ const governance = [
       </div>
 
       <!-- Contributors -->
-      <div id="contributors-section" class="mt-16 hidden" data-contributors-section>
+      <div id="contributors-section" class="mt-16">
         <h3 class="text-lg font-bold text-text-base heading-font mb-6">Contributors</h3>
         <div class="glass-panel rounded-2xl p-6">
-          <div class="flex flex-wrap gap-3" data-contributors-list></div>
+          <p class="max-w-3xl text-sm text-text-muted leading-relaxed mb-5">
+            Human contributors from the charts repository history. Bot and automation accounts are excluded so the
+            community page reflects people who have contributed code, docs, tests, and chart fixes.
+          </p>
+          <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3">
+            {
+              chartContributors.map((contributor) => (
+                <a
+                  href={contributor.profileUrl}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  class="group flex min-w-0 items-center gap-3 rounded-xl border border-border bg-bg-surface/40 px-3 py-3 transition-all hover:border-primary/40 hover:bg-bg-surface/80"
+                  title={`${contributor.name} - ${contributor.contributions} contributions`}
+                >
+                  <img
+                    src={contributor.avatarUrl}
+                    alt={contributor.name}
+                    class="h-10 w-10 rounded-full"
+                    loading="lazy"
+                    width="40"
+                    height="40"
+                  />
+                  <span class="min-w-0 flex-1">
+                    <span class="block truncate text-sm font-semibold text-text-base group-hover:text-primary-light">
+                      {contributor.name}
+                    </span>
+                    <span class="block truncate text-xs text-text-muted">@{contributor.login}</span>
+                  </span>
+                  <span class="shrink-0 rounded-full bg-primary/10 px-2 py-1 text-xs font-mono text-primary-light">
+                    {contributor.contributions}
+                  </span>
+                </a>
+              ))
+            }
+          </div>
         </div>
       </div>
-
-      <script is:inline>
-        (() => {
-          const section = document.querySelector('[data-contributors-section]');
-          const list = document.querySelector('[data-contributors-list]');
-          if (!section || !list) return;
-
-          const createContributorLink = (contributor) => {
-            const link = document.createElement('a');
-            link.href = contributor.html_url;
-            link.target = '_blank';
-            link.rel = 'noopener noreferrer';
-            link.className =
-              'group flex items-center gap-2.5 rounded-xl border border-border bg-bg-surface/40 px-3 py-2 transition-all hover:border-primary/40 hover:bg-bg-surface/80';
-            link.title = `${contributor.login} - ${contributor.contributions} contributions`;
-
-            const avatar = document.createElement('img');
-            avatar.src = contributor.avatar_url;
-            avatar.alt = contributor.login;
-            avatar.className = 'w-7 h-7 rounded-full';
-            avatar.loading = 'lazy';
-            avatar.width = 28;
-            avatar.height = 28;
-
-            const login = document.createElement('span');
-            login.className = 'text-sm font-medium text-text-base group-hover:text-primary-light';
-            login.textContent = contributor.login;
-
-            const contributions = document.createElement('span');
-            contributions.className = 'text-xs text-text-muted font-mono';
-            contributions.textContent = String(contributor.contributions);
-
-            link.append(avatar, login, contributions);
-            return link;
-          };
-
-          fetch('https://api.github.com/repos/helmforgedev/charts/contributors?per_page=30', {
-            headers: { Accept: 'application/vnd.github+json' },
-          })
-            .then((response) => {
-              if (!response.ok) throw new Error('GitHub contributors request failed');
-              return response.json();
-            })
-            .then((contributors) => contributors.filter((contributor) => !contributor.login.includes('[bot]')))
-            .then((contributors) => {
-              if (contributors.length === 0) return;
-              list.replaceChildren(...contributors.map(createContributorLink));
-              section.classList.remove('hidden');
-            })
-            .catch(() => {
-              section.remove();
-            });
-        })();
-      </script>
 
       <!-- Governance -->
       <div class="mt-16">


### PR DESCRIPTION
## Summary

Refreshes the community page contributor section so it reflects human contributors from the charts repository history instead of relying on a limited GitHub contributors endpoint at runtime.

## Changes

- Adds a static contributor data file for the charts repository human contributors.
- Removes the client-side GitHub API fetch from `/community`.
- Renders contributor cards at build time, excluding bot and automation accounts.
- Keeps the section visible and stable even when GitHub API rate limits apply.
- Documents the generation date and source command for the static contributor list.

## Companion

- Charts README refresh: helmforgedev/charts#724

## Review follow-up

- Addressed CodeRabbit's top-level nitpick by documenting how `chartContributors` was generated and when to refresh it. There was no resolvable review thread for this nitpick.

## Validation

- `npm run format:check`
- `npm run lint`
- `npm run build`
- Playwright screenshot check for `/community` on desktop and mobile
- `make release-check REPO=site`
- `make attribution-check REPO=site`
- `make org-check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The Community page now shows a visible Contributors section using preloaded contributor data.
  * Contributor cards now display avatar, name, GitHub login, profile link, and contribution count.
* **Bug Fixes**
  * Removed reliance on live GitHub loading for contributors, improving page consistency and reducing the chance of an empty contributors section.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->