### PR TITLE
fix(community): use HelmForge contributors badge

### DIFF
--- a/src/pages/community.astro
+++ b/src/pages/community.astro
@@ -146,7 +146,7 @@ const governance = [
               aria-label="View HelmForge contributors on GitHub"
             >
               <img
-                src="https://contrib.rocks/image?repo=helmforgedev/charts&max=100"
+                src="https://repo.helmforge.dev/badges/contributors.svg"
                 alt="HelmForge contributors"
                 class="max-w-full rounded-xl"
                 loading="lazy"


### PR DESCRIPTION
## Summary

- use the HelmForge-hosted contributors badge on the community page
- keep README and site aligned on the same contributor source
- avoid contrib.rocks omissions for GitHub coauthors

## Validation

- npm run format:check
- npm run lint -- --max-warnings=0
- npm run build
- make release-check REPO=site
- make attribution-check REPO=site

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated the contributors badge to use a dedicated source, improving reliability and presentation on the community page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->